### PR TITLE
feat: Show alert if scheduler is inactive or app version is stale

### DIFF
--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js
@@ -4,6 +4,8 @@
 frappe.ui.form.on('Banking Settings', {
 	refresh: (frm) => {
 		if (frm.doc.enabled) {
+			frm.trigger("get_app_health");
+
 			frm.add_custom_button(__('Link Bank and Accounts'), () => {
 				frm.events.refresh_banks(frm);
 			});
@@ -203,7 +205,7 @@ frappe.ui.form.on('Banking Settings', {
 							target="_blank"
 							class="${subscription.billing_portal ? "" : "hidden"}"
 						>
-							<b>${__("Open Billing Portal")}</b> 
+							<b>${__("Open Billing Portal")}</b>
 							${frappe.utils.icon("link-url", "sm")}
 						</a>
 					</p>
@@ -216,7 +218,28 @@ frappe.ui.form.on('Banking Settings', {
 
 			frm.refresh_field("subscription");
 		}
-	}
+	},
+
+	get_app_health: async (frm) => {
+		const data = await frm.call({
+			method: "get_app_health",
+		});
+
+		let messages = data.message;
+		if (messages) {
+			if(messages["info"]) {
+				frm.set_intro(messages["info"], "blue");
+			}
+
+			if (messages["warning"]) {
+				$(frm.$wrapper.find(".form-layout")[0]).prepend(`
+					<div class='form-message yellow'>
+						${messages["warning"]}
+					</div>
+				`);
+			}
+		}
+	},
 });
 
 class KlarnaKosmaConnect {


### PR DESCRIPTION
Resolves https://github.com/alyf-de/banking/issues/70

<img width="1301" alt="Screenshot 2023-11-02 at 4 10 07 PM" src="https://github.com/alyf-de/banking/assets/25857446/137c8184-f8d7-4eeb-a276-aea949f322db">

- The scheduler being inactive is a good enough check. If the scheduler is not working due to some kind of error, the web server would also most likely go down, taking down the site
- The app version check does a basic latest release vs in-app version comparison