### PR TITLE
fix: Create PE against SI for transaction amount

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -906,8 +906,8 @@ def get_unpaid_si_matching_query(exact_match, exact_party_match, currency, compa
 	party_condition = sales_invoice.customer == Parameter("%(party)s")
 	party_match = frappe.qb.terms.Case().when(party_condition, 1).else_(0)
 
-	grand_total_condition = sales_invoice.grand_total == Parameter("%(amount)s")
-	amount_match = frappe.qb.terms.Case().when(grand_total_condition, 1).else_(0)
+	outstanding_amount_condition = sales_invoice.outstanding_amount == Parameter("%(amount)s")
+	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
 
 	query = (
 		frappe.qb.from_(sales_invoice)
@@ -933,7 +933,7 @@ def get_unpaid_si_matching_query(exact_match, exact_party_match, currency, compa
 	)
 
 	if exact_match:
-		query = query.where(grand_total_condition)
+		query = query.where(outstanding_amount_condition)
 
 	if exact_party_match:
 		query = query.where(party_condition)
@@ -996,8 +996,8 @@ def get_unpaid_pi_matching_query(exact_match, exact_party_match, currency, compa
 	party_condition = purchase_invoice.supplier == Parameter("%(party)s")
 	party_match = frappe.qb.terms.Case().when(party_condition, 1).else_(0)
 
-	grand_total_condition = purchase_invoice.grand_total == Parameter("%(amount)s")
-	amount_match = frappe.qb.terms.Case().when(grand_total_condition, 1).else_(0)
+	outstanding_amount_condition = purchase_invoice.outstanding_amount == Parameter("%(amount)s")
+	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
 
 	query = (
 		frappe.qb.from_(purchase_invoice)
@@ -1023,7 +1023,7 @@ def get_unpaid_pi_matching_query(exact_match, exact_party_match, currency, compa
 	)
 
 	if exact_match:
-		query = query.where(grand_total_condition)
+		query = query.where(outstanding_amount_condition)
 	if exact_party_match:
 		query = query.where(party_condition)
 

--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -57,7 +57,10 @@ class CustomBankTransaction(BankTransaction):
 	def make_pe_against_invoice(self, payment_doctype, payment_name):
 		bank_account = frappe.db.get_value("Bank Account", self.bank_account, "account")
 		payment_entry = get_payment_entry(
-			payment_doctype, payment_name, bank_account=bank_account
+			payment_doctype,
+			payment_name,
+			party_amount=self.unallocated_amount,
+			bank_account=bank_account,
 		)
 		payment_entry.reference_no = self.reference_number or payment_name
 		payment_entry.submit()

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -188,9 +188,11 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		}
 
 		// Total of selected row amounts in summary_data
+		// Cap total_allocated to unallocated amount
 		let total_allocated = Object.values(this.summary_data).reduce(
 			(a, b) => a + b, 0
 		);
+		total_allocated = Math.min(total_allocated, this.transaction.unallocated_amount);
 
 		// Deduct allocated amount from transaction's unallocated amount
 		// to show the final effect on reconciling


### PR DESCRIPTION
Closes https://github.com/alyf-de/banking/issues/59
- Make sure PE against SI is not made for full SI amount blindly
   ![2023-10-05 16 33 03](https://github.com/alyf-de/banking/assets/25857446/9607f234-a734-4984-8fcd-522282f00544)

- Summary total allocated should not exceed pending to allocate. Max 50 will be allocated out of 100, if 50 is pending to allocate
   ![2023-10-05 16 30 52](https://github.com/alyf-de/banking/assets/25857446/eb8d1f8a-4ab8-40b2-a970-00ec40a241d9)

   
