### PR TITLE
fix: Set default country in kosma popup based on selected company

### DIFF
--- a/banking/connectors/admin_request.py
+++ b/banking/connectors/admin_request.py
@@ -5,14 +5,9 @@ from typing import Dict, Optional
 import requests
 
 
-class AdminRequest():
+class AdminRequest:
 	def __init__(
-		self,
-		ip_address: str,
-		user_agent: str,
-		api_token: str,
-		url: str,
-		customer_id: str
+		self, ip_address: str, user_agent: str, api_token: str, url: str, customer_id: str
 	) -> None:
 		self.ip_address = ip_address
 		self.user_agent = user_agent
@@ -22,16 +17,14 @@ class AdminRequest():
 
 	@property
 	def headers(self):
-		return {
-			"Authorization": f"Token {self.api_token}"
-		}
+		return {"Authorization": f"Token {self.api_token}"}
 
 	@property
 	def data(self):
 		return {
 			"ip_address": self.ip_address,
 			"user_agent": self.user_agent,
-			"customer_id": self.customer_id
+			"customer_id": self.customer_id,
 		}
 
 	def get_client_token(
@@ -39,35 +32,32 @@ class AdminRequest():
 		current_flow: str,
 		account: Optional[Dict] = None,
 		from_date: Optional[str] = None,
-		to_date: Optional[str] = None
+		to_date: Optional[str] = None,
+		country_code: Optional[str] = None,
 	):
 		data = self.data
-		data.update({
-			"current_flow": current_flow,
-			"account": account,
-			"from_date": from_date,
-			"to_date": to_date
-		})
+		data.update(
+			{
+				"current_flow": current_flow,
+				"account": account,
+				"from_date": from_date,
+				"to_date": to_date,
+				"country_code": country_code,
+			}
+		)
 
 		method = "banking_admin.api.get_client_token"
 		return requests.post(
-			url=self.url + method,
-			headers=self.headers,
-			data=json.dumps(data)
+			url=self.url + method, headers=self.headers, data=json.dumps(data)
 		)
 
 	def flow_accounts(self, session_id: str, flow_id: str):
 		data = self.data
-		data.update({
-			"session_id": session_id,
-			"flow_id": flow_id
-		})
+		data.update({"session_id": session_id, "flow_id": flow_id})
 
 		method = "banking_admin.api.fetch_accounts_and_bank"
 		return requests.post(
-			url=self.url + method,
-			headers=self.headers,
-			data=json.dumps(data)
+			url=self.url + method, headers=self.headers, data=json.dumps(data)
 		)
 
 	def flow_transactions(
@@ -75,21 +65,16 @@ class AdminRequest():
 		session_id: str,
 		flow_id: str,
 		url: Optional[str] = None,
-		offset: Optional[str] = None
+		offset: Optional[str] = None,
 	):
 		data = self.data
-		data.update({
-			"session_id": session_id,
-			"flow_id": flow_id,
-			"url": url,
-			"offset": offset
-		})
+		data.update(
+			{"session_id": session_id, "flow_id": flow_id, "url": url, "offset": offset}
+		)
 
 		method = "banking_admin.api.fetch_flow_transactions"
 		return requests.post(
-			url=self.url + method,
-			headers=self.headers,
-			data=json.dumps(data)
+			url=self.url + method, headers=self.headers, data=json.dumps(data)
 		)
 
 	def end_session(self, session_id: str):
@@ -97,24 +82,15 @@ class AdminRequest():
 		data.update({"session_id": session_id})
 
 		method = "banking_admin.api.end_session"
-		requests.post(
-			url=self.url + method,
-			headers=self.headers,
-			data=json.dumps(data)
-		)
+		requests.post(url=self.url + method, headers=self.headers, data=json.dumps(data))
 
 	def consent_accounts(self, consent_id: str, consent_token: str):
 		data = self.data
-		data.update({
-			"consent_id": consent_id,
-			"consent_token": consent_token
-		})
+		data.update({"consent_id": consent_id, "consent_token": consent_token})
 
 		method = "banking_admin.api.fetch_consent_accounts"
 		return requests.post(
-			url=self.url + method,
-			headers=self.headers,
-			data=json.dumps(data)
+			url=self.url + method, headers=self.headers, data=json.dumps(data)
 		)
 
 	def consent_transactions(
@@ -124,31 +100,29 @@ class AdminRequest():
 		consent_id: str,
 		consent_token: str,
 		url: Optional[str] = None,
-		offset: Optional[str] = None
+		offset: Optional[str] = None,
 	):
 		data = self.data
-		data.update({
-			"account_id": account_id,
-			"start_date": start_date,
-			"consent_id": consent_id,
-			"consent_token": consent_token,
-			"url": url,
-			"offset": offset
-		})
+		data.update(
+			{
+				"account_id": account_id,
+				"start_date": start_date,
+				"consent_id": consent_id,
+				"consent_token": consent_token,
+				"url": url,
+				"offset": offset,
+			}
+		)
 
 		method = "banking_admin.api.fetch_consent_transactions"
 		return requests.post(
-			url=self.url + method,
-			headers=self.headers,
-			data=json.dumps(data)
+			url=self.url + method, headers=self.headers, data=json.dumps(data)
 		)
 
 	def fetch_subscription(self):
 		method = "banking_admin.api.fetch_subscription_details"
 		return requests.post(
-			url=self.url + method,
-			headers=self.headers,
-			data=json.dumps(self.data)
+			url=self.url + method, headers=self.headers, data=json.dumps(self.data)
 		)
 
 	def get_customer_portal(self):

