### PR TITLE
refactor(Bank Reconciliation Tool): tab creation

### DIFF
--- a/banking/locale/de.po
+++ b/banking/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-01-31 19:26+0053\n"
+"POT-Creation-Date: 2025-01-31 20:31+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -141,11 +141,11 @@ msgstr "Bankabgleich Beta"
 msgid "Bank Transaction"
 msgstr "Banktransaktion"
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:106
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:122
 msgid "Bank Transaction {0} Matched"
 msgstr "Banktransaktion {0} abgeglichen"
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:98
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:114
 msgid "Bank Transaction {0} Partially {1}"
 msgstr "Banktransaktion {0} teilweise abgeglichen"
 
@@ -153,7 +153,7 @@ msgstr "Banktransaktion {0} teilweise abgeglichen"
 msgid "Bank Transaction {0} is already fully reconciled"
 msgstr "Banktransaktion {0} ist bereits vollständig abgeglichen"
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:108
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:124
 msgid "Bank Transaction {0} reconciled with a new {1}"
 msgstr "Banktransaktion {0} mit einem neuen {1} abgeglichen"
 
@@ -258,6 +258,10 @@ msgstr "Land"
 msgid "Create"
 msgstr "Erstellen"
 
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:70
+msgid "Create Voucher"
+msgstr "Beleg erstellen"
+
 #. Label of a Section Break field in DocType 'EBICS User'
 #: banking/ebics/doctype/ebics_user/ebics_user.json
 msgid "Credentials"
@@ -286,6 +290,10 @@ msgstr "Einzahlung"
 #: banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js:98
 msgid "Description"
 msgstr "Beschreibung"
+
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:47
+msgid "Details"
+msgstr "Details"
 
 #. Label of a Select field in DocType 'Banking Reference Mapping'
 #: banking/klarna_kosma_integration/doctype/banking_reference_mapping/banking_reference_mapping.json
@@ -558,6 +566,10 @@ msgstr ""
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:341
 msgid "Loan Repayment"
 msgstr ""
+
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:58
+msgid "Match Voucher"
+msgstr "Beleg abgleichen"
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:192
 msgid "Mode of Payment"

--- a/banking/locale/es.po
+++ b/banking/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-01-31 19:26+0053\n"
+"POT-Creation-Date: 2025-01-31 20:31+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -141,11 +141,11 @@ msgstr ""
 msgid "Bank Transaction"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:106
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:122
 msgid "Bank Transaction {0} Matched"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:98
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:114
 msgid "Bank Transaction {0} Partially {1}"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "Bank Transaction {0} is already fully reconciled"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:108
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:124
 msgid "Bank Transaction {0} reconciled with a new {1}"
 msgstr ""
 
@@ -258,6 +258,10 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:70
+msgid "Create Voucher"
+msgstr ""
+
 #. Label of a Section Break field in DocType 'EBICS User'
 #: banking/ebics/doctype/ebics_user/ebics_user.json
 msgid "Credentials"
@@ -285,6 +289,10 @@ msgstr "Depósito"
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js:98
 msgid "Description"
+msgstr ""
+
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:47
+msgid "Details"
 msgstr ""
 
 #. Label of a Select field in DocType 'Banking Reference Mapping'
@@ -557,6 +565,10 @@ msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:341
 msgid "Loan Repayment"
+msgstr ""
+
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:58
+msgid "Match Voucher"
 msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:192

--- a/banking/locale/fr.po
+++ b/banking/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-01-31 19:26+0053\n"
+"POT-Creation-Date: 2025-01-31 20:31+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -141,11 +141,11 @@ msgstr ""
 msgid "Bank Transaction"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:106
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:122
 msgid "Bank Transaction {0} Matched"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:98
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:114
 msgid "Bank Transaction {0} Partially {1}"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "Bank Transaction {0} is already fully reconciled"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:108
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:124
 msgid "Bank Transaction {0} reconciled with a new {1}"
 msgstr ""
 
@@ -258,6 +258,10 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:70
+msgid "Create Voucher"
+msgstr ""
+
 #. Label of a Section Break field in DocType 'EBICS User'
 #: banking/ebics/doctype/ebics_user/ebics_user.json
 msgid "Credentials"
@@ -285,6 +289,10 @@ msgstr "Dépôt"
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js:98
 msgid "Description"
+msgstr ""
+
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:47
+msgid "Details"
 msgstr ""
 
 #. Label of a Select field in DocType 'Banking Reference Mapping'
@@ -557,6 +565,10 @@ msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:341
 msgid "Loan Repayment"
+msgstr ""
+
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:58
+msgid "Match Voucher"
 msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:192

--- a/banking/locale/it.po
+++ b/banking/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-01-31 19:26+0053\n"
+"POT-Creation-Date: 2025-01-31 20:31+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -141,11 +141,11 @@ msgstr ""
 msgid "Bank Transaction"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:106
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:122
 msgid "Bank Transaction {0} Matched"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:98
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:114
 msgid "Bank Transaction {0} Partially {1}"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "Bank Transaction {0} is already fully reconciled"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:108
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:124
 msgid "Bank Transaction {0} reconciled with a new {1}"
 msgstr ""
 
