### PR TITLE
feat: use transaction hash as fallback for ID

### DIFF
--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -1,4 +1,5 @@
 import contextlib
+import hashlib
 import json
 from typing import TYPE_CHECKING, Literal
 
@@ -238,7 +239,9 @@ def _create_bank_transaction(
 	# sepa_transaction.bank_reference can be None, but we can still find an ID in the XML
 	# For our test bank, the latter is a timestamp with nanosecond accuracy.
 	transaction_id = (
-		sepa_transaction.bank_reference or sepa_transaction._xmlobj.Refs.TxId.text
+		sepa_transaction.bank_reference
+		or sepa_transaction._xmlobj.Refs.TxId.text
+		or get_transaction_hash(sepa_transaction)
 	)
 
 	# NOTE: This does not work for old data, this ID is different from Kosma's
@@ -270,6 +273,24 @@ def _create_bank_transaction(
 	with contextlib.suppress(frappe.exceptions.UniqueValidationError):
 		bt.insert()
 		bt.submit()
+
+
+def get_transaction_hash(transaction: "SEPATransaction"):
+	sha = hashlib.sha256()
+	for value in (
+		transaction.date,
+		transaction.iban,
+		transaction.name,
+		transaction.eref,
+		transaction.amount.value,
+		transaction.amount.currency,
+		transaction.info,
+		*transaction.purpose,
+	):
+		if value:
+			sha.update(frappe.safe_encode(str(value)))
+
+	return sha.hexdigest()
 
 
 def log_request(


### PR DESCRIPTION
Some bank's statements lack transaction IDs. In this case we use a hash of all relevant transaction data as a makeshift ID.