### PR TITLE
fix: freeze during auto reconcile

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -64,7 +64,7 @@ frappe.ui.form.on('Bank Reconciliation Tool Beta', {
 							to_reference_date: frm.doc.to_reference_date,
 						},
 						freeze: true,
-						freeze_message: "Auto Reconciling ...",
+						freeze_message: __("Auto Reconciling ..."),
 						callback: (r) => {
 							if (!r.exc) {
 								frm.refresh();

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -63,6 +63,8 @@ frappe.ui.form.on('Bank Reconciliation Tool Beta', {
 							from_reference_date: frm.doc.from_reference_date,
 							to_reference_date: frm.doc.to_reference_date,
 						},
+						freeze: true,
+						freeze_message: "Auto Reconciling ...",
 						callback: (r) => {
 							if (!r.exc) {
 								frm.refresh();


### PR DESCRIPTION
When users click on "Auto Reconcile," they often don't wait for the feedback. Also, when they choose long date range filters, the process takes time, and they tend to click the "Auto Reconcile" button multiple times, missing the final feedback. This can create the impression that the auto reconcile tool isn't working properly. To enhance the user experience, I suggest freezing the screen with a message like "Auto Reconciling" to indicate that the tool is in progress. Thanks!