### PR TITLE
fix: Name Accounts without alias

### DIFF
--- a/banking/demo_responses/test_responses.py
+++ b/banking/demo_responses/test_responses.py
@@ -4,32 +4,28 @@ session_response = frappe._dict(
 	{
 		"session_data": {
 			"consent": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/consent/get",
-			"flows":
-				{
-					"account_details": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/account-details",
-					"accounts": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/accounts",
-					"balances": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/balances",
-					"transactions": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/transactions",
-					"transfer": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/transfer"
-				},
+			"flows": {
+				"account_details": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/account-details",
+				"accounts": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/accounts",
+				"balances": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/balances",
+				"transactions": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/transactions",
+				"transfer": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/transfer",
+			},
 			"self": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123",
 			"session_id": "xyz123",
 			"session_id_short": "HB7LM8GT",
 			"consent_scope": {
 				"lifetime": 90,
 				"accounts": {},
-				"transactions": {
-					"from_date": "2023-01-01",
-					"to_date": "2023-03-23"
-				}
-			}
+				"transactions": {"from_date": "2023-01-01", "to_date": "2023-03-23"},
+			},
 		},
 		"flow_data": {
 			"client_token": "xaBStTc1963.sa3fica234.qSHfI1M0LFYUy-csbwj589598_QW-67",
 			"flow_id": "e9fon1j1f03pq329svvrjqid1h2ikutf",
 			"self": "https://api.openbanking.playground.klarna.com/xs2a/v1/sessions/xyz123/flows/e9fon1j1f03pq329svvrjqid1h2ikutf",
-			"state": "CONSUMER_INPUT_NEEDED"
-		}
+			"state": "CONSUMER_INPUT_NEEDED",
+		},
 	}
 )
 
@@ -41,7 +37,7 @@ bank_data_response = frappe._dict(
 		"connection": "PSD2",
 		"bank_krn": "krn:openbanking:global:bank:269ca6ce-7d5f-4eb0-917a-0fdf8d1cbba9",
 		"integration_krn": "krn:openbanking:global:integration:ed45cfda-6774-47ba-a4fc-4b4720865628",
-		"sub_integration_krn": "krn:openbanking:global:sub-integration:dd59babd-ba6f-4feb-a26e-ca439ca62f88"
+		"sub_integration_krn": "krn:openbanking:global:sub-integration:dd59babd-ba6f-4feb-a26e-ca439ca62f88",
 	}
 )
 
@@ -51,8 +47,8 @@ consent_response = frappe._dict(
 		"consent_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjNlYWRhNTA4LThlOTAtNDNhNS05NDE0LTk5ZWEwZDQxMTNmZSJ9.eyJ2ZXJzaW9",
 		"consents": {
 			"accounts": "https://api.openbanking.playground.klarna.com/xs2a/v1/consents/4bn7guh6shbl2e/accounts/get",
-			"transactions": "https://api.openbanking.playground.klarna.com/xs2a/v1/consents/4bn7guh6shbl2e/transactions/get"
-		}
+			"transactions": "https://api.openbanking.playground.klarna.com/xs2a/v1/consents/4bn7guh6shbl2e/transactions/get",
+		},
 	}
 )
 
