### PR TITLE
feat: less labels in bank reco panel

### DIFF
--- a/banking/public/js/bank_reconciliation_panels.js
+++ b/banking/public/js/bank_reconciliation_panels.js
@@ -123,12 +123,14 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 					<!-- Date & Amount -->
 					<div class="d-flex">
 						<div class="w-50">
-							<span class="bt-label"> ${__("Date: ")} </span>
-							<span><b>${transaction.date}</b></span>
+							<span title="${__("Date")}">${frappe.format(transaction.date, {fieldtype: "Date"})}</span>
 						</div>
 
 						<div class="w-50 bt-amount-contianer">
-							<span class="bt-amount ${transaction.withdrawal ? 'text-danger' : 'text-success'}">
+							<span
+								title="${__("Amount")}"
+								class="bt-amount ${transaction.withdrawal ? 'text-danger' : 'text-success'}"
+							>
 								<b>${symbol} ${format_currency(amount, transaction.currency)}</b>
 							</span>
 						</div>
@@ -136,19 +138,25 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 
 
 					<!-- Description, Reference, Party -->
-					<div class="description ${transaction.description ? '' : 'hide'}">
-						<span class="bt-label"> ${__("Description: ")} </span>
+					<div
+						title="${__("Account Holder")}"
+						class="account-holder ${transaction.bank_party_name ? '' : 'hide'}"
+					>
+						<span class="account-holder-value">${transaction.bank_party_name}</span>
+					</div>
+
+					<div
+						title="${__("Description")}"
+						class="description ${transaction.description ? '' : 'hide'}"
+					>
 						<span class="description-value">${transaction.description}</span>
 					</div>
 
-					<div class="reference ${transaction.reference_number ? '' : 'hide'}">
-						<span class="bt-label"> ${__("Reference: ")} </span>
+					<div
+						title="${__("Reference")}"
+						class="reference ${transaction.reference_number ? '' : 'hide'}"
+					>
 						<span class="reference-value">${transaction.reference_number}</span>
-					</div>
-
-					<div class="account-holder ${transaction.bank_party_name ? '' : 'hide'}">
-						<span class="bt-label"> ${__("Account Holder: ")} </span>
-						<span class="account-holder-value">${transaction.bank_party_name}</span>
 					</div>
 				</div>
 			`).find("#" + transaction.name);


### PR DESCRIPTION
![Bildschirmfoto 2023-08-11 um 12 51 06](https://github.com/alyf-de/banking/assets/14891507/dbb7647c-1463-4207-998b-003c7eb44712)

Looks a bit cleaner, IMO. People will figure out what's the party name and what's the description, I guess 😄 . For accessibility and in case of doubt: `title` attribute (shows on long hover).