@@ -258,6 +258,10 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:70
+msgid "Create Voucher"
+msgstr ""
+
 #. Label of a Section Break field in DocType 'EBICS User'
 #: banking/ebics/doctype/ebics_user/ebics_user.json
 msgid "Credentials"
@@ -285,6 +289,10 @@ msgstr "Deposito"
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js:98
 msgid "Description"
+msgstr ""
+
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:47
+msgid "Details"
 msgstr ""
 
 #. Label of a Select field in DocType 'Banking Reference Mapping'
@@ -557,6 +565,10 @@ msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:341
 msgid "Loan Repayment"
+msgstr ""
+
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:58
+msgid "Match Voucher"
 msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:192

--- a/banking/locale/main.pot
+++ b/banking/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-01-31 19:26+0053\n"
-"PO-Revision-Date: 2025-01-31 19:26+0053\n"
+"POT-Creation-Date: 2025-01-31 20:31+0053\n"
+"PO-Revision-Date: 2025-01-31 20:31+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -141,11 +141,11 @@ msgstr ""
 msgid "Bank Transaction"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:106
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:122
 msgid "Bank Transaction {0} Matched"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:98
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:114
 msgid "Bank Transaction {0} Partially {1}"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "Bank Transaction {0} is already fully reconciled"
 msgstr ""
 
-#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:108
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:124
 msgid "Bank Transaction {0} reconciled with a new {1}"
 msgstr ""
 
@@ -258,6 +258,10 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:70
+msgid "Create Voucher"
+msgstr ""
+
 #. Label of a Section Break field in DocType 'EBICS User'
 #: banking/ebics/doctype/ebics_user/ebics_user.json
 msgid "Credentials"
@@ -285,6 +289,10 @@ msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js:98
 msgid "Description"
+msgstr ""
+
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:47
+msgid "Details"
 msgstr ""
 
 #. Label of a Select field in DocType 'Banking Reference Mapping'
@@ -557,6 +565,10 @@ msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:341
 msgid "Loan Repayment"
+msgstr ""
+
+#: banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js:58
+msgid "Match Voucher"
 msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:192

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
@@ -41,47 +41,63 @@ erpnext.accounts.bank_reconciliation.ActionsPanelManager = class ActionsPanelMan
 		// Remove any listeners from previous tabs
 		frappe.realtime.off("doc_update");
 
-		["Details", "Match Voucher", "Create Voucher"].forEach(tab => {
-			let tab_name = frappe.scrub(tab);
-			this.add_tab(tab_name, tab);
-
-			let $tab_link = this.tabs_list_ul.find(`#${tab_name}-tab`);
-			$tab_link.on("click", () => {
-				this.$tab_content.empty();
-
-				if (tab == "Details") {
-					new erpnext.accounts.bank_reconciliation.DetailsTab({
+		const tabs = [
+			{
+				tab_name: "details",
+				tab_label: __("Details"),
+				make_tab: () => {
+					return new erpnext.accounts.bank_reconciliation.DetailsTab({
 						actions_panel: this,
 						transaction: this.transaction,
 						panel_manager: this.panel_manager,
 					});
-				} else if (tab == "Match Voucher") {
-					new erpnext.accounts.bank_reconciliation.MatchTab({
+				}
+			},
+			{
+				tab_name: "match_voucher",
+				tab_label: __("Match Voucher"),
+				make_tab: () => {
+					return new erpnext.accounts.bank_reconciliation.MatchTab({
 						actions_panel: this,
 						transaction: this.transaction,
 						panel_manager: this.panel_manager,
 						doc: this.doc,
 					});
-				} else {
-					new erpnext.accounts.bank_reconciliation.CreateTab({
+				}
+			},
+			{
+				tab_name: "create_voucher",
+				tab_label: __("Create Voucher"),
+				make_tab: () => {
+					return new erpnext.accounts.bank_reconciliation.CreateTab({
 						actions_panel: this,
 						transaction: this.transaction,
 						panel_manager: this.panel_manager,
 						company: this.doc.company,
 					});
 				}
+			}
+		];
+
+		for (const {tab_name, tab_label, make_tab} of tabs) {
+			this.add_tab(tab_name, tab_label);
+
+			let $tab_link = this.tabs_list_ul.find(`#${tab_name}-tab`);
+			$tab_link.on("click", () => {
+				this.$tab_content.empty();
+				make_tab();
 			});
-		});
+		}
 	}
 
-	add_tab(tab_name, tab) {
+	add_tab(tab_name, tab_label) {
 		this.tabs_list_ul.append(`
 			<li class="nav-item">
 				<a class="nav-actions-link"
 					id="${tab_name}-tab" data-toggle="tab"
-					href="#" role="tab" aria-controls="${tab}"
+					href="#" role="tab" aria-controls="${tab_name}"
 				>
-					${__(tab)}
+					${tab_label}
 				</a>
 			</li>
 		`);


### PR DESCRIPTION
Issue: tab labels were not getting extracted as translatable strings, hence lost translations while migrating to `.po` files.

Fix:

- Refactored tab creation in the **Bank Reconciliation Tool**, improving translatability and making the code more declarative.
- Updated translation files accordingly