@@ -61,31 +57,21 @@ accounts_response_1 = frappe._dict(
 		"result": {
 			"accounts": [
 				{
-					"id":"NzRiOWMzOWItNDQxYi00ZGYzLWIyZjItODA5Y2Y1MWFjNzQ0",
+					"id": "NzRiOWMzOWItNDQxYi00ZGYzLWIyZjItODA5Y2Y1MWFjNzQ0",
 					"alias": "My checking account",
 					"account_number": "000000005686751168",
 					"iban": "DE43000000005686751168",
 					"holder_name": "Max Mustermann",
 					"bic": "TESTDE10XXX",
-					"bank_address": {
-						"country": "DE"
-					},
+					"bank_address": {"country": "DE"},
 					"transfer_type": "FULL",
 					"account_type": "DEFAULT",
 					"capabilities": {
-						"account_details": {
-							"available": True
-						},
-						"transactions": {
-							"available": True
-						},
-						"balances": {
-							"available": True
-						},
-						"transfer": {
-							"available": True
-						}
-					}
+						"account_details": {"available": True},
+						"transactions": {"available": True},
+						"balances": {"available": True},
+						"transfer": {"available": True},
+					},
 				},
 				{
 					"id": "YmI5NDAzZDctMGNmNi00ZjNiLTkyZGItM2JiNGVkZDM3ZDkw",
@@ -98,27 +84,17 @@ accounts_response_1 = frappe._dict(
 						"postalcode": "01234",
 						"city": "Musterstadt",
 						"region": "Hessen",
-						"country": "DE"
+						"country": "DE",
 					},
-					"bank_address": {
-						"country": "DE"
-					},
+					"bank_address": {"country": "DE"},
 					"transfer_type": "FULL",
 					"account_type": "DEFAULT",
 					"capabilities": {
-						"account_details": {
-							"available": True
-						},
-						"transactions": {
-							"available": True
-						},
-						"balances": {
-							"available": True
-						},
-						"transfer": {
-							"available": True
-						}
-					}
+						"account_details": {"available": True},
+						"transactions": {"available": True},
+						"balances": {"available": True},
+						"transfer": {"available": True},
+					},
 				},
 				{
 					"id": "YzQ1MzZlMDQtOGZjNy00YWFlLWEyOTEtNjcyZjYzMTJhM2Q3",
@@ -127,25 +103,15 @@ accounts_response_1 = frappe._dict(
 					"iban": "DE55000000004896641138",
 					"holder_name": "Max Mustermann",
 					"bic": "TESTDE10XXX",
-					"bank_address": {
-						"country": "DE"
-					},
+					"bank_address": {"country": "DE"},
 					"transfer_type": "FULL",
 					"account_type": "DEFAULT",
 					"capabilities": {
-						"account_details": {
-							"available": True
-						},
-						"transactions": {
-							"available": True
-						},
-						"balances": {
-							"available": True
-						},
-						"transfer": {
-							"available": True
-						}
-					}
+						"account_details": {"available": True},
+						"transactions": {"available": True},
+						"balances": {"available": True},
+						"transfer": {"available": True},
+					},
 				},
 				{
 					"id": "YTM5ODI4ZWItNjk5NC00NTdhLTkxZjItYzI5ZmExMzU5Y2Nm",
@@ -154,25 +120,15 @@ accounts_response_1 = frappe._dict(
 					"iban": "DE28000000008746441159",
 					"holder_name": "Max Mustermann",
 					"bic": "TESTDE10XXX",
-					"bank_address": {
-						"country": "DE"
-					},
+					"bank_address": {"country": "DE"},
 					"transfer_type": "REFERENCE",
 					"account_type": "SAVING",
 					"capabilities": {
-						"account_details": {
-							"available": True
-						},
-						"transactions": {
-							"available": True
-						},
-						"balances": {
-							"available": True
-						},
-						"transfer": {
-							"available": False
-						}
-					}
+						"account_details": {"available": True},
+						"transactions": {"available": True},
+						"balances": {"available": True},
+						"transfer": {"available": False},
+					},
 				},
 				{
 					"id": "OGFjYWRhNDAtYzJhZC0xMWViLTg1MjktMDI0MmFjMTMwMDAz",
@@ -181,32 +137,22 @@ accounts_response_1 = frappe._dict(
 					"iban": "DE90000000008116641159",
 					"holder_name": "Max Mustermann",
 					"bic": "TESTDE10XXX",
-					"bank_address": {
-						"country": "DE"
-					},
+					"bank_address": {"country": "DE"},
 					"transfer_type": "RESTRICTED",
 					"account_type": "DEFAULT",
 					"capabilities": {
-						"account_details": {
-							"available": True
-						},
-						"transactions": {
-							"available": False
-						},
-						"balances": {
-							"available": False
-						},
-						"transfer": {
-							"available": False
-						}
-					}
-				}
+						"account_details": {"available": True},
+						"transactions": {"available": False},
+						"balances": {"available": False},
+						"transfer": {"available": False},
+					},
+				},
 			],
 			"type": "accounts",
