### PR TITLE
fix: swap debit and credit

### DIFF
--- a/klarna_kosma_integration/klarna_kosma_integration/utils.py
+++ b/klarna_kosma_integration/klarna_kosma_integration/utils.py
@@ -173,8 +173,8 @@ def new_bank_transaction(account: str, transaction: Dict):
 				"date": getdate(transaction.get("value_date") or transaction.get("date")),
 				"status": status,
 				"bank_account": account,
-				"deposit": debit,
-				"withdrawal": credit,  # TODO: verify
+				"deposit": credit,
+				"withdrawal": debit,
 				"currency": amount_data.get("currency"),
 				"transaction_id": transaction_id,
 				"reference_number": transaction.get("bank_references", {}).get("end_to_end"),


### PR DESCRIPTION
> When your bank account is [debited](https://www.investopedia.com/terms/d/debit.asp), money is taken out of the account. The opposite of a debit is a [credit](https://www.investopedia.com/terms/c/credit.asp), in which case money is added to your account.

– https://www.investopedia.com/ask/answers/050415/what-happens-when-my-bank-account-debited.asp