### PR TITLE
fix: Broken EC Reconciliation (frontport #100)

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -8,7 +8,7 @@ sudo apt update && sudo apt install redis-server libcups2-dev
 
 pip install frappe-bench
 
-git clone https://github.com/frappe/frappe --branch version-14 --depth 1
+git clone https://github.com/frappe/frappe --branch version-15 --depth 1
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
 mysql --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
@@ -27,9 +27,9 @@ sed -i 's/schedule:/# schedule:/g' Procfile
 sed -i 's/socketio:/# socketio:/g' Procfile
 sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
 
-bench get-app payments --branch version-14
-bench get-app erpnext --branch version-14
-bench get-app hrms --branch version-14
+bench get-app payments --branch version-15
+bench get-app erpnext --branch version-15
+bench get-app hrms --branch version-15
 bench get-app banking "${GITHUB_WORKSPACE}"
 
 bench start &> bench_run_logs.txt &

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -29,9 +29,11 @@ sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
 
 bench get-app payments --branch version-14
 bench get-app erpnext --branch version-14
+bench get-app hrms --branch version-14
 bench get-app banking "${GITHUB_WORKSPACE}"
 
 bench start &> bench_run_logs.txt &
 bench new-site --db-root-password root --admin-password admin test_site --install-app erpnext
+bench --site test_site install-app hrms
 bench --site test_site install-app banking
 bench setup requirements --dev

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, ALYF GmbH and contributors
 # For license information, please see license.txt
 import json
+import datetime
 from typing import Union
 
 import frappe
@@ -71,8 +72,8 @@ def get_bank_transactions(
 def create_journal_entry_bts(
 	bank_transaction_name: str,
 	reference_number: str = None,
-	reference_date: str = None,
-	posting_date: str = None,
+	reference_date: str | datetime.date = None,
+	posting_date: str | datetime.date = None,
 	entry_type: str = None,
 	second_account: str = None,
 	mode_of_payment: str = None,

--- a/banking/klarna_kosma_integration/test_kosma.py
+++ b/banking/klarna_kosma_integration/test_kosma.py
@@ -186,7 +186,7 @@ class TestKosma(FrappeTestCase):
 		self.assertEqual(get_count("Bank Transaction"), 17)
 		self.assertEqual(test_transn_doc.withdrawal, 3242.29)
 		self.assertEqual(test_transn_doc.deposit, 0.0)
-		self.assertEqual(test_transn_doc.status, "Settled")
+		self.assertEqual(test_transn_doc.status, "Unreconciled")
 		self.assertEqual(test_transn_doc.date, getdate("2022-12-03"))
 		self.assertEqual(test_transn_doc.bank_party_name, "Hans Mustermann")
 		self.assertEqual(test_transn_doc.bank_party_iban, "DE18000000006636981175")

--- a/banking/klarna_kosma_integration/utils.py
+++ b/banking/klarna_kosma_integration/utils.py
@@ -262,13 +262,6 @@ def new_bank_transaction(account: str, transaction: Dict) -> bool:
 	debit = 0 if is_credit else float(amount)
 	credit = float(amount) if is_credit else 0
 
-	state_map = {
-		"PROCESSED": "Settled",
-		"PENDING": "Pending",
-		"CANCELED": "Settled",  # TODO: is this status ok ? Should we even consider making cancelled/failed records
-		"FAILED": "Settled",
-	}
-	status = state_map[transaction.get("state")]
 	transaction_id = transaction.get("transaction_id")
 
 	if not transaction_id and transaction.get("state") == "PENDING":
@@ -283,7 +276,6 @@ def new_bank_transaction(account: str, transaction: Dict) -> bool:
 		{
 			"doctype": "Bank Transaction",
 			"date": getdate(transaction.get("value_date") or transaction.get("date")),
-			"status": status,
 			"bank_account": account,
 			"deposit": credit,
 			"withdrawal": debit,

--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -126,6 +126,7 @@ class CustomBankTransaction(BankTransaction):
 			)
 		payment_entry.posting_date = self.date
 		payment_entry.reference_no = self.reference_number or first_invoice[DOCNAME]
+		payment_entry.reference_date = self.date
 
 		# clear references to allocate invoices correctly with splits
 		payment_entry.references = []
@@ -154,14 +155,18 @@ class CustomBankTransaction(BankTransaction):
 	def prepare_invoices_to_split(self, invoices):
 		invoices_to_split = []
 		for invoice in invoices:
+			is_expense_claim = invoice[DOCTYPE] == "Expense Claim"
+			total_field = "grand_total" if is_expense_claim else "base_grand_total"
+			due_date_field = "posting_date" if is_expense_claim else "due_date"
+
 			invoice_data = frappe.db.get_value(
 				invoice[DOCTYPE],
 				invoice[DOCNAME],
 				[
 					"name as voucher_no",
 					"posting_date",
-					"base_grand_total as invoice_amount",
-					"due_date",
+					f"{total_field} as invoice_amount",
+					f"{due_date_field} as due_date",
 				],
 				as_dict=True,
 			)
@@ -172,6 +177,7 @@ class CustomBankTransaction(BankTransaction):
 		return invoices_to_split
 
 	def validate_invoices_to_bill(self, invoices_to_bill):
+		"""Validate if the invoices are of the same doctype and party."""
 		unique_doctypes = {invoice[DOCTYPE] for invoice in invoices_to_bill}
 		if len(unique_doctypes) > 1:
 			frappe.throw(


### PR DESCRIPTION
Port of https://github.com/alyf-de/banking/pull/100

- The fields fetched in `get_value` did not exist in Expense Claim
- Provision to dynamically decide what the field should be