-			"bank_name": "Testbank"
+			"bank_name": "Testbank",
 		},
 		"client_token": "xaBStTc1963.sa3fica234.qSHfI1M0LFYUy-csbwj589598_QW-67",
-		"state": "FINISHED"
+		"state": "FINISHED",
 	}
 )
 
@@ -216,7 +162,7 @@ accounts_response_2 = frappe._dict(
 			"accounts": [
 				{
 					"id": "0",
-					"alias": "Girokonto (Max Mustermann)",
+					"alias": None,
 					"account_number": "23456789",
 					"iban": "DE06000000000023456789",
 					"holder_name": "Max Mustermann",
@@ -224,19 +170,11 @@ accounts_response_2 = frappe._dict(
 					"transfer_type": "FULL",
 					"account_type": "DEFAULT",
 					"capabilities": {
-						"account_details": {
-							"available": True
-						},
-						"transactions": {
-							"available": True
-						},
-						"balances": {
-							"available": True
-						},
-						"transfer": {
-							"available": True
-						}
-					}
+						"account_details": {"available": True},
+						"transactions": {"available": True},
+						"balances": {"available": True},
+						"transfer": {"available": True},
+					},
 				},
 				{
 					"id": "1",
@@ -248,19 +186,11 @@ accounts_response_2 = frappe._dict(
 					"transfer_type": "FULL",
 					"account_type": "DEFAULT",
 					"capabilities": {
-						"account_details": {
-							"available": True
-						},
-						"transactions": {
-							"available": True
-						},
-						"balances": {
-							"available": True
-						},
-						"transfer": {
-							"available": True
-						}
-					}
+						"account_details": {"available": True},
+						"transactions": {"available": True},
+						"balances": {"available": True},
+						"transfer": {"available": True},
+					},
 				},
 				{
 					"id": "2",
@@ -272,19 +202,11 @@ accounts_response_2 = frappe._dict(
 					"transfer_type": "FULL",
 					"account_type": "DEFAULT",
 					"capabilities": {
-						"account_details": {
-							"available": True
-						},
-						"transactions": {
-							"available": True
-						},
-						"balances": {
-							"available": True
-						},
-						"transfer": {
-							"available": True
-						}
-					}
+						"account_details": {"available": True},
+						"transactions": {"available": True},
+						"balances": {"available": True},
+						"transfer": {"available": True},
+					},
 				},
 				{
 					"id": "3",
@@ -296,19 +218,11 @@ accounts_response_2 = frappe._dict(
 					"transfer_type": "FULL",
 					"account_type": "DEFAULT",
 					"capabilities": {
-						"account_details": {
-							"available": True
-						},
-						"transactions": {
-							"available": True
-						},
-						"balances": {
-							"available": True
-						},
-						"transfer": {
-							"available": True
-						}
-					}
+						"account_details": {"available": True},
+						"transactions": {"available": True},
+						"balances": {"available": True},
+						"transfer": {"available": True},
+					},
 				},
 				{
 					"id": "4",
@@ -320,19 +234,11 @@ accounts_response_2 = frappe._dict(
 					"transfer_type": "FULL",
 					"account_type": "DEFAULT",
 					"capabilities": {
-						"account_details": {
-							"available": True
-						},
-						"transactions": {
-							"available": True
-						},
-						"balances": {
-							"available": True
-						},
-						"transfer": {
-							"available": True
-						}
-					}
+						"account_details": {"available": True},
+						"transactions": {"available": True},
+						"balances": {"available": True},
+						"transfer": {"available": True},
+					},
 				},
 				{
 					"id": "5",
@@ -345,26 +251,18 @@ accounts_response_2 = frappe._dict(
 					"transfer_type": "NONE",
 					"account_type": "SAVING",
 					"capabilities": {
-						"account_details": {
-							"available": False
-						},
-						"transactions": {
-							"available": False
-						},
-						"balances": {
-							"available": False
-						},
-						"transfer": {
-							"available": False
-						}
-					}
-				}
+						"account_details": {"available": False},
+						"transactions": {"available": False},
+						"balances": {"available": False},
+						"transfer": {"available": False},
+					},
+				},
 			],
 			"type": "accounts",
