### PR TITLE
fix: Change field name in Period Closing as changed in ERPNext

### DIFF
--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -44,8 +44,8 @@ class CustomBankTransaction(BankTransaction):
 		latest_period_close_date = frappe.db.get_value(
 			"Period Closing Voucher",
 			{"company": self.company, "docstatus": 1},
-			"posting_date",
-			order_by="posting_date desc",
+			"period_end_date",
+			order_by="period_end_date desc",
 		)
 		if latest_period_close_date and getdate(self.date) <= getdate(
 			latest_period_close_date


### PR DESCRIPTION
- CI breaks following https://github.com/frappe/erpnext/pull/43798 due to field name changes in Period Closing Voucher
- Use `period_end_date` instead of obsolete `posting_date`
-  Works as before
    <img width="700" alt="Screenshot 2024-10-31 at 1 11 14 PM" src="https://github.com/user-attachments/assets/04893f09-42f3-4221-89ad-dc46e9eff725">


> [!WARNING]
> Do not Backport