### PR TITLE
fix: Make `session_id_short` a keyword argument

### DIFF
--- a/klarna_kosma_integration/klarna_kosma_integration/doctype/klarna_kosma_settings/klarna_kosma_settings.py
+++ b/klarna_kosma_integration/klarna_kosma_integration/doctype/klarna_kosma_settings/klarna_kosma_settings.py
@@ -69,7 +69,7 @@ def add_bank_accounts(accounts: str, company: str, bank_name: str) -> None:
 
 
 @frappe.whitelist()
-def sync_transactions(account: str, session_id_short: Optional[str]) -> None:
+def sync_transactions(account: str, session_id_short: Optional[str] = None) -> None:
 	"""
 	Enqueue transactions sync via the Consent API.
 	"""


### PR DESCRIPTION
**Issue:**
```py
Traceback (most recent call last):
  File "apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 85, in execute
    frappe.get_attr(self.method)()
  File "apps/klarna_kosma_integration/klarna_kosma_integration/klarna_kosma_integration/doctype/klarna_kosma_settings/klarna_kosma_settings.py", line 127, in sync_all_accounts_and_transactions
    sync_transactions(account=bank_account)
TypeError: sync_transactions() missing 1 required positional argument: 'session_id_short'
```