### PR TITLE
fix: Use `bill_no` instead of `name` as PI default Reference field

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -446,10 +446,9 @@ def subtract_allocations(gl_account, vouchers):
 	This does not affect "unpaid" vouchers (e.g. unpaid invoices) since they
 	are never directly allocated to a Bank Transaction.
 	"""
-	rows = get_total_allocated_amount([
-		(voucher.get("doctype"), voucher.get("name"))
-		for voucher in vouchers
-	])
+	rows = get_total_allocated_amount(
+		[(voucher.get("doctype"), voucher.get("name")) for voucher in vouchers]
+	)
 
 	if not rows:
 		return
@@ -1141,6 +1140,11 @@ def get_pi_matching_query(
 	"""
 	Get matching purchase invoice query when they are also used as payment entries (is_paid)
 	"""
+	# Default to bill_no instead of name.
+	# "name" is passed when it is unset. Handle specific default here.
+	if reference_field == "name" or not reference_field:
+		reference_field = "bill_no"
+
 	purchase_invoice = frappe.qb.DocType("Purchase Invoice")
 	description = common_filters.description
 
@@ -1192,7 +1196,7 @@ def get_pi_matching_query(
 			ConstantColumn("Purchase Invoice").as_("doctype"),
 			purchase_invoice.name,
 			purchase_invoice.paid_amount,
-			purchase_invoice[reference_field or "bill_no"].as_("reference_no"),
+			purchase_invoice[reference_field].as_("reference_no"),
 			purchase_invoice.bill_date.as_("reference_date"),
 			purchase_invoice.supplier.as_("party"),
 			ConstantColumn("Supplier").as_("party_type"),
@@ -1230,6 +1234,11 @@ def get_unpaid_pi_matching_query(
 	include_only_returns: bool = False,
 	reference_field: str = "name",
 ):
+	# Default to bill_no instead of name.
+	# "name" is passed when it is unset. Handle specific default here.
+	if reference_field == "name" or not reference_field:
+		reference_field = "bill_no"
+
 	purchase_invoice = frappe.qb.DocType("Purchase Invoice")
 	description = common_filters.description
 
@@ -1269,7 +1278,7 @@ def get_unpaid_pi_matching_query(
 			ConstantColumn("Purchase Invoice").as_("doctype"),
 			purchase_invoice.name.as_("name"),
 			purchase_invoice.outstanding_amount.as_("paid_amount"),
-			purchase_invoice[reference_field or "name"].as_("reference_no"),
+			purchase_invoice[reference_field].as_("reference_no"),
 			purchase_invoice.bill_date.as_("reference_date"),
 			purchase_invoice.supplier.as_("party"),
 			ConstantColumn("Supplier").as_("party_type"),


### PR DESCRIPTION
Closes https://github.com/alyf-de/banking/issues/146

This means that "name" can never be used as reference for a PI (since fallbacknis bill_no and name is not a settings option), but that's fine since we use `name` as we did not know what other field could work and name is already a column. Here we have certainty.

## Working
- Banking Settings has no config for PI
   <img width="700" alt="Screenshot 2025-01-06 at 9 19 00 PM" src="https://github.com/user-attachments/assets/f5934db7-c8c4-4335-ad97-bae3ebbee7d7" />
- `bill_no` in **Paid Purchase Invoice**
  <img width="700" alt="Screenshot 2025-01-06 at 9 15 33 PM" src="https://github.com/user-attachments/assets/fd1e288a-eeae-403f-a69a-2c13aa6184e4" />
- Reference in Tool for **Paid Voucher**
   <img width="700" alt="Screenshot 2025-01-06 at 9 15 48 PM" src="https://github.com/user-attachments/assets/6dfc42cc-d868-4867-b684-d02f6cbee105" />
- Reference in Tool for **Unpaid Voucher**
   <img width="700" alt="Screenshot 2025-01-06 at 9 21 40 PM" src="https://github.com/user-attachments/assets/8651743f-c1f8-412d-95f4-d8ffb3500b1d" />


