### PR TITLE
fix: Remove horizontal scroll from match vouchers tab

### DIFF
--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -83,7 +83,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			return [
 				this.help_button(row.name),
 				row.reference_date || row.posting_date, // Reference Date
-				format_currency(row.paid_amount, row.currency),
+				{amount: row.paid_amount, currency: row.currency},
 				row.reference_no || '',
 				row.party || '',
 				row.name,
@@ -454,6 +454,9 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				name: __("Remaining"),
 				editable: false,
 				width: 100,
+				format: (value, row, column, data) => {
+					return format_currency(row[4].amount, row[4].currency)
+				},
 			},
 			{
 				name: __("Reference Number"),
@@ -482,7 +485,6 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 	}
 
 	get_amount_from_row(row) {
-		let value = row[5].content;
-		return flt(value.split(" ") ? value.split(" ")[1] : 0);
+		return row[4].amount;
 	}
 }

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -82,12 +82,12 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			}
 			return [
 				this.help_button(row.name),
-				row.doctype,
 				row.reference_date || row.posting_date, // Reference Date
 				format_currency(row.paid_amount, row.currency),
 				row.reference_no || '',
 				row.party || '',
-				row.name
+				row.name,
+				row.doctype,
 			];
 		});
 
@@ -440,12 +440,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			{
 				name: __("Reason"),
 				editable: false,
-				width: 50,
-			},
-			{
-				name: __("Document Type"),
-				editable: false,
-				width: 100,
+				width: 80,
 			},
 			{
 				name: __("Reference Date"),
@@ -463,7 +458,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			{
 				name: __("Reference Number"),
 				editable: false,
-				width: 200,
+				width: 115,
 			},
 			{
 				name: __("Party"),
@@ -473,10 +468,15 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			{
 				name: __("Document Name"),
 				editable: false,
-				width: 100,
+				width: 150,
 				format: (value, row, column, data) => {
-					return frappe.format(value, {fieldtype: "Link", options: data[1]});
+					return frappe.format(value, {fieldtype: "Link", options: data[6]});
 				},
+			},
+			{
+				name: __("Document Type"),
+				editable: false,
+				width: 50,
 			},
 		];
 	}

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -85,7 +85,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				row.reference_date || row.posting_date, // Reference Date
 				{amount: row.paid_amount, currency: row.currency},
 				row.reference_no || '',
-				row.party || '',
+				{party: row.party, party_type: row.party_type},
 				{docname: row.name, doctype: row.doctype},
 			];
 		});
@@ -466,6 +466,9 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				name: __("Party"),
 				editable: false,
 				width: 100,
+				format: (value, row, column, data) => {
+					return frappe.format(row[6].party, {fieldtype: "Link", options: row[6].party_type});
+				},
 			},
 			{
 				name: __("Document Name"),

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -86,8 +86,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				{amount: row.paid_amount, currency: row.currency},
 				row.reference_no || '',
 				row.party || '',
-				row.name,
-				row.doctype,
+				{docname: row.name, doctype: row.doctype},
 			];
 		});
 
@@ -235,8 +234,8 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			if (value === 1) {
 				let row = voucher_rows[idx];
 				selected_vouchers.push({
-					payment_doctype: row[3].content,
-					payment_name: row[8].content,
+					payment_doctype: row[7].doctype,
+					payment_name: row[7].docname,
 					amount: this.get_amount_from_row(row),
 				});
 			}
@@ -473,13 +472,8 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				editable: false,
 				width: 150,
 				format: (value, row, column, data) => {
-					return frappe.format(value, {fieldtype: "Link", options: data[6]});
+					return frappe.format(row[7].docname, {fieldtype: "Link", options: row[7].doctype});
 				},
-			},
-			{
-				name: __("Document Type"),
-				editable: false,
-				width: 50,
 			},
 		];
 	}

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -105,7 +105,8 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 					content: row.name,
 					format: (value) => {
 						return frappe.format(row.name, {fieldtype: "Link", options: row.doctype});
-					}
+					},
+					doctype: row.doctype,
 				},
 			];
 		});
@@ -147,7 +148,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 	check_data_table_row(row) {
 		if (!row) return;
 
-		let id = row[6].docname;
+		let id = row[5].content;  // Voucher name
 		let value = this.get_amount_from_row(row);
 
 		// If `id` in summary_data, remove it (row was unchecked), else add it
@@ -205,8 +206,8 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			if (value === 1) {
 				let row = voucher_rows[idx];
 				selected_vouchers.push({
-					payment_doctype: row[6].doctype,
-					payment_name: row[6].docname,
+					payment_doctype: row[5].doctype,
+					payment_name: row[5].content,  // Voucher name
 					amount: this.get_amount_from_row(row),
 				});
 			}
@@ -435,6 +436,6 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 	}
 
 	get_amount_from_row(row) {
-		return row[3].amount;
+		return row[2].content;  // Amount
 	}
 }

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -96,6 +96,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			dynamicRowHeight: true,
 			checkboxColumn: true,
 			inlineFilters: true,
+			layout: "fluid",
 		};
 
 
