### PR TITLE
fix: include description match in rank

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -970,12 +970,9 @@ def get_si_matching_query(
 	date_condition = si.posting_date == common_filters.date
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
-	description_condition = (
-		Instr(common_filters.description, RegExpReplace(si.name, r"^[^0-9]*", "")) > 0
-		if common_filters.description
-		else False
+	description_match = get_description_match_condition(
+		common_filters.description, si.name
 	)
-	description_match = frappe.qb.terms.Case().when(description_condition, 1).else_(0)
 
 	rank_expression = party_rank + amount_rank + date_rank + description_match + 1
 
@@ -1030,13 +1027,9 @@ def get_unpaid_si_matching_query(
 		sales_invoice.outstanding_amount == common_filters.amount
 	)
 	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
-	description_condition = (
-		Instr(common_filters.description, RegExpReplace(sales_invoice.name, r"^[^0-9]*", ""))
-		> 0
-		if common_filters.description
-		else False
+	description_match = get_description_match_condition(
+		common_filters.description, sales_invoice.name
 	)
-	description_match = frappe.qb.terms.Case().when(description_condition, 1).else_(0)
 	rank_expression = party_match + amount_match + description_match + 1
 
 	query = (
@@ -1099,15 +1092,9 @@ def get_pi_matching_query(
 	)
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
-	description_condition = (
-		Instr(
-			common_filters.description, RegExpReplace(purchase_invoice.name, r"^[^0-9]*", "")
-		)
-		> 0
-		if common_filters.description
-		else False
+	description_match = get_description_match_condition(
+		common_filters.description, purchase_invoice.name
 	)
-	description_match = frappe.qb.terms.Case().when(description_condition, 1).else_(0)
 
 	rank_expression = party_rank + amount_rank + date_rank + description_match + 1
 
@@ -1162,15 +1149,9 @@ def get_unpaid_pi_matching_query(
 		purchase_invoice.outstanding_amount == common_filters.amount
 	)
 	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
-	description_condition = (
-		Instr(
-			common_filters.description, RegExpReplace(purchase_invoice.name, r"^[^0-9]*", "")
-		)
-		> 0
-		if common_filters.description
-		else False
+	description_match = get_description_match_condition(
+		common_filters.description, purchase_invoice.name
 	)
-	description_match = frappe.qb.terms.Case().when(description_condition, 1).else_(0)
 	rank_expression = party_match + amount_match + description_match + 1
 
 	# We skip date rank as the date of an unpaid bill is mostly
@@ -1235,13 +1216,9 @@ def get_unpaid_ec_matching_query(
 	)
 	outstanding_amount_condition = outstanding_amount == common_filters.amount
 	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
-	description_condition = (
-		Instr(common_filters.description, RegExpReplace(expense_claim.name, r"^[^0-9]*", ""))
-		> 0
-		if common_filters.description
-		else False
+	description_match = get_description_match_condition(
+		common_filters.description, expense_claim.name
 	)
-	description_match = frappe.qb.terms.Case().when(description_condition, 1).else_(0)
 
 	rank_expression = party_match + amount_match + description_match + 1
 
@@ -1305,3 +1282,28 @@ def get_invoice_function_map(document_types: list, is_deposit: bool):
 		for doctype in order
 		if (doctype in document_types and fn_map[doctype])
 	}
+
+
+def get_description_match_condition(description: str, name_column):
+	"""Get the description match condition for a document name.
+
+	Args:
+	    description: The bank transaction description to search in
+	    name_column: The document name column to match against (e.g., expense_claim.name)
+
+	Returns:
+	    A query condition that will be 1 if the description contains the document number
+	    and 0 otherwise.
+	"""
+	return (
+		frappe.qb.terms.Case()
+		.when(
+			(
+				Instr(description, RegExpReplace(name_column, r"^[^0-9]*", "")) > 0
+				if description
+				else False
+			),
+			1,
+		)
+		.else_(0)
+	)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -666,11 +666,12 @@ def get_bt_matching_query(
 	)
 	party_rank = frappe.qb.terms.Case().when(party_condition, 1).else_(0)
 	amount_condition = amount_equality if exact_match else getattr(bt, field) > 0.0
+	rank_expression = ref_rank + amount_rank + party_rank + unallocated_rank + 1
 
 	query = (
 		frappe.qb.from_(bt)
 		.select(
-			(ref_rank + amount_rank + party_rank + unallocated_rank + 1).as_("rank"),
+			rank_expression.as_("rank"),
 			ConstantColumn("Bank Transaction").as_("doctype"),
 			bt.name,
 			bt.unallocated_amount.as_("paid_amount"),
@@ -690,6 +691,7 @@ def get_bt_matching_query(
 		.where(bt.bank_account == common_filters.bank_account)
 		.where(amount_condition)
 		.where(bt.docstatus == 1)
+		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
@@ -716,10 +718,12 @@ def get_ld_matching_query(exact_match: bool, common_filters: frappe._dict):
 	reference_rank = frappe.qb.terms.Case().when(matching_reference, 1).else_(0)
 	party_rank = frappe.qb.terms.Case().when(matching_party, 1).else_(0)
 
+	rank_expression = reference_rank + party_rank + date_rank + 1
+
 	query = (
 		frappe.qb.from_(loan_disbursement)
 		.select(
-			(reference_rank + party_rank + date_rank + 1).as_("rank"),
+			rank_expression.as_("rank"),
 			ConstantColumn("Loan Disbursement").as_("doctype"),
 			loan_disbursement.name,
 			loan_disbursement.disbursed_amount.as_("paid_amount"),
@@ -736,6 +740,7 @@ def get_ld_matching_query(exact_match: bool, common_filters: frappe._dict):
 		.where(loan_disbursement.docstatus == 1)
 		.where(loan_disbursement.clearance_date.isnull())
 		.where(loan_disbursement.disbursement_account == common_filters.bank_account)
+		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
@@ -764,10 +769,12 @@ def get_lr_matching_query(exact_match: bool, common_filters: frappe._dict):
 	reference_rank = frappe.qb.terms.Case().when(matching_reference, 1).else_(0)
 	party_rank = frappe.qb.terms.Case().when(matching_party, 1).else_(0)
 
+	rank_expression = reference_rank + party_rank + date_rank + 1
+
 	query = (
 		frappe.qb.from_(loan_repayment)
 		.select(
-			(reference_rank + party_rank + date_rank + 1).as_("rank"),
+			rank_expression.as_("rank"),
 			ConstantColumn("Loan Repayment").as_("doctype"),
 			loan_repayment.name,
 			loan_repayment.amount_paid.as_("paid_amount"),
@@ -784,6 +791,7 @@ def get_lr_matching_query(exact_match: bool, common_filters: frappe._dict):
 		.where(loan_repayment.docstatus == 1)
 		.where(loan_repayment.clearance_date.isnull())
 		.where(loan_repayment.payment_account == common_filters.bank_account)
+		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -489,7 +489,7 @@ def check_matching(
 
 	if transaction.description:
 		for voucher in matching_vouchers:
-			if voucher.get("name_in_desc_match"):
+			if "name_in_desc_match" in voucher:
 				# already covered in DB query
 				continue
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1298,11 +1298,7 @@ def get_description_match_condition(description: str, name_column):
 	return (
 		frappe.qb.terms.Case()
 		.when(
-			(
-				Instr(description, RegExpReplace(name_column, r"^[^0-9]*", "")) > 0
-				if description
-				else False
-			),
+			Instr(description or "", RegExpReplace(name_column, r"^[^0-9]*", "")) > 0,
 			1,
 		)
 		.else_(0)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -21,6 +21,7 @@ from pypika import Order
 
 MAX_QUERY_RESULTS = 150
 Instr = CustomFunction("INSTR", ["a", "b"])
+RegExpReplace = CustomFunction("REGEXP_REPLACE", ["a", "b", "c"])
 
 
 class BankReconciliationToolBeta(Document):
@@ -970,7 +971,7 @@ def get_si_matching_query(
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
 	description_condition = (
-		Instr(common_filters.description, si.name) > 0
+		Instr(common_filters.description, RegExpReplace(si.name, r"^[^0-9]*", "")) > 0
 		if common_filters.description
 		else False
 	)
@@ -1030,7 +1031,8 @@ def get_unpaid_si_matching_query(
 	)
 	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
 	description_condition = (
-		Instr(common_filters.description, sales_invoice.name) > 0
+		Instr(common_filters.description, RegExpReplace(sales_invoice.name, r"^[^0-9]*", ""))
+		> 0
 		if common_filters.description
 		else False
 	)
@@ -1098,7 +1100,10 @@ def get_pi_matching_query(
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
 	description_condition = (
-		Instr(common_filters.description, purchase_invoice.name) > 0
+		Instr(
+			common_filters.description, RegExpReplace(purchase_invoice.name, r"^[^0-9]*", "")
+		)
+		> 0
 		if common_filters.description
 		else False
 	)
@@ -1158,7 +1163,10 @@ def get_unpaid_pi_matching_query(
 	)
 	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
 	description_condition = (
-		Instr(common_filters.description, purchase_invoice.name) > 0
+		Instr(
+			common_filters.description, RegExpReplace(purchase_invoice.name, r"^[^0-9]*", "")
+		)
+		> 0
 		if common_filters.description
 		else False
 	)
@@ -1228,7 +1236,8 @@ def get_unpaid_ec_matching_query(
 	outstanding_amount_condition = outstanding_amount == common_filters.amount
 	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
 	description_condition = (
-		Instr(common_filters.description, expense_claim.name) > 0
+		Instr(common_filters.description, RegExpReplace(expense_claim.name, r"^[^0-9]*", ""))
+		> 0
 		if common_filters.description
 		else False
 	)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -834,10 +834,12 @@ def get_pe_matching_query(
 	date_condition = Coalesce(pe.reference_date, pe.posting_date) == common_filters.date
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
+	rank_expression = ref_rank + amount_rank + party_rank + date_rank + 1
+
 	query = (
 		frappe.qb.from_(pe)
 		.select(
-			(ref_rank + amount_rank + party_rank + date_rank + 1).as_("rank"),
+			rank_expression.as_("rank"),
 			ConstantColumn("Payment Entry").as_("doctype"),
 			pe.name,
 			pe.paid_amount,
@@ -859,7 +861,7 @@ def get_pe_matching_query(
 		.where(getattr(pe, account_from_to) == common_filters.bank_account)
 		.where(amount_condition)
 		.where(filter_by_date)
-		.orderby(pe.reference_date if cint(filter_by_reference_date) else pe.posting_date)
+		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
@@ -902,12 +904,14 @@ def get_je_matching_query(
 	date_condition = Coalesce(je.cheque_date, je.posting_date) == common_filters.date
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
+	rank_expression = ref_rank + amount_rank + date_rank + 1
+
 	query = (
 		frappe.qb.from_(jea)
 		.join(je)
 		.on(jea.parent == je.name)
 		.select(
-			(ref_rank + amount_rank + date_rank + 1).as_("rank"),
+			rank_expression.as_("rank"),
 			ConstantColumn("Journal Entry").as_("doctype"),
 			je.name,
 			getattr(jea, amount_field).as_("paid_amount"),
@@ -928,7 +932,7 @@ def get_je_matching_query(
 		.where(amount_equality if exact_match else getattr(jea, amount_field) > 0.0)
 		.where(je.docstatus == 1)
 		.where(filter_by_date)
-		.orderby(je.cheque_date if cint(filter_by_reference_date) else je.posting_date)
+		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
-from frappe.query_builder.functions import Coalesce
+from frappe.query_builder.functions import Coalesce, CustomFunction
 from frappe.utils import cint, flt, sbool
 
 from erpnext import get_company_currency, get_default_cost_center
@@ -17,9 +17,10 @@ from erpnext.accounts.doctype.bank_transaction.bank_transaction import (
 	get_total_allocated_amount,
 )
 from erpnext.accounts.utils import get_account_currency
-
+from pypika import Order
 
 MAX_QUERY_RESULTS = 150
+Instr = CustomFunction("INSTR", ["a", "b"])
 
 
 class BankReconciliationToolBeta(Document):
@@ -488,6 +489,10 @@ def check_matching(
 
 	if transaction.description:
 		for voucher in matching_vouchers:
+			if voucher.get("name_in_desc_match"):
+				# already covered in DB query
+				continue
+
 			# higher rank if voucher name is in bank transaction
 			reference_no = voucher["reference_no"]
 			if reference_no and (reference_no.strip() in transaction.description):
@@ -560,6 +565,7 @@ def get_matching_queries(
 	is_deposit = transaction.deposit > 0.0
 
 	common_filters.exact_party_match = "exact_party_match" in (document_types or [])
+	common_filters.description = transaction.description
 
 	if "payment_entry" in document_types:
 		frappe.has_permission("Payment Entry", throw=True)
@@ -951,12 +957,21 @@ def get_si_matching_query(
 	date_condition = si.posting_date == common_filters.date
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
+	description_condition = (
+		Instr(common_filters.description, si.name) > 0
+		if common_filters.description
+		else False
+	)
+	description_match = frappe.qb.terms.Case().when(description_condition, 1).else_(0)
+
+	rank_expression = party_rank + amount_rank + date_rank + description_match + 1
+
 	query = (
 		frappe.qb.from_(sip)
 		.join(si)
 		.on(sip.parent == si.name)
 		.select(
-			(party_rank + amount_rank + date_rank + 1).as_("rank"),
+			rank_expression.as_("rank"),
 			ConstantColumn("Sales Invoice").as_("doctype"),
 			si.name,
 			sip.amount.as_("paid_amount"),
@@ -969,12 +984,14 @@ def get_si_matching_query(
 			party_rank.as_("party_match"),
 			amount_rank.as_("amount_match"),
 			date_rank.as_("date_match"),
+			description_match.as_("name_in_desc_match"),
 		)
 		.where(si.docstatus == 1)
 		.where(sip.clearance_date.isnull())
 		.where(sip.account == common_filters.bank_account)
 		.where(amount_condition)
 		.where(si.currency == currency)
+		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
@@ -1000,11 +1017,18 @@ def get_unpaid_si_matching_query(
 		sales_invoice.outstanding_amount == common_filters.amount
 	)
 	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
+	description_condition = (
+		Instr(common_filters.description, sales_invoice.name) > 0
+		if common_filters.description
+		else False
+	)
+	description_match = frappe.qb.terms.Case().when(description_condition, 1).else_(0)
+	rank_expression = party_match + amount_match + description_match + 1
 
 	query = (
 		frappe.qb.from_(sales_invoice)
 		.select(
-			(party_match + amount_match + 1).as_("rank"),
+			rank_expression.as_("rank"),
 			ConstantColumn("Sales Invoice").as_("doctype"),
 			sales_invoice.name.as_("name"),
 			sales_invoice.outstanding_amount.as_("paid_amount"),
@@ -1017,11 +1041,13 @@ def get_unpaid_si_matching_query(
 			sales_invoice.currency,
 			party_match.as_("party_match"),
 			amount_match.as_("amount_match"),
+			description_match.as_("name_in_desc_match"),
 		)
 		.where(sales_invoice.docstatus == 1)
 		.where(sales_invoice.company == company)  # because we do not have bank account check
 		.where(sales_invoice.outstanding_amount != 0.0)
 		.where(sales_invoice.currency == currency)
+		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
@@ -1059,10 +1085,19 @@ def get_pi_matching_query(
 	)
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
 
+	description_condition = (
+		Instr(common_filters.description, purchase_invoice.name) > 0
+		if common_filters.description
+		else False
+	)
+	description_match = frappe.qb.terms.Case().when(description_condition, 1).else_(0)
+
+	rank_expression = party_rank + amount_rank + date_rank + description_match + 1
+
 	query = (
 		frappe.qb.from_(purchase_invoice)
 		.select(
-			(party_rank + amount_rank + date_rank + 1).as_("rank"),
+			rank_expression.as_("rank"),
 			ConstantColumn("Purchase Invoice").as_("doctype"),
 			purchase_invoice.name,
 			purchase_invoice.paid_amount,
@@ -1076,6 +1111,7 @@ def get_pi_matching_query(
 			party_rank.as_("party_match"),
 			amount_rank.as_("amount_match"),
 			date_rank.as_("date_match"),
+			description_match.as_("name_in_desc_match"),
 		)
 		.where(purchase_invoice.docstatus == 1)
 		.where(purchase_invoice.is_paid == 1)
@@ -1083,6 +1119,7 @@ def get_pi_matching_query(
 		.where(purchase_invoice.cash_bank_account == common_filters.bank_account)
 		.where(amount_condition)
 		.where(purchase_invoice.currency == currency)
+		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
@@ -1108,13 +1145,20 @@ def get_unpaid_pi_matching_query(
 		purchase_invoice.outstanding_amount == common_filters.amount
 	)
 	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
+	description_condition = (
+		Instr(common_filters.description, purchase_invoice.name) > 0
+		if common_filters.description
+		else False
+	)
+	description_match = frappe.qb.terms.Case().when(description_condition, 1).else_(0)
+	rank_expression = party_match + amount_match + description_match + 1
 
 	# We skip date rank as the date of an unpaid bill is mostly
 	# earlier than the date of the bank transaction
 	query = (
 		frappe.qb.from_(purchase_invoice)
 		.select(
-			(party_match + amount_match + 1).as_("rank"),
+			rank_expression.as_("rank"),
 			ConstantColumn("Purchase Invoice").as_("doctype"),
 			purchase_invoice.name.as_("name"),
 			purchase_invoice.outstanding_amount.as_("paid_amount"),
@@ -1127,12 +1171,14 @@ def get_unpaid_pi_matching_query(
 			purchase_invoice.currency,
 			party_match.as_("party_match"),
 			amount_match.as_("amount_match"),
+			description_match.as_("name_in_desc_match"),
 		)
 		.where(purchase_invoice.docstatus == 1)
 		.where(purchase_invoice.company == company)
 		.where(purchase_invoice.outstanding_amount != 0.0)
 		.where(purchase_invoice.is_paid == 0)
 		.where(purchase_invoice.currency == currency)
+		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
@@ -1147,7 +1193,10 @@ def get_unpaid_pi_matching_query(
 
 
 def get_unpaid_ec_matching_query(
-	exact_match: bool, currency: str, common_filters: frappe._dict, company: str
+	exact_match: bool,
+	currency: str,
+	common_filters: frappe._dict,
+	company: str,
 ):
 	if currency != get_company_currency(company):
 		# Expense claims are always in company currency
@@ -1166,11 +1215,19 @@ def get_unpaid_ec_matching_query(
 	)
 	outstanding_amount_condition = outstanding_amount == common_filters.amount
 	amount_match = frappe.qb.terms.Case().when(outstanding_amount_condition, 1).else_(0)
+	description_condition = (
+		Instr(common_filters.description, expense_claim.name) > 0
+		if common_filters.description
+		else False
+	)
+	description_match = frappe.qb.terms.Case().when(description_condition, 1).else_(0)
+
+	rank_expression = party_match + amount_match + description_match + 1
 
 	query = (
 		frappe.qb.from_(expense_claim)
 		.select(
-			(party_match + amount_match + 1).as_("rank"),
+			rank_expression.as_("rank"),
 			ConstantColumn("Expense Claim").as_("doctype"),
 			expense_claim.name.as_("name"),
 			outstanding_amount.as_("paid_amount"),
@@ -1183,11 +1240,13 @@ def get_unpaid_ec_matching_query(
 			ConstantColumn(currency).as_("currency"),
 			party_match.as_("party_match"),
 			amount_match.as_("amount_match"),
+			description_match.as_("name_in_desc_match"),
 		)
 		.where(expense_claim.docstatus == 1)
 		.where(expense_claim.company == company)
 		.where(outstanding_amount > 0.0)
 		.where(expense_claim.status == "Unpaid")
+		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 


### PR DESCRIPTION
- `voucher_number in description` is now part of the queries and increases the rank
- Only match the voucher _number_, not the entire voucher name
    (`"9999" in description` instead of `"RE-9999" in description`)
- Order all query results by rank, so that top ranked results come first
