### PR TITLE
feat: Date as matching parameter

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
+from frappe.query_builder.functions import Coalesce
 from frappe.utils import cint, flt
 from pypika.terms import Parameter
 
@@ -397,6 +398,7 @@ def check_matching(
 		"party_type": transaction.party_type,
 		"party": transaction.party,
 		"bank_account": bank_account,
+		"date": transaction.date,
 	}
 
 	matching_vouchers = []
@@ -616,14 +618,18 @@ def get_ld_matching_query(bank_account, exact_match, filters):
 		"party_type"
 	) and loan_disbursement.applicant == filters.get("party")
 
-	rank = frappe.qb.terms.Case().when(matching_reference, 1).else_(0)
+	date_condition = Coalesce(
+		loan_disbursement.reference_date, loan_disbursement.disbursement_date
+	) == Parameter("%(date)s")
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
+	rank = frappe.qb.terms.Case().when(matching_reference, 1).else_(0)
 	rank1 = frappe.qb.terms.Case().when(matching_party, 1).else_(0)
 
 	query = (
 		frappe.qb.from_(loan_disbursement)
 		.select(
-			(rank + rank1 + 1).as_("rank"),
+			(rank + rank1 + date_rank + 1).as_("rank"),
 			ConstantColumn("Loan Disbursement").as_("doctype"),
 			loan_disbursement.name,
 			loan_disbursement.disbursed_amount.as_("paid_amount"),
@@ -635,6 +641,7 @@ def get_ld_matching_query(bank_account, exact_match, filters):
 			ConstantColumn("").as_("currency"),
 			rank.as_("reference_number_match"),
 			rank1.as_("party_match"),
+			date_rank.as_("date_match"),
 		)
 		.where(loan_disbursement.docstatus == 1)
 		.where(loan_disbursement.clearance_date.isnull())
@@ -658,14 +665,18 @@ def get_lr_matching_query(bank_account, exact_match, filters):
 		"party_type"
 	) and loan_repayment.applicant == filters.get("party")
 
