### PR TITLE
fix: amount allocation with space issue

### DIFF
--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -483,6 +483,6 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 
 	get_amount_from_row(row) {
 		let value = row[5].content;
-		return flt(value.split(" ") ? value.split(" ")[1] : 0);
+		return flt(value.split(" ") ? value.split(" ").slice(1).join("") : 0);
 	}
 }


### PR DESCRIPTION
Issue in Amount Allocation - 
For currencies with format which have spaces after thousand, Current Split was getting only the first character as amount , not the whole amount.
https://drive.google.com/file/d/1RBiGxycgobSdzTL2MGHvARDlVcInOKWM/view?usp=sharing


Solution - 
Updated Split Function which gets the complete amount.
https://drive.google.com/file/d/1cSg5DM1wRfU9IPdDEVwtC0GURx1EXBNC/view?usp=sharing

