### PR TITLE
feat: log ebics requests

### DIFF
--- a/banking/ebics/doctype/ebics_request/ebics_request.js
+++ b/banking/ebics/doctype/ebics_request/ebics_request.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, ALYF GmbH and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('EBICS Request', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/banking/ebics/doctype/ebics_request/ebics_request.json
+++ b/banking/ebics/doctype/ebics_request/ebics_request.json
@@ -1,0 +1,72 @@
+{
+ "actions": [],
+ "creation": "2025-03-12 17:57:07.347730",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "ebics_user",
+  "order_type",
+  "requested_by",
+  "parameters",
+  "status",
+  "response"
+ ],
+ "fields": [
+  {
+   "fieldname": "ebics_user",
+   "fieldtype": "Link",
+   "label": "EBICS User",
+   "options": "EBICS User"
+  },
+  {
+   "fieldname": "order_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Order Type"
+  },
+  {
+   "fieldname": "requested_by",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Requested By",
+   "options": "System\nUser"
+  },
+  {
+   "fieldname": "parameters",
+   "fieldtype": "Code",
+   "label": "Parameters"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Successful\nNo Data Available\nFailed"
+  },
+  {
+   "fieldname": "response",
+   "fieldtype": "Code",
+   "label": "Response"
+  }
+ ],
+ "in_create": 1,
+ "links": [],
+ "modified": "2025-03-12 19:06:17.168084",
+ "modified_by": "Administrator",
+ "module": "EBICS",
+ "name": "EBICS Request",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "export": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager"
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/banking/ebics/doctype/ebics_request/ebics_request.py
+++ b/banking/ebics/doctype/ebics_request/ebics_request.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class EBICSRequest(Document):
+	pass

--- a/banking/ebics/doctype/ebics_request/test_ebics_request.py
+++ b/banking/ebics/doctype/ebics_request/test_ebics_request.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, ALYF GmbH and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestEBICSRequest(FrappeTestCase):
+	pass

--- a/banking/ebics/doctype/ebics_user/ebics_user.json
+++ b/banking/ebics/doctype/ebics_user/ebics_user.json
@@ -137,8 +137,13 @@
    "label": "Split Batch Transactions"
   }
  ],
- "links": [],
- "modified": "2025-01-21 15:21:31.597353",
+ "links": [
+  {
+   "link_doctype": "EBICS Request",
+   "link_fieldname": "ebics_user"
+  }
+ ],
+ "modified": "2025-03-12 17:59:35.346499",
  "modified_by": "Administrator",
  "module": "EBICS",
  "name": "EBICS User",

