### PR TITLE
feat: show only relevant bank accounts

### DIFF
--- a/klarna_kosma_integration/klarna_kosma_integration/doctype/klarna_kosma_settings/klarna_kosma_settings.js
+++ b/klarna_kosma_integration/klarna_kosma_integration/doctype/klarna_kosma_settings/klarna_kosma_settings.js
@@ -14,7 +14,14 @@ frappe.ui.form.on('Klarna Kosma Settings', {
 					options: "Bank Account",
 					label: __("Bank Account"),
 					fieldname: "bank_account",
-					reqd: 1
+					reqd: 1,
+					get_query: () => {
+						return {
+							filters: {
+								"kosma_account_id": ["is", "set"],
+							}
+						};
+					},
 				}, (data) => {
 					new KlarnaKosmaConnect({
 						frm: frm,


### PR DESCRIPTION
When asking the user which **Bank Accounts** to sync transactions for, offer only **Bank Accounts** that have a _Kosma Account ID_ set.