### PR TITLE
fix: request specific dates

### DIFF
--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2022, ALYF GmbH and contributors
 # For license information, please see license.txt
 
+from datetime import timedelta
 from requests import HTTPError
 from semantic_version import Version
 from typing import Dict
@@ -8,7 +9,7 @@ from typing import Dict
 import frappe
 from frappe import _
 from frappe.model.document import Document
-
+from frappe.utils.data import now_datetime
 from banking.klarna_kosma_integration.admin import Admin
 
 
@@ -61,6 +62,7 @@ def daily_sync_ebics():
 			)
 		)
 
+	yesterday = (now_datetime() - timedelta(days=1)).date().isoformat()
 	for ebics_user in frappe.get_all(
 		"EBICS User",
 		filters={
@@ -74,6 +76,8 @@ def daily_sync_ebics():
 		frappe.enqueue(
 			sync_ebics_transactions,
 			requested_by="System",
+			start_date=yesterday,
+			end_date=yesterday,
 			ebics_user=ebics_user,
 		)
 
@@ -92,6 +96,7 @@ def intraday_sync_ebics():
 	if not banking_settings.enabled or not banking_settings.enable_ebics:
 		return
 
+	today = now_datetime().date().isoformat()
 	for ebics_user in frappe.get_all(
 		"EBICS User",
 		filters={
@@ -106,6 +111,8 @@ def intraday_sync_ebics():
 		frappe.enqueue(
 			sync_ebics_transactions,
 			requested_by="System",
+			start_date=today,
+			end_date=today,
 			ebics_user=ebics_user,
 			intraday=True,
 		)


### PR DESCRIPTION
Previously, the auto-sync requested the latest unread documents. This leads to race-conditions when the same EBICS user is running on two different prod systems. Now we request documents for specific date ranges in hopes that the bank will return all documents in this range, not just the unread ones.

If this doesn't help, we'll need to configure separate EBICS user per system.