-			"bank_name": "Testbank"
+			"bank_name": "Testbank",
 		},
 		"client_token": "xaBStTc1963.sa3fica234.qSHfI1M0LFYUy-csbwj589598_QW-67",
-		"state": "FINISHED"
+		"state": "FINISHED",
 	}
 )
 
@@ -377,7 +275,7 @@ transactions_consent_response = frappe._dict(
 					"reference": "eBay, Additional information about Ebay",
 					"bank_references": {
 						"unstructured": "eBay",
-						"additional_information": "Additional information about Ebay"
+						"additional_information": "Additional information about Ebay",
 					},
 					"counter_party": {
 						"id": "YmI5NDAzZDctMGNmNi00ZjNiLTkyZGItM2JiNGVkZDM3ZDkw",
@@ -390,10 +288,10 @@ transactions_consent_response = frappe._dict(
 							"postalcode": "01234",
 							"city": "Musterstadt",
 							"region": "Hessen",
-							"country": "DE"
+							"country": "DE",
 						},
 						"transfer_type": "FULL",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-12-02",
 					"value_date": "2022-12-03",
@@ -401,17 +299,14 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "DIRECT_DEBIT",
-					"amount": {
-						"amount": 324229,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 324229, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "a7fdab5b3937e193bcc1ff79934d3e79",
 					"reference": "zalando plus fashion-service 5812871289, Additional information about Zalando",
 					"bank_references": {
 						"unstructured": "zalando plus fashion-service 5812871289",
-						"additional_information": "Additional information about Zalando"
+						"additional_information": "Additional information about Zalando",
 					},
 					"counter_party": {
 						"id": "ODE5NGNlMzAtZGY2OS00N2JiLTgzNjQtYmI5ZTc4NDljM2Ux",
@@ -419,7 +314,7 @@ transactions_consent_response = frappe._dict(
 						"iban": "DE90000000008116641159",
 						"holder_name": "Zalando",
 						"transfer_type": "FULL",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-12-01",
 					"value_date": "2022-12-02",
@@ -427,17 +322,14 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "TRANSFER",
-					"amount": {
-						"amount": 13990,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 13990, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "9c59156d4bea01cbc61b73e34bf10588",
 					"reference": "LASTSCHRIFT / BELASTUNG AMAZON PRIME VIDEO END-TO-END-REF.: / MANDATSREF.: GLÄUBIGER-ID: Ref. AMAZON MEDIA EU S.A R.L., Additional information about Amazon",
 					"bank_references": {
 						"unstructured": "LASTSCHRIFT / BELASTUNG AMAZON PRIME VIDEO END-TO-END-REF.: / MANDATSREF.: GLÄUBIGER-ID: Ref. AMAZON MEDIA EU S.A R.L.",
-						"additional_information": "Additional information about Amazon"
+						"additional_information": "Additional information about Amazon",
 					},
 					"counter_party": {
 						"id": "OWFjYmRmOWItZDY3Ny00MGU2LTg2MjktZWZlYzU5NGI0ZDgw",
@@ -445,7 +337,7 @@ transactions_consent_response = frappe._dict(
 						"iban": "DE53000000001716448159",
 						"holder_name": "AMAZON MEDIA EU S.A R.L.",
 						"transfer_type": "FULL",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-12-01",
 					"value_date": "2022-12-02",
@@ -453,17 +345,14 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "DIRECT_DEBIT",
-					"amount": {
-						"amount": 6500,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 6500, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "3cd2c0595fe803ae5bcfb1334568757f",
 					"reference": "transfer, Additional information about the transfer",
 					"bank_references": {
 						"unstructured": "transfer",
-						"additional_information": "Additional information about the transfer"
+						"additional_information": "Additional information about the transfer",
 					},
 					"counter_party": {
 						"id": "YmI5NDAzZDctMGNmNi00ZjNiLTkyZGItM2JiNGVkZDM3ZDkw",
@@ -476,33 +365,30 @@ transactions_consent_response = frappe._dict(
 							"postalcode": "01234",
 							"city": "Musterstadt",
 							"region": "Hessen",
-							"country": "DE"
+							"country": "DE",
 						},
 						"transfer_type": "FULL",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-11-29",
 					"value_date": "2022-11-29",
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "DIRECT_DEBIT",
-					"amount": {
-						"amount": 50000,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 50000, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "aa1fa05ae1d76654da7bd271b645c30a",
 					"reference": "Netflix 2388191, Additional information about Netflix",
 					"bank_references": {
 						"unstructured": "Netflix 2388191",
-						"additional_information": "Additional information about Netflix"
+						"additional_information": "Additional information about Netflix",
 					},
 					"counter_party": {
 						"id": "ODI4ODRjZjAtODU0MS00MjY1LThhN2UtYTk5NjYwMGMxNGZj",
 						"holder_name": "Netflix",
 						"transfer_type": "FULL",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-11-28",
 					"value_date": "2022-11-29",
@@ -510,17 +396,14 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "TRANSFER",
-					"amount": {
-						"amount": 1199,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 1199, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "2c1de6e0c8798ff6ca511284341d56ab",
 					"reference": "Thanks for the coffee, Additional information about that coffee",
 					"bank_references": {
 						"unstructured": "Thanks for the coffee",
-						"additional_information": "Additional information about that coffee"
+						"additional_information": "Additional information about that coffee",
 					},
 					"counter_party": {
 						"id": "ZDFiYzc1YzEtNmRiOS00ODY1LTk1NTYtMjg5YjdkMGNkYzQ4",
@@ -528,7 +411,7 @@ transactions_consent_response = frappe._dict(
 						"iban": "DE18000000002716442159",
 						"holder_name": "Angela Murkel",
 						"transfer_type": "FULL",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-11-28",
 					"value_date": "2022-11-29",
@@ -536,22 +419,19 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "CREDIT",
 					"method": "TRANSFER",
-					"amount": {
-						"amount": 580,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 580, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "7719b188bf37724c8102d55a7223a54f",
 					"reference": "523628918, Additional information",
 					"bank_references": {
 						"unstructured": "523628918",
-						"additional_information": "Additional information"
+						"additional_information": "Additional information",
 					},
 					"counter_party": {
 						"id": "YjYyODYzMzgtNTExZi00MDQyLThmY2MtMzkyNjU5NGI1MGI3",
 						"holder_name": "Spotify",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-11-28",
 					"value_date": "2022-11-29",
@@ -559,22 +439,19 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "DIRECT_DEBIT",
-					"amount": {
-						"amount": 7791,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 7791, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "4b020576191ebc04b9d44921cd34e6ef",
 					"reference": "REWE SAGT DANKE. 1251611//Linden/DE, Additional information about Rewe",
 					"bank_references": {
 						"unstructured": "REWE SAGT DANKE. 1251611//Linden/DE",
-						"additional_information": "Additional information about Rewe"
+						"additional_information": "Additional information about Rewe",
 					},
 					"counter_party": {
 						"id": "MzUwNWZiZDMtMDBhMy00ODk2LWI1NTMtYTdkOWI5Njc4MzI3",
 						"holder_name": "REWE Alexander Mar",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-11-27",
 					"value_date": "2022-11-28",
@@ -582,22 +459,19 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "DIRECT_DEBIT",
-					"amount": {
-						"amount": 2320,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 2320, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "463b8c45f4aceb228d4600b6343f3791",
 					"reference": "302-123123-1900368 AMZN Mktp DE HEWEHASQE, Additional information about Amazon",
 					"bank_references": {
 						"unstructured": "302-123123-1900368 AMZN Mktp DE HEWEHASQE",
-						"additional_information": "Additional information about Amazon"
+						"additional_information": "Additional information about Amazon",
 					},
 					"counter_party": {
 						"id": "NWI4NzVjMDktZDQ0OC00NzY4LWJjM2QtOTc4NTM2YzY3YjIw",
 						"holder_name": "AMAZON PAYMENTS EUROPE S.C.A.",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-11-24",
 					"value_date": "2022-11-25",
@@ -605,39 +479,33 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "DIRECT_DEBIT",
-					"amount": {
-						"amount": 4999,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 4999, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "b8a1dca24c632eb8ec5e9d825344b534",
 					"reference": "VK 3543774/WETTENBERGRING 1/ ABHOCHS 20,00 ABWA+Mittelhess.Wasserbetriebe, Additional information about ABWA",
 					"bank_references": {
 						"unstructured": "VK 3543774/WETTENBERGRING 1/ ABHOCHS 20,00 ABWA+Mittelhess.Wasserbetriebe",
-						"additional_information": "Additional information about ABWA"
+						"additional_information": "Additional information about ABWA",
 					},
 					"counter_party": {
 						"id": "ZDUzMTk3YjUtZGFhZS00M2UyLWIzMjAtNTdiZmYwNjRmYjE3",
 						"holder_name": "Stadtwerke Giessen AG",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-11-23",
 					"booking_date": "2022-11-23",
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "DIRECT_DEBIT",
-					"amount": {
-						"amount": 15200,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 15200, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "a7b08375d13ebbee08d3cb7a133d1b5b",
 					"reference": "Miete + Nebenkosten, Additional information about the rent",
 					"bank_references": {
 						"unstructured": "Miete + Nebenkosten",
-						"additional_information": "Additional information about the rent"
+						"additional_information": "Additional information about the rent",
 					},
 					"counter_party": {
 						"id": "NDc1MjZiOGYtMjhmZi00OWRjLWI0NDQtZWRkYTFiMTM1Mzcz",
@@ -645,7 +513,7 @@ transactions_consent_response = frappe._dict(
 						"iban": "DE02000000003716541159",
 						"holder_name": "Franz Maier",
 						"transfer_type": "FULL",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-11-21",
 					"value_date": "2022-11-22",
@@ -653,24 +521,21 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "CREDIT",
 					"method": "DIRECT_DEBIT",
-					"amount": {
-						"amount": 75000,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 75000, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "66c1ece556154678377390481f81cf72",
 					"reference": "Cancelled: Kd-Nr..260293061,Rg-Nr..273723473/5,Mehr Infosunter.Ihre Mobilfunkrechnung., Additional information about the cancellation",
 					"bank_references": {
 						"unstructured": "Cancelled: Kd-Nr..260293061,Rg-Nr..273723473/5,Mehr Infosunter.Ihre Mobilfunkrechnung.",
-						"additional_information": "Additional information about the cancellation"
+						"additional_information": "Additional information about the cancellation",
 					},
 					"counter_party": {
 						"id": "Y2U5ZDExOGEtZTUyZC00NDA4LTlhZGItYWU3MTQyNDdiYzY0",
 						"account_number": "000000004716441199",
 						"iban": "DE46000000004716441199",
 						"holder_name": "Telefonica Germany GmbH + Co. OHG",
-						"transfer_type": "FULL"
+						"transfer_type": "FULL",
 					},
 					"date": "2022-11-21",
 					"value_date": "2022-11-22",
@@ -678,24 +543,21 @@ transactions_consent_response = frappe._dict(
 					"state": "CANCELED",
 					"type": "DEBIT",
 					"method": "DIRECT_DEBIT",
-					"amount": {
-						"amount": 2500,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 2500, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "d5098dc4868fc8c8ffa4249f255f4b7c",
 					"reference": "Rundfunk 01.2019 - 03.2019 Beitragsnr. 61261261Aenderungen ganz bequem. www.rundfunkbeitrag.de, Additional information about the contract",
 					"bank_references": {
 						"unstructured": "Rundfunk 01.2019 - 03.2019 Beitragsnr. 61261261Aenderungen ganz bequem. www.rundfunkbeitrag.de",
-						"additional_information": "Additional information about the contract"
+						"additional_information": "Additional information about the contract",
 					},
 					"counter_party": {
 						"id": "NGQ5NWMxZTgtNDFjMS00YTQ0LWFjZWItMzhlMzc0Yzc5M2E0",
 						"account_number": "000000005716441119",
 						"iban": "DE27000000005716441119",
 						"holder_name": "Rundfunk ARD, ZDF, DRadio",
-						"transfer_type": "FULL"
+						"transfer_type": "FULL",
 					},
 					"date": "2022-11-18",
 					"value_date": "2022-11-19",
@@ -703,17 +565,14 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "TRANSFER",
-					"amount": {
-						"amount": 5250,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 5250, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "0a17cd586421d8d0acf8496b52e2e6d6",
 					"reference": "transfer, Additional information about the transfer",
 					"bank_references": {
 						"unstructured": "transfer",
-						"additional_information": "Additional information about the transfer"
+						"additional_information": "Additional information about the transfer",
 					},
 					"counter_party": {
 						"id": "YmI5NDAzZDctMGNmNi00ZjNiLTkyZGItM2JiNGVkZDM3ZDkw",
@@ -726,10 +585,10 @@ transactions_consent_response = frappe._dict(
 							"postalcode": "01234",
 							"city": "Musterstadt",
 							"region": "Hessen",
-							"country": "DE"
+							"country": "DE",
 						},
 						"transfer_type": "FULL",
-						"account_type": "DEFAULT"
+						"account_type": "DEFAULT",
 					},
 					"date": "2022-11-17",
 					"value_date": "2022-11-17",
@@ -737,10 +596,7 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "TRANSFER",
-					"amount": {
-						"amount": 15000,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 15000, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "4910a6ba29252a018c650151a3cf311c",
@@ -748,14 +604,14 @@ transactions_consent_response = frappe._dict(
 					"bank_references": {
 						"unstructured": "Uber transfer",
 						"end_to_end": "4541fce0-fba6-45bf-a0c2-ff176da98476",
-						"additional_information": "Additional information about Uber"
+						"additional_information": "Additional information about Uber",
 					},
 					"counter_party": {
 						"id": "MzNkOGRlNzEtYTVkMy00M2Q2LTgwMzctOGZlZTRiNGUzMmU2",
 						"account_number": "000000005478456489",
 						"iban": "DE69000000005478456489",
 						"holder_name": "Uber",
-						"transfer_type": "FULL"
+						"transfer_type": "FULL",
 					},
 					"date": "2022-11-16",
 					"value_date": "2022-11-17",
@@ -763,24 +619,21 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "TRANSFER",
-					"amount": {
-						"amount": 571,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 571, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "486a861fd6f9b3ec77979c666228bf10",
 					"reference": "b6a6616c-8c39-4576-a560-6db75fe4d41e, Additional information",
 					"bank_references": {
 						"end_to_end": "b6a6616c-8c39-4576-a560-6db75fe4d41e",
-						"additional_information": "Additional information"
+						"additional_information": "Additional information",
 					},
 					"counter_party": {
 						"id": "MzNkOGRlNzEtYTVkMy00M2Q2LTgwMzctOGZlZTRiNGUzMmU2",
 						"account_number": "000000005478456489",
 						"iban": "DE69000000005478456489",
 						"holder_name": "Uber",
-						"transfer_type": "FULL"
+						"transfer_type": "FULL",
 					},
 					"date": "2022-11-16",
 					"value_date": "2022-11-16",
@@ -788,10 +641,7 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "TRANSFER",
-					"amount": {
-						"amount": 197,
-						"currency": "EUR"
-					}
+					"amount": {"amount": 197, "currency": "EUR"},
 				},
 				{
 					"transaction_id": "9649ebf4bdc358a5e029a15626964e4a",
@@ -800,14 +650,14 @@ transactions_consent_response = frappe._dict(
 						"structured": "Uber Eats meal 278591",
 						"message": "Klarna AB",
 						"additional_information": "Additional information about Uber Eats",
-						"national": "RF369912345678901234588"
+						"national": "RF369912345678901234588",
 					},
 					"counter_party": {
 						"id": "ZDllMjBmMTAtMzFhNi00NzBkLWFiOTQtMDFjNWZiMjBkMzY1",
 						"account_number": "000000007382156416",
 						"iban": "DE72000000007382156416",
 						"holder_name": "Uber Eats",
-						"transfer_type": "FULL"
+						"transfer_type": "FULL",
 					},
 					"date": "2022-11-15",
 					"value_date": "2022-11-16",
@@ -815,16 +665,13 @@ transactions_consent_response = frappe._dict(
 					"state": "PROCESSED",
 					"type": "DEBIT",
 					"method": "TRANSFER",
-					"amount": {
-						"amount": 2471,
-						"currency": "EUR"
-					}
-				}
+					"amount": {"amount": 2471, "currency": "EUR"},
+				},
 			],
 			"from_date": "2022-01-01",
 			"to_date": "2022-12-08",
-			"pagination": {}
+			"pagination": {},
 		},
-		"consent_token": "bca38b24a804aa37d821d31af00f5598230122c5bbfc4c4ad5ed40e4258f04ca"
+		"consent_token": "bca38b24a804aa37d821d31af00f5598230122c5bbfc4c4ad5ed40e4258f04ca",
 	}
 )

--- a/banking/klarna_kosma_integration/utils.py
+++ b/banking/klarna_kosma_integration/utils.py
@@ -200,7 +200,7 @@ def get_account_name(account: Dict) -> str:
 	alias = account.get("alias")
 	if alias:
 		is_alias_distinct = "(" in alias
-		alias_with_acc_holder = f"{alias} ({account.get('holder_name')})"
+		alias_with_acc_holder = f"{alias} ({account.get('holder_name', '')})"
 
 		account_name = alias if is_alias_distinct else alias_with_acc_holder
 	else:

--- a/banking/klarna_kosma_integration/utils.py
+++ b/banking/klarna_kosma_integration/utils.py
@@ -197,11 +197,14 @@ def get_account_name(account: Dict) -> str:
 	- Accounts: [{alias: "My checking account"}, {alias: "My salary account"}, {alias: "My restricted account"}]
 	- (distinct) Accounts: [{alias: "Girokonto (Max Mustermann)"}, {alias: "Girokonto (Hans Mustermann)"}]
 	"""
-	is_account_alias_distinct = "(" in account.get("alias")
-	if is_account_alias_distinct:
-		account_name = account.get("alias")
+	alias = account.get("alias")
+	if alias:
+		is_alias_distinct = "(" in alias
+		alias_with_acc_holder = f"{alias} ({account.get('holder_name')})"
+
+		account_name = alias if is_alias_distinct else alias_with_acc_holder
 	else:
-		account_name = f"{account.get('alias')} ({account.get('holder_name')})"
+		account_name = account.get("iban") or account.get("account_number")
 
 	return account_name
 


### PR DESCRIPTION
**Issue:**
```py
File "apps/banking/banking/klarna_kosma_integration/utils.py", line 200, in get_account_name

    is_account_alias_distinct = "(" in account.get("alias")

TypeError: argument of type 'NoneType' is not iterable
```

**Fix:**
Fix is in banking/klarna_kosma_integration/utils.py
- Use IBAN or ACC NO. if alias is absent
- Account names without alias will be like:  "DE52000000000012345678 - Sparkasse"
- Test to check account creation without alias
- Misc: pre-commit formatting