--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js
@@ -203,7 +203,7 @@ frappe.ui.form.on('Banking Settings', {
 							target="_blank"
 							class="${subscription.billing_portal ? "" : "hidden"}"
 						>
-							<b>${__("Open Billing Portal")}</b> 
+							<b>${__("Open Billing Portal")}</b>
 							${frappe.utils.icon("link-url", "sm")}
 						</a>
 					</p>
@@ -246,6 +246,7 @@ class KlarnaKosmaConnect {
 				account: this.account || null,
 				from_date: this.flow === "accounts" ? this.start_date : this.from_date,
 				to_date: this.to_date,
+				company: this.company || null,
 			},
 			freeze: true,
 			freeze_message: __("Please wait. Redirecting to Bank...")

--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
@@ -30,11 +30,12 @@ def get_client_token(
 	account: Optional[str] = None,
 	from_date: Optional[str] = None,
 	to_date: Optional[str] = None,
+	company: Optional[str] = None,
 ) -> Dict:
 	"""
 	Returns Client Token to render XS2A App & Short Session ID to track session
 	"""
-	return Admin().get_client_token(current_flow, account, from_date, to_date)
+	return Admin().get_client_token(current_flow, account, from_date, to_date, company)
 
 
 @frappe.whitelist()
@@ -121,7 +122,7 @@ def sync_all_accounts_and_transactions():
 			if not frappe.db.exists("Bank Account", bank_account_name):
 				continue
 
-			update_account(account, bank_account_name) # update account kosma id
+			update_account(account, bank_account_name)  # update account kosma id
 
 			# list of legitimate bank account names
 			accounts_list.append(bank_account_name)

--- a/banking/klarna_kosma_integration/utils.py
+++ b/banking/klarna_kosma_integration/utils.py
@@ -368,3 +368,17 @@ def set_session_state(session_id_short: str, result: str = None):
 			"status": result.get("session_state", "Running"),
 		},
 	)
+
+
+def get_country_code(company: Optional[str] = None):
+	"""
+	Get Country Code from Company or Bank Account.
+	"""
+	if not company:
+		return None
+
+	country = frappe.db.get_value("Company", company, "country")
+	if country == "Malta":
+		return "ML"
+
+	return frappe.db.get_value("Country", country, "code").upper()

--- a/banking/klarna_kosma_integration/utils.py
+++ b/banking/klarna_kosma_integration/utils.py
@@ -20,6 +20,38 @@ from frappe.utils import (
 if TYPE_CHECKING:
 	from frappe.model.document import Document
 
+# Ref: https://docs.openbanking.klarna.com/countries.html
+# Some countries are modified to match the country names in ERPNext (eg. GB -> UK)
+SUPPORTED_COUNTRIES = [
+	"Austria",
+	"Belgium",
+	"Switzerland",
+	"Czech Republic",
+	"Germany",
+	"Denmark",
+	"Estonia",
+	"Spain",
+	"Finland",
+	"France",
+	"United Kingdom",
+	"Croatia",
+	"Hungary",
+	"Ireland",
+	"Italy",
+	"Lithuania",
+	"Luxembourg",
+	"Latvia",
+	"Malta",
+	"Mexico",
+	"Netherlands",
+	"Norway",
+	"Portugal",
+	"Poland",
+	"Sweden",
+	"Slovakia",
+	"United States",
+]
+
 
 def needs_consent(bank: str, company: str) -> bool:
 	"""Returns False if there is atleast 1 hour before consent expires."""
@@ -378,7 +410,11 @@ def get_country_code(company: Optional[str] = None):
 		return None
 
 	country = frappe.db.get_value("Company", company, "country")
+
+	if country not in SUPPORTED_COUNTRIES:
+		return None
+
 	if country == "Malta":
-		return "ML"
+		return "ML"  # Kosma uses ML for Malta, ERPNext uses MT
 
 	return frappe.db.get_value("Country", country, "code").upper()


### PR DESCRIPTION
Depends on https://github.com/alyf-de/banking-admin/pull/28

The country of the selected company will be preselected in the Kosma popup:
![2023-11-03 14 03 24](https://github.com/alyf-de/banking/assets/25857446/92f17d91-cb04-468f-a6ea-22dfab549f3c)

If the country is not supported (eg. An indian company is chosen), it will default to no preselection. Kosma decides the default:
<img width="1326" alt="Screenshot 2023-11-06 at 10 58 17 AM" src="https://github.com/alyf-de/banking/assets/25857446/b20c5928-1cbf-49e1-85d7-082088004d23">



**What's done**:
- Pass 'company' from `banking_settings.js` to the API that calls to banking admin
- Pre-commit formatting