### PR TITLE
fix: Show single JE row + minor refactor

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -978,6 +978,9 @@ def get_je_matching_query(
 		.select(
 			"*",
 			rank_expression.as_("rank"),
+			ref_rank.as_("reference_number_match"),
+			amount_rank.as_("amount_match"),
+			date_rank.as_("date_match"),
 		)
 		.where(amount_filter)
 		.orderby(rank_expression, order=Order.desc)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
+from frappe.query_builder.functions import Sum
 from frappe.utils import cint, flt, sbool
 from frappe.query_builder.functions import Cast, Coalesce
 
@@ -430,7 +431,7 @@ def get_linked_payments(
 		from_reference_date,
 		to_reference_date,
 	)
-	subtract_allocations(gl_account, matching)
+	subtract_allocations(gl_account, vouchers=matching)
 
 	return matching
 
@@ -446,21 +447,30 @@ def subtract_allocations(gl_account, vouchers):
 	This does not affect "unpaid" vouchers (e.g. unpaid invoices) since they
 	are never directly allocated to a Bank Transaction.
 	"""
-	rows = get_total_allocated_amount(
+	voucher_allocated_amounts = get_total_allocated_amount(
 		[(voucher.get("doctype"), voucher.get("name")) for voucher in vouchers]
 	)
 
-	if not rows:
+	if not voucher_allocated_amounts:
 		return
 
 	for voucher in vouchers:
-		for (doctype, name), values in rows.items():
-			if doctype != voucher.get("doctype") or name != voucher.get("name"):
-				continue
+		if amount := get_allocated_amount(voucher_allocated_amounts, voucher, gl_account):
+			voucher["paid_amount"] -= amount
 
-			for value in values:
-				if value["gl_account"] == gl_account:
-					voucher["paid_amount"] -= value["total"]
+
+def get_allocated_amount(voucher_allocated_amounts, voucher, gl_account):
+	if not (
+		voucher_details := voucher_allocated_amounts.get(
+			(voucher.get("doctype"), voucher.get("name"))
+		)
+	):
+		return
+
+	if not (row := voucher_details.get(gl_account)):
+		return
+
+	return row.get("total")
 
 
 def check_matching(
@@ -921,53 +931,58 @@ def get_je_matching_query(
 	cr_or_dr = "credit" if common_filters.payment_type == "Pay" else "debit"
 	amount_field = getattr(jea, f"{cr_or_dr}_in_account_currency")
 
-	ref_rank = ref_equality_condition(je.cheque_no, common_filters.reference_no)
-	amount_rank = amount_rank_condition(amount_field, common_filters.amount)
-	amount_filter = (
-		amount_field == common_filters.amount if exact_match else amount_field > 0.0
-	)
-
 	filter_by_date = je.posting_date.between(from_date, to_date)
 	if cint(filter_by_reference_date):
 		filter_by_date = je.cheque_date.between(from_reference_date, to_reference_date)
 
-	date_condition = Coalesce(je.cheque_date, je.posting_date) == common_filters.date
-	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
-
-	rank_expression = ref_rank + amount_rank + date_rank + 1
-
-	query = (
+	subquery = (
 		frappe.qb.from_(jea)
 		.join(je)
 		.on(jea.parent == je.name)
 		.select(
-			rank_expression.as_("rank"),
+			Sum(amount_field).as_("paid_amount"),
 			ConstantColumn("Journal Entry").as_("doctype"),
 			je.name,
-			amount_field.as_("paid_amount"),
 			je.cheque_no.as_("reference_no"),
-			je.cheque_date.as_("reference_date"),
+			Coalesce(je.cheque_date, je.posting_date).as_("reference_date"),
 			je.pay_to_recd_from.as_("party"),
 			jea.party_type,
 			je.posting_date,
 			jea.account_currency.as_("currency"),
-			ref_rank.as_("reference_number_match"),
-			amount_rank.as_("amount_match"),
-			date_rank.as_("date_match"),
 		)
 		.where(je.docstatus == 1)
 		.where(je.voucher_type != "Opening Entry")
 		.where(je.clearance_date.isnull())
 		.where(jea.account == common_filters.bank_account)
-		.where(amount_filter)
-		.where(je.docstatus == 1)
 		.where(filter_by_date)
-		.orderby(rank_expression, order=Order.desc)
-		.limit(MAX_QUERY_RESULTS)
+		.groupby(je.name)
+		.orderby(je.cheque_date if cint(filter_by_reference_date) else je.posting_date)
 	)
 
 	if frappe.flags.auto_reconcile_vouchers:
-		query = query.where(je.cheque_no == common_filters.reference_no)
+		subquery = subquery.where(je.cheque_no == common_filters.reference_no)
+
+	ref_rank = ref_equality_condition(subquery.reference_no, common_filters.reference_no)
+	amount_rank = amount_rank_condition(subquery.paid_amount, common_filters.amount)
+	amount_filter = (
+		subquery.paid_amount == common_filters.amount
+		if exact_match
+		else subquery.paid_amount > 0.0
+	)
+	date_condition = subquery.reference_date == common_filters.date
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+	rank_expression = ref_rank + amount_rank + date_rank + 1
+
+	query = (
+		frappe.qb.from_(subquery)
+		.select(
+			"*",
+			rank_expression.as_("rank"),
+		)
+		.where(amount_filter)
+		.orderby(rank_expression, order=Order.desc)
+		.limit(MAX_QUERY_RESULTS)
+	)
 
 	return query
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -664,6 +664,55 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(first_match["amount_match"], 1)
 		self.assertEqual(first_match["ref_in_desc_match"], 0)
 
+	def test_split_jv_match_against_transaction(self):
+		"""
+		Test if a split JV shows up as a single consolidated row in the tool
+		and fully reconciles the Bank Transaction.
+		"""
+		bt = create_bank_transaction(
+			deposit=200, reference_no="abcdef123", bank_account=self.bank_account
+		)
+		journal_entry = create_journal_entry_bts(
+			bank_transaction_name=bt.name,
+			party_type="Customer",
+			party=self.customer,
+			posting_date=bt.date,
+			reference_number=bt.reference_number,
+			reference_date=bt.date,
+			entry_type="Bank Entry",
+			second_account=frappe.db.get_value(
+				"Company", bt.company, "default_receivable_account"
+			),
+			allow_edit=True,
+		)
+
+		# Split the JV Row into two
+		journal_entry.accounts[1].debit_in_account_currency = 100
+		journal_entry.append(
+			"accounts",
+			{
+				"account": frappe.get_value("Bank Account", bt.bank_account, "account"),
+				"bank_account": bt.bank_account,
+				"credit_in_account_currency": 0.0,
+				"debit_in_account_currency": 100,
+				"cost_center": journal_entry.accounts[1].cost_center,
+			},
+		)
+		journal_entry.submit()
+
+		matched_vouchers = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["journal_entry"],
+			from_date=getdate(),
+			to_date=getdate(),
+		)
+		first_match = matched_vouchers[0]
+
+		self.assertEqual(len(matched_vouchers), 1)
+		self.assertEqual(first_match["reference_no"], bt.reference_number)
+		self.assertEqual(first_match["name"], journal_entry.name)
+		self.assertEqual(first_match["paid_amount"], 200.0)
+
 
 def get_pe_references(vouchers: list):
 	return frappe.get_all(

--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -65,13 +65,6 @@ class CustomBankTransaction(BankTransaction):
 		}
 		self.append("payment_entries", pe)
 
-	def get_outstanding_amount(self, payment_doctype, payment_name):
-		if payment_doctype not in ("Sales Invoice", "Purchase Invoice"):
-			return 0
-
-		# Check if the invoice is unpaid
-		return flt(frappe.db.get_value(payment_doctype, payment_name, "outstanding_amount"))
-
 	def reconcile_paid_vouchers(self, vouchers):
 		"""Reconcile paid vouchers with the Bank Transaction."""
 		for voucher in vouchers:


### PR DESCRIPTION
> https://github.com/frappe/erpnext/pull/46803 fixes issues where a JE row split into multiple rows would not get fully reconciled

- After the fix above, a JE is reconciled based on the sum of the rows having the same account head
- We make sure that the tool also reflects how it eventually interprets things for clarity:
	- Consider **ACC-JV-2025-00001:**
		<img width="500" alt="Screenshot 2025-03-31 at 3 43 50 PM" src="https://github.com/user-attachments/assets/c6ae78b6-c518-4e1d-ae5e-bb44ce2e3343" />
	- Before:
		<img width="500" alt="Screenshot 2025-03-31 at 3 45 41 PM" src="https://github.com/user-attachments/assets/fd6aef71-1f7e-4ab7-b1b5-dbb558f309eb" />
	- After:
		<img width="500" alt="Screenshot 2025-03-31 at 4 30 30 PM" src="https://github.com/user-attachments/assets/7c64d4f8-b752-44fd-a94c-070f201a8803" />

- The changes in this PR do not change any logical behavior, only the UX. ERPNext handles the reconciliation logic change.
- Misc: Remove unused `get_outstanding_amount` 
- Misc: Refactor `get_allocated_amount`

> [!NOTE]
> I can't find any valid case as to why a user would want to see the rows split in the tool since they most likely come from the same bank transaction and are split in the JE for dimension tagging reasons or distribution among different accounts. Either way, the income/expense should be against a single real-world BT.