### PR TITLE
fix: Avoid passing accounts in session scope for transactions flow

### DIFF
--- a/klarna_kosma_integration/connectors/klarna_kosma_flow.py
+++ b/klarna_kosma_integration/connectors/klarna_kosma_flow.py
@@ -64,7 +64,7 @@ class KlarnaKosmaFlow(KlarnaKosmaConnector):
 		flow_response_val = flow_response.json()
 		return flow_response_val.get("data", {}) or flow_response_val
 
-	def start_session(self, iban: Optional[str] = None) -> Dict:
+	def start_session(self, flow_type: str, iban: Optional[str] = None) -> Dict:
 		"""
 		Start a Kosma Session and return session details
 		"""
@@ -72,9 +72,13 @@ class KlarnaKosmaFlow(KlarnaKosmaConnector):
 		if iban:
 			transaction_data["ibans"] = [iban]
 
-		data = {
-			"consent_scope": {"lifetime": 90, "accounts": {}, "transactions": transaction_data}
-		}
+		data = {"consent_scope": {"lifetime": 90, "transactions": transaction_data}}
+
+		if flow_type == "accounts":
+			# Avoid accounts scope in a transactions flow to avoid accounts fetch
+			# Transactions in scope can be used for both flows
+			data["consent_scope"]["accounts"] = {}
+
 		self.add_psu(data)
 
 		session_response = requests.put(

--- a/klarna_kosma_integration/klarna_kosma_integration/kosma.py
+++ b/klarna_kosma_integration/klarna_kosma_integration/kosma.py
@@ -57,9 +57,13 @@ class Kosma:
 		from_date: Optional[str] = None,
 		to_date: Optional[str] = None,
 	) -> Dict:
-		flow = self.get_flow(from_date, to_date)
-		session_details = self.start_session(flow, account)
-		flow_data = self.start_flow(flow, current_flow, session_details, account)
+		flow_obj = self.get_flow(from_date, to_date)
+		session_details = self.start_session(
+			flow_obj=flow_obj, flow_type=current_flow, account=account
+		)
+		flow_data = self.start_flow(
+			flow_obj, current_flow=current_flow, session=session_details, account=account
+		)
 
 		return {
 			"session_id_short": session_details.get("session_id_short"),
@@ -162,12 +166,15 @@ class Kosma:
 			self.handle_exception(exc, _("Failed to get Kosma Transactions."))
 
 	def start_session(
-		self, flow_obj: "KlarnaKosmaFlow", account: Optional[str] = None
+		self,
+		flow_obj: "KlarnaKosmaFlow",
+		flow_type: str,
+		account: Optional[str] = None,
 	) -> Dict:
 		try:
-			iban = frappe.db.get_value("Bank Account", account, "iban")
+			iban = frappe.db.get_value("Bank Account", account, "iban") if account else None
 
-			session_details = flow_obj.start_session(iban)
+			session_details = flow_obj.start_session(flow_type, iban)
 			flow_obj.raise_for_status(session_details)
 
 			create_session_doc(session_details)


### PR DESCRIPTION
Fixes https://github.com/alyf-de/klarna_kosma_integration/issues/24

- Pass flow type so that we can only add accounts in session scope if it is an accounts flow
- This should avoid accounts fetch during transactions flow
- Works as it used to in Playground environment. Needs to be tested in production