### PR TITLE
fix: disallow CAMT upload via Google Drive

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -270,6 +270,7 @@ function show_camt_uploader(frm) {
 		allow_take_photo: false,
 		allow_web_link: false,
 		allow_multiple: false,
+		allow_google_drive: false,
 		disable_file_browser: true,
 		bank_account: frm.doc.bank_account,
 		restrictions: {


### PR DESCRIPTION
Depends on https://github.com/frappe/frappe/pull/32517