@@ -439,12 +440,10 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			{
 				name: __("Reason"),
 				editable: false,
-				width: 80,
 			},
 			{
-				name: __("Reference Date"),
+				name: __("Date"),
 				editable: false,
-				width: 120,
 				format: (value) => {
 					return frappe.format(value, {fieldtype: "Date"});
 				},
@@ -452,28 +451,24 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			{
 				name: __("Remaining"),
 				editable: false,
-				width: 100,
 				format: (value, row, column, data) => {
 					return format_currency(row[4].amount, row[4].currency)
 				},
 			},
 			{
-				name: __("Reference Number"),
+				name: __("Reference"),
 				editable: false,
-				width: 115,
 			},
 			{
 				name: __("Party"),
 				editable: false,
-				width: 100,
 				format: (value, row, column, data) => {
 					return frappe.format(row[6].party, {fieldtype: "Link", options: row[6].party_type});
 				},
 			},
 			{
-				name: __("Document Name"),
+				name: __("Voucher"),
 				editable: false,
-				width: 150,
 				format: (value, row, column, data) => {
 					return frappe.format(row[7].docname, {fieldtype: "Link", options: row[7].doctype});
 				},

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -97,6 +97,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			checkboxColumn: true,
 			inlineFilters: true,
 			layout: "fluid",
+			serialNoColumn: false,
 		};
 
 
@@ -177,7 +178,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 	check_data_table_row(row) {
 		if (!row) return;
 
-		let id = row[1].content;
+		let id = row[6].docname;
 		let value = this.get_amount_from_row(row);
 
 		// If `id` in summary_data, remove it (row was unchecked), else add it
@@ -235,8 +236,8 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			if (value === 1) {
 				let row = voucher_rows[idx];
 				selected_vouchers.push({
-					payment_doctype: row[7].doctype,
-					payment_name: row[7].docname,
+					payment_doctype: row[6].doctype,
+					payment_name: row[6].docname,
 					amount: this.get_amount_from_row(row),
 				});
 			}
@@ -452,7 +453,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				name: __("Remaining"),
 				editable: false,
 				format: (value, row, column, data) => {
-					return format_currency(row[4].amount, row[4].currency)
+					return format_currency(row[3].amount, row[3].currency)
 				},
 			},
 			{
@@ -463,20 +464,20 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				name: __("Party"),
 				editable: false,
 				format: (value, row, column, data) => {
-					return frappe.format(row[6].party, {fieldtype: "Link", options: row[6].party_type});
+					return frappe.format(row[5].party, {fieldtype: "Link", options: row[5].party_type});
 				},
 			},
 			{
 				name: __("Voucher"),
 				editable: false,
 				format: (value, row, column, data) => {
-					return frappe.format(row[7].docname, {fieldtype: "Link", options: row[7].doctype});
+					return frappe.format(row[6].docname, {fieldtype: "Link", options: row[6].doctype});
 				},
 			},
 		];
 	}
 
 	get_amount_from_row(row) {
-		return row[4].amount;
+		return row[3].amount;
 	}
 }

--- a/banking/public/scss/bank_reconciliation_beta.scss
+++ b/banking/public/scss/bank_reconciliation_beta.scss
@@ -5,7 +5,7 @@
 .list-panel {
 	display: flex;
 	flex-direction: column;
-	width: 40%;
+	width: 30%;
 	height: 100vh;
 	border: 1px solid var(--gray-200);
 
@@ -48,6 +48,11 @@
 
 		}
 	}
+
+	*::-webkit-scrollbar {
+		width: 3px;
+		height: 3px;
+	}
 }
 
 .bt-amount-contianer {
@@ -61,7 +66,7 @@
 .actions-panel {
 	display: flex;
 	flex-direction: column;
-	width: 60%;
+	width: 70%;
 	height: 100vh;
 	border: 1px solid var(--gray-200);
 	overflow-y: scroll;
@@ -82,6 +87,11 @@
 		* .dt-toast {
 			display: none !important;
 		}
+	}
+
+	*::-webkit-scrollbar {
+		width: 3px;
+		height: 3px;
 	}
 }
 
@@ -128,11 +138,11 @@
 
 .bank-reco-beta-empty-state {
 	display: flex;
-    flex-direction: column;
-    min-height: 30vh;
+	flex-direction: column;
+	min-height: 30vh;
 	align-items: center;
-    justify-content: center;
-    padding: 2rem;
+	justify-content: center;
+	padding: 2rem;
 	font-size: 14px;
 	color: var(--gray-600);
 
@@ -143,14 +153,14 @@
 
 .no-transactions {
 	display: flex;
-    flex-direction: column;
-    min-height: 30vh;
-    align-items: center;
-    justify-content: center;
-    padding: 2rem;
-    font-size: 14px;
-    width: 100%;
-    color: var(--gray-600);
+	flex-direction: column;
+	min-height: 30vh;
+	align-items: center;
+	justify-content: center;
+	padding: 2rem;
+	font-size: 14px;
+	width: 100%;
+	color: var(--gray-600);
 
 	> img {
 		margin-bottom: var(--margin-md);


### PR DESCRIPTION
Solves https://github.com/alyf-de/banking/issues/48

- Adjusted horizontal space between transactions list and actions area
- Reduced scrollbar idth of transactions area
- Adjusted column widths of datatable
- Document Type field moved to end of datatable. Its not an important column and often has repetitive information

## Before:
- The important columns are not all visible
- LHS is has some whitespace since its taking up way more space than it needs
- Horizontal scroll
<img width="1315" alt="Screenshot 2023-11-03 at 12 24 28 PM" src="https://github.com/alyf-de/banking/assets/25857446/82ca129d-ae65-40bf-93ac-5d75d3f92592">


## After:
- Match reasons are highlighted in bold. One less action for users
- No horizontal scroll
- Reference, Party and Voucher are left aligned
<img width="1306" alt="Screenshot 2023-11-06 at 4 03 59 PM" src="https://github.com/alyf-de/banking/assets/25857446/4e3caf3e-52e9-462b-bd8d-218868ac54e1">

