### PR TITLE
fix: timing of sync jobs

### DIFF
--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -114,10 +114,10 @@ doc_events = {
 
 scheduler_events = {
 	"cron": {
-		"30 6,10,14,18 * * *": [  # at 6:30, 10:30, 14:30, 18:30
+		"7 7-18 * * 1-5": [  # At minute 7 past every hour from 7 through 18 on every day-of-week from Monday through Friday.
 			"banking.klarna_kosma_integration.doctype.banking_settings.banking_settings.intraday_sync_ebics",
 		],
-		"42 2 * * *": [  # daily at 2:42 am
+		"42 4 * * *": [  # Daily at 4:42 am
 			"banking.klarna_kosma_integration.doctype.banking_settings.banking_settings.sync_all_accounts_and_transactions",
 		],
 	},


### PR DESCRIPTION
According to one customer's bank, C52 is made available every hour and C53 between 22:00 and 4:00.

- Increase intraday sync frequency to every hour during work times on workdays
- Run daily sync later in the morning to ensure data is available

Minutes are off on purpose to avoid overloaded bank servers when requesting data at the same time as everybody else.