### PR TITLE
Fix: Missing company arg in get_account_balance fn

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -177,6 +177,7 @@ frappe.ui.form.on('Bank Reconciliation Tool Beta', {
 				args: {
 					bank_account: frm.doc.bank_account,
 					till_date: frm.doc.bank_statement_from_date,
+					company: frm.doc.company,
 				},
 				callback: (response) => {
 					frm.set_value("account_opening_balance", response.message);
@@ -193,6 +194,7 @@ frappe.ui.form.on('Bank Reconciliation Tool Beta', {
 				args: {
 					bank_account: frm.doc.bank_account,
 					till_date: frm.doc.bank_statement_to_date,
+					company: frm.doc.company,
 				},
 				callback: (response) => {
 					frm.cleared_balance = response.message;


### PR DESCRIPTION
Added the missing required "company" arg to the  get_account_balance() fn

Resolves #153 