### PR TITLE
fix: don't fetch C54 if batch splitting is disabled

### DIFF
--- a/banking/ebics/manager.py
+++ b/banking/ebics/manager.py
@@ -114,20 +114,22 @@ class EBICSManager:
 		return level_perms
 
 	def download_bank_statements(
-		self, start_date: str | None = None, end_date: str | None = None
+		self,
+		start_date: str | None = None,
+		end_date: str | None = None,
+		with_c54: bool = False,
 	) -> "Iterator[CAMTDocument]":
 		"""Yield an iterator over CAMTDocument objects for the given date range."""
 		from fintech.sepa import CAMTDocument
 
 		client = self.get_client()
-		permitted_types = self.get_permitted_order_types()
 
 		try:
 			camt53 = client.C53(start_date, end_date)
 		except fintech.ebics.EbicsNoDataAvailable:
 			return
 
-		camt54 = client.C54(start_date, end_date) if "C54" in permitted_types else None
+		camt54 = client.C54(start_date, end_date) if with_c54 else None
 
 		for name in sorted(camt53):
 			yield CAMTDocument(xml=camt53[name], camt54=camt54)

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -90,11 +90,25 @@ def sync_ebics_transactions(
 			reference_name=ebics_user,
 		)
 
+	if not intraday and user.split_batch_transactions and "C54" not in permitted_types:
+		frappe.log_error(
+			title=_("Banking Error"),
+			message=_(
+				"EBICS User {0} lacks permission 'C54' for splitting batch transactions. The permitted types are: {1}."
+			).format(ebics_user, ", ".join(permitted_types)),
+			reference_doctype="EBICS User",
+			reference_name=ebics_user,
+		)
+
 	try:
 		camt_documents = (
 			manager.download_intraday_transactions()
 			if intraday
-			else manager.download_bank_statements(start_date, end_date)
+			else manager.download_bank_statements(
+				start_date,
+				end_date,
+				with_c54=user.split_batch_transactions and "C54" in permitted_types,
+			)
 		)
 	except Exception:
 		frappe.log_error(


### PR DESCRIPTION
Apparently the bank can sometimes tell us that C54 is enabled, but still return an error when we try to fetch it (they can configure it separately for EBICS User and Bank Account). Now the user is in control to enable or disable fetching of C54.