--- a/banking/ebics/doctype/ebics_user/ebics_user.py
+++ b/banking/ebics/doctype/ebics_user/ebics_user.py
@@ -193,6 +193,7 @@ def download_bank_statements(
 
 	frappe.enqueue(
 		sync_ebics_transactions,
+		requested_by="User",
 		ebics_user=ebics_user,
 		start_date=from_date,
 		end_date=to_date,

--- a/banking/ebics/manager.py
+++ b/banking/ebics/manager.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import fintech
 
 if TYPE_CHECKING:
-	from typing import Callable, Iterator
+	from typing import Callable
 
 	from fintech.ebics import (
 		EbicsBank,
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 		EbicsKeyRing,
 		EbicsUser,
 	)
-	from fintech.sepa import CAMTDocument
 
 
 class EBICSManager:
@@ -114,42 +113,3 @@ class EBICSManager:
 					level_perms.extend(order_types.split())
 
 		return level_perms
-
-	def download_bank_statements(
-		self,
-		start_date: str | None = None,
-		end_date: str | None = None,
-		with_c54: bool = False,
-	) -> "Iterator[CAMTDocument]":
-		"""Yield an iterator over CAMTDocument objects for the given date range."""
-		from fintech.sepa import CAMTDocument
-
-		client = self.get_client()
-
-		try:
-			camt53 = client.C53(start_date, end_date)
-		except fintech.ebics.EbicsNoDataAvailable:
-			return
-
-		camt54 = client.C54(start_date, end_date) if with_c54 else None
-
-		for name in sorted(camt53):
-			yield CAMTDocument(xml=camt53[name], camt54=camt54)
-
-		client.confirm_download(success=True)
-
-	def download_intraday_transactions(self) -> "Iterator[CAMTDocument]":
-		"""Yield an iterator over CAMTDocument objects."""
-		from fintech.sepa import CAMTDocument
-
-		client = self.get_client()
-
-		try:
-			camt52 = client.C52()
-		except fintech.ebics.EbicsNoDataAvailable:
-			return
-
-		for name in sorted(camt52):
-			yield CAMTDocument(xml=camt52[name])
-
-		client.confirm_download(success=True)

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -1,6 +1,8 @@
 import contextlib
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, Literal
 
+import fintech
 import frappe
 from frappe import _
 from frappe.utils.data import get_link_to_form
@@ -59,6 +61,7 @@ def get_ebics_manager(
 
 def sync_ebics_transactions(
 	ebics_user: str,
+	requested_by: Literal["User", "System"],
 	start_date: str | None = None,
 	end_date: str | None = None,
 	passphrase: str | None = None,
@@ -67,50 +70,44 @@ def sync_ebics_transactions(
 	user = frappe.get_doc("EBICS User", ebics_user)
 	manager = get_ebics_manager(ebics_user=user, passphrase=passphrase)
 
-	# Not sure yet, how reliable permitted types are. For now, we just log an error
-	# instead of raising an exception or returning.
+	from fintech.sepa import (
+		CAMTDocument,
+	)  # import possible only after manager is initialized
+
 	permitted_types = manager.get_permitted_order_types()
-	if intraday and "C52" not in permitted_types:
-		frappe.log_error(
-			title=_("Banking Error"),
-			message=_(
-				"It seems like EBICS User {0} lacks permission 'C52' for downloading intraday transactions. The permitted types are: {1}."
-			).format(ebics_user, ", ".join(permitted_types)),
-			reference_doctype="EBICS User",
-			reference_name=ebics_user,
-		)
+	validate_permitted_types(user, permitted_types, intraday)
 
-	if not intraday and "C53" not in permitted_types:
-		frappe.log_error(
-			title=_("Banking Error"),
-			message=_(
-				"It seems like EBICS User {0} lacks permission 'C52' for downloading booked bank statements. The permitted types are: {1}."
-			).format(ebics_user, ", ".join(permitted_types)),
-			reference_doctype="EBICS User",
-			reference_name=ebics_user,
-		)
-
-	if not intraday and user.split_batch_transactions and "C54" not in permitted_types:
-		frappe.log_error(
-			title=_("Banking Error"),
-			message=_(
-				"EBICS User {0} lacks permission 'C54' for splitting batch transactions. The permitted types are: {1}."
-			).format(ebics_user, ", ".join(permitted_types)),
-			reference_doctype="EBICS User",
-			reference_name=ebics_user,
-		)
+	with_c54 = user.split_batch_transactions and "C54" in permitted_types
+	request = log_request(
+		ebics_user,
+		"C52" if intraday else "C53",
+		requested_by,
+		{
+			"start_date": start_date,
+			"end_date": end_date,
+		},
+	)
 
 	try:
-		camt_documents = (
-			manager.download_intraday_transactions()
-			if intraday
-			else manager.download_bank_statements(
-				start_date,
-				end_date,
-				with_c54=user.split_batch_transactions and "C54" in permitted_types,
-			)
+		client = manager.get_client()
+		main_xml = (
+			client.C52(start_date, end_date) if intraday else client.C53(start_date, end_date)
 		)
-	except Exception:
+		batch_xml = client.C54(start_date, end_date) if with_c54 else None
+		request.db_set(
+			{
+				"status": "Successful",
+				"response": json.dumps(
+					{file_name: file.decode() for file_name, file in main_xml.items()},
+					indent=2,
+				),
+			}
+		)
+	except fintech.ebics.EbicsNoDataAvailable:
+		request.db_set({"status": "Successful", "response": "No Data Available"})
+		return
+	except Exception as e:
+		request.db_set({"status": "Failed", "response": str(e)})
 		frappe.log_error(
 			title=_("Banking Error"),
 			reference_doctype="EBICS User",
@@ -118,52 +115,108 @@ def sync_ebics_transactions(
 		)
 		return
 
-	for camt_document in camt_documents:
-		bank_account = frappe.db.get_value(
-			"Bank Account",
-			{
-				"iban": camt_document.iban,
-				"disabled": 0,
-				"bank": user.bank,
-				"is_company_account": 1,
-				"company": user.company,
-			},
+	# Keep the request log, no matter what happens next.
+	frappe.db.commit()
+
+	# We want to process either all documents or none. If we fail to process one, we
+	# want to rollback the entire transaction and report an error.
+	try:
+		for name in sorted(main_xml):
+			camt_document = CAMTDocument(xml=main_xml[name], camt54=batch_xml)
+			process_camt_document(user, camt_document)
+	except Exception:
+		frappe.db.rollback()
+		frappe.log_error(
+			title=_("Banking Error"),
+			reference_doctype="EBICS Request",
+			reference_name=request.name,
 		)
-		if not bank_account:
-			frappe.log_error(
-				title=_("Banking Error"),
-				message=_("Bank Account not found for IBAN {0}").format(camt_document.iban),
-				reference_doctype="EBICS User",
-				reference_name=ebics_user,
-			)
+		client.confirm_download(success=False)
+		return
+
+	client.confirm_download(success=True)
+
+
+def validate_permitted_types(user, permitted_types, intraday: bool):
+	# Not sure yet, how reliable permitted types are. For now, we just log an error
+	# instead of raising an exception or returning.
+	if intraday and "C52" not in permitted_types:
+		frappe.log_error(
+			title=_("Banking Error"),
+			message=_(
+				"It seems like EBICS User {0} lacks permission 'C52' for downloading intraday transactions. The permitted types are: {1}."
+			).format(user.name, ", ".join(permitted_types)),
+			reference_doctype="EBICS User",
+			reference_name=user.name,
+		)
+
+	if not intraday and "C53" not in permitted_types:
+		frappe.log_error(
+			title=_("Banking Error"),
+			message=_(
+				"It seems like EBICS User {0} lacks permission 'C52' for downloading booked bank statements. The permitted types are: {1}."
+			).format(user.name, ", ".join(permitted_types)),
+			reference_doctype="EBICS User",
+			reference_name=user.name,
+		)
+
+	if not intraday and user.split_batch_transactions and "C54" not in permitted_types:
+		frappe.log_error(
+			title=_("Banking Error"),
+			message=_(
+				"EBICS User {0} lacks permission 'C54' for splitting batch transactions. The permitted types are: {1}."
+			).format(user.name, ", ".join(permitted_types)),
+			reference_doctype="EBICS User",
+			reference_name=user.name,
+		)
+
+
+def process_camt_document(user, camt_document):
+	bank_account = frappe.db.get_value(
+		"Bank Account",
+		{
+			"iban": camt_document.iban,
+			"disabled": 0,
+			"bank": user.bank,
+			"is_company_account": 1,
+			"company": user.company,
+		},
+	)
+	if not bank_account:
+		frappe.log_error(
+			title=_("Banking Error"),
+			message=_("Bank Account not found for IBAN {0}").format(camt_document.iban),
+			reference_doctype="EBICS User",
+			reference_name=user.name,
+		)
+		return
+
+	if camt_document._type in ("camt.053.001.08", "camt.052.001.08"):
+		# Recognize a batch solely by the presence of the Btch element or more than one subtransaction.
+		camt_document._strict_batch_parsing = True
+
+	for transaction in camt_document:
+		if transaction.status and transaction.status != "BOOK":
+			# Skip PDNG and INFO transactions
 			continue
 
-		if camt_document._type in ("camt.053.001.08", "camt.052.001.08"):
-			# Recognize a batch solely by the presence of the Btch element or more than one subtransaction.
-			camt_document._strict_batch_parsing = True
-
-		for transaction in camt_document:
-			if transaction.status and transaction.status != "BOOK":
-				# Skip PDNG and INFO transactions
-				continue
-
-			if (
-				transaction.batch
-				and (user.split_batch_transactions or len(transaction) == 1)
-				and len(transaction) >= 1
-			):
-				# Split batch transactions into sub-transactions, based on info
-				# from camt.054 that is sometimes available.
-				# If that's not possible, create a single transaction
-				for sub_transaction in transaction:
-					_create_bank_transaction(
-						bank_account,
-						user.company,
-						sub_transaction,
-						user.start_date,
-					)
-			else:
-				_create_bank_transaction(bank_account, user.company, transaction, user.start_date)
+		if (
+			transaction.batch
+			and (user.split_batch_transactions or len(transaction) == 1)
+			and len(transaction) >= 1
+		):
+			# Split batch transactions into sub-transactions, based on info
+			# from camt.054 that is sometimes available.
+			# If that's not possible, create a single transaction
+			for sub_transaction in transaction:
+				_create_bank_transaction(
+					bank_account,
+					user.company,
+					sub_transaction,
+					user.start_date,
+				)
+		else:
+			_create_bank_transaction(bank_account, user.company, transaction, user.start_date)
 
 
 def _create_bank_transaction(
@@ -211,3 +264,17 @@ def _create_bank_transaction(
 	with contextlib.suppress(frappe.exceptions.UniqueValidationError):
 		bt.insert()
 		bt.submit()
+
+
+def log_request(
+	ebics_user: str,
+	order_type: str,
+	requested_by: Literal["User", "System"],
+	parameters: dict,
+):
+	request = frappe.new_doc("EBICS Request")
+	request.ebics_user = ebics_user
+	request.order_type = order_type
+	request.requested_by = requested_by
+	request.parameters = json.dumps(parameters, indent=2)
+	return request.save(ignore_permissions=True)

--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
@@ -66,6 +66,7 @@ def daily_sync_ebics():
 	):
 		frappe.enqueue(
 			sync_ebics_transactions,
+			requested_by="System",
 			ebics_user=ebics_user,
 		)
 
@@ -90,6 +91,7 @@ def intraday_sync_ebics():
 	):
 		frappe.enqueue(
 			sync_ebics_transactions,
+			requested_by="System",
 			ebics_user=ebics_user,
 			intraday=True,
 		)


### PR DESCRIPTION
Keep logs of **EBICS Requests**, with info about the initiator (system or user), status (successful, failed) and response data. This will hopefully make the analysis of support requests easier.

Towards #170

Had to move the actual ebics requests from manager into the main loop, so we can determine if they were successful or not. To keep sane, I in turn extracted `validate_order_types` and `process_camt_document` into separate methods.

List:
![Bildschirmfoto 2025-03-12 um 19 21 29](https://github.com/user-attachments/assets/d2945bab-071d-4b53-86da-bcc888af4907)

Form:
![Bildschirmfoto 2025-03-12 um 19 22 01](https://github.com/user-attachments/assets/40e46b3b-fa3d-4d01-931b-6dbafb22c116)