-	rank = frappe.qb.terms.Case().when(matching_reference, 1).else_(0)
+	date_condition = Coalesce(
+		loan_repayment.reference_date, loan_repayment.posting_date
+	) == Parameter("%(date)s")
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
+	rank = frappe.qb.terms.Case().when(matching_reference, 1).else_(0)
 	rank1 = frappe.qb.terms.Case().when(matching_party, 1).else_(0)
 
 	query = (
 		frappe.qb.from_(loan_repayment)
 		.select(
-			(rank + rank1 + 1).as_("rank"),
+			(rank + rank1 + date_rank + 1).as_("rank"),
 			ConstantColumn("Loan Repayment").as_("doctype"),
 			loan_repayment.name,
 			loan_repayment.amount_paid.as_("paid_amount"),
@@ -677,6 +688,7 @@ def get_lr_matching_query(bank_account, exact_match, filters):
 			ConstantColumn("").as_("currency"),
 			rank.as_("reference_number_match"),
 			rank1.as_("party_match"),
+			date_rank.as_("date_match"),
 		)
 		.where(loan_repayment.docstatus == 1)
 		.where(loan_repayment.clearance_date.isnull())
@@ -730,10 +742,13 @@ def get_pe_matching_query(
 	if cint(filter_by_reference_date):
 		filter_by_date = pe.reference_date.between(from_reference_date, to_reference_date)
 
+	date_condition = Coalesce(pe.reference_date, pe.posting_date) == transaction.date
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+
 	query = (
 		frappe.qb.from_(pe)
 		.select(
-			(ref_rank + amount_rank + party_rank + 1).as_("rank"),
+			(ref_rank + amount_rank + party_rank + date_rank + 1).as_("rank"),
 			ConstantColumn("Payment Entry").as_("doctype"),
 			pe.name,
 			pe.paid_amount,
@@ -746,6 +761,7 @@ def get_pe_matching_query(
 			ref_rank.as_("reference_number_match"),
 			amount_rank.as_("amount_match"),
 			party_rank.as_("party_match"),
+			date_rank.as_("date_match"),
 		)
 		.where(pe.docstatus == 1)
 		.where(pe.payment_type.isin([payment_type, "Internal Transfer"]))
@@ -792,12 +808,15 @@ def get_je_matching_query(
 	if cint(filter_by_reference_date):
 		filter_by_date = je.cheque_date.between(from_reference_date, to_reference_date)
 
+	date_condition = Coalesce(je.cheque_date, je.posting_date) == transaction.date
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+
 	query = (
 		frappe.qb.from_(jea)
 		.join(je)
 		.on(jea.parent == je.name)
 		.select(
-			(ref_rank + amount_rank + 1).as_("rank"),
+			(ref_rank + amount_rank + date_rank + 1).as_("rank"),
 			ConstantColumn("Journal Entry").as_("doctype"),
 			je.name,
 			getattr(jea, amount_field).as_("paid_amount"),
@@ -809,6 +828,7 @@ def get_je_matching_query(
 			jea.account_currency.as_("currency"),
 			ref_rank.as_("reference_number_match"),
 			amount_rank.as_("amount_match"),
+			date_rank.as_("date_match"),
 		)
 		.where(je.docstatus == 1)
 		.where(je.voucher_type != "Opening Entry")
@@ -838,12 +858,15 @@ def get_si_matching_query(exact_match, exact_party_match, currency):
 	party_condition = si.customer == Parameter("%(party)s")
 	party_rank = frappe.qb.terms.Case().when(party_condition, 1).else_(0)
 
+	date_condition = si.posting_date == Parameter("%(date)s")
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+
 	query = (
 		frappe.qb.from_(sip)
 		.join(si)
 		.on(sip.parent == si.name)
 		.select(
-			(party_rank + amount_rank + 1).as_("rank"),
+			(party_rank + amount_rank + date_rank + 1).as_("rank"),
 			ConstantColumn("Sales Invoice").as_("doctype"),
 			si.name,
 			sip.amount.as_("paid_amount"),
@@ -855,6 +878,7 @@ def get_si_matching_query(exact_match, exact_party_match, currency):
 			si.currency,
 			party_rank.as_("party_match"),
 			amount_rank.as_("amount_match"),
+			date_rank.as_("date_match"),
 		)
 		.where(si.docstatus == 1)
 		.where(sip.clearance_date.isnull())
@@ -923,10 +947,15 @@ def get_pi_matching_query(exact_match, exact_party_match, currency):
 	party_condition = purchase_invoice.supplier == Parameter("%(party)s")
 	party_rank = frappe.qb.terms.Case().when(party_condition, 1).else_(0)
 
+	date_condition = Coalesce(
+		purchase_invoice.bill_date, purchase_invoice.posting_date
+	) == Parameter("%(date)s")
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+
 	query = (
 		frappe.qb.from_(purchase_invoice)
 		.select(
-			(party_rank + amount_rank + 1).as_("rank"),
+			(party_rank + amount_rank + date_rank + 1).as_("rank"),
 			ConstantColumn("Purchase Invoice").as_("doctype"),
 			purchase_invoice.name,
 			purchase_invoice.paid_amount,
@@ -938,6 +967,7 @@ def get_pi_matching_query(exact_match, exact_party_match, currency):
 			purchase_invoice.currency,
 			party_rank.as_("party_match"),
 			amount_rank.as_("amount_match"),
+			date_rank.as_("date_match"),
 		)
 		.where(purchase_invoice.docstatus == 1)
 		.where(purchase_invoice.is_paid == 1)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -623,13 +623,13 @@ def get_ld_matching_query(bank_account, exact_match, filters):
 	) == Parameter("%(date)s")
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
-	rank = frappe.qb.terms.Case().when(matching_reference, 1).else_(0)
-	rank1 = frappe.qb.terms.Case().when(matching_party, 1).else_(0)
+	reference_rank = frappe.qb.terms.Case().when(matching_reference, 1).else_(0)
+	party_rank = frappe.qb.terms.Case().when(matching_party, 1).else_(0)
 
 	query = (
 		frappe.qb.from_(loan_disbursement)
 		.select(
-			(rank + rank1 + date_rank + 1).as_("rank"),
+			(reference_rank + party_rank + date_rank + 1).as_("rank"),
 			ConstantColumn("Loan Disbursement").as_("doctype"),
 			loan_disbursement.name,
 			loan_disbursement.disbursed_amount.as_("paid_amount"),
@@ -639,8 +639,8 @@ def get_ld_matching_query(bank_account, exact_match, filters):
 			loan_disbursement.applicant_type.as_("party_type"),
 			loan_disbursement.disbursement_date.as_("posting_date"),
 			ConstantColumn("").as_("currency"),
-			rank.as_("reference_number_match"),
-			rank1.as_("party_match"),
+			reference_rank.as_("reference_number_match"),
+			party_rank.as_("party_match"),
 			date_rank.as_("date_match"),
 		)
 		.where(loan_disbursement.docstatus == 1)
@@ -670,13 +670,13 @@ def get_lr_matching_query(bank_account, exact_match, filters):
 	) == Parameter("%(date)s")
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
-	rank = frappe.qb.terms.Case().when(matching_reference, 1).else_(0)
-	rank1 = frappe.qb.terms.Case().when(matching_party, 1).else_(0)
+	reference_rank = frappe.qb.terms.Case().when(matching_reference, 1).else_(0)
+	party_rank = frappe.qb.terms.Case().when(matching_party, 1).else_(0)
 
 	query = (
 		frappe.qb.from_(loan_repayment)
 		.select(
-			(rank + rank1 + date_rank + 1).as_("rank"),
+			(reference_rank + party_rank + date_rank + 1).as_("rank"),
 			ConstantColumn("Loan Repayment").as_("doctype"),
 			loan_repayment.name,
 			loan_repayment.amount_paid.as_("paid_amount"),
@@ -686,8 +686,8 @@ def get_lr_matching_query(bank_account, exact_match, filters):
 			loan_repayment.applicant_type.as_("party_type"),
 			loan_repayment.posting_date,
 			ConstantColumn("").as_("currency"),
-			rank.as_("reference_number_match"),
-			rank1.as_("party_match"),
+			reference_rank.as_("reference_number_match"),
+			party_rank.as_("party_match"),
 			date_rank.as_("date_match"),
 		)
 		.where(loan_repayment.docstatus == 1)

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -74,6 +74,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		this.match_params = {};
 		let table_data = vouchers.map((row) => {
 			this.match_params[row.name] = {
+				"Date": row.date_match || 0,
 				"Party": row.party_match || 0,
 				"Transaction Amount": row.amount_match || 0,
 				"Unallocated Amount": row.unallocated_amount_match || 0,

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -449,6 +449,9 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				name: __("Reference Date"),
 				editable: false,
 				width: 120,
+				format: (value) => {
+					return frappe.format(value, {fieldtype: "Date"});
+				},
 			},
 			{
 				name: __("Remaining"),


### PR DESCRIPTION
- For all DocTypes except **Unpaid PI and SI**, include a date match
- If the Reference Date or Posting Date (if ref date is empty) matches the Bank Transaction date, the match score is bumped up
- Format "Reference Date" in the match table

<img width="1330" alt="Screenshot 2023-09-18 at 7 28 48 PM" src="https://github.com/alyf-de/banking/assets/25857446/98b44a4f-2456-4239-a0d4-1c3b8a95ef1b">

