### PR TITLE
fix: Allow Multi Currency JV from Tool

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -102,9 +102,9 @@ def create_journal_entry_bts(
 	bank_debit_amount = bank_transaction.unallocated_amount if bank_transaction.deposit > 0.0 else 0.0
 	bank_credit_amount = bank_transaction.unallocated_amount if bank_transaction.withdrawal > 0.0 else 0.0
 
-	company_bank_account = frappe.get_value("Bank Account", bank_transaction.bank_account, "account")
+	bank_gl_account = frappe.get_value("Bank Account", bank_transaction.bank_account, "account")
 	company, bank_account_currency = frappe.get_value(
-		"Account", company_bank_account, ["company", "account_currency"]
+		"Account", bank_gl_account, ["company", "account_currency"]
 	)
 
 	second_account_type, second_account_currency = frappe.db.get_value(
@@ -118,8 +118,8 @@ def create_journal_entry_bts(
 	if second_account_currency != bank_account_currency:
 		frappe.throw(
 			_(
-				"The currency of the second account ({0}) must be the same as of the bank account ({1})"
-			).format(second_account, bank_account_currency)
+				"The currency of the second account ({0} : {1}) must be the same as of the bank account ({2} : {3})"
+			).format(second_account, second_account_currency, bank_gl_account, bank_account_currency)
 		)
 
 	journal_entry = frappe.new_doc("Journal Entry")
@@ -145,7 +145,7 @@ def create_journal_entry_bts(
 				"cost_center": get_default_cost_center(company),
 			},
 			{
-				"account": company_bank_account,
+				"account": bank_gl_account,
 				"bank_account": bank_transaction.bank_account,
 				"credit_in_account_currency": bank_credit_amount,
 				"debit_in_account_currency": bank_debit_amount,

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -155,8 +155,8 @@ def create_journal_entry_bts(
 	)
 
 	company_currency = get_company_currency(company)
-	journal_entry.multi_currency = any(
-		currency != company_currency for currency in [bank_account_currency, second_account_currency]
+	journal_entry.multi_currency = (
+		0 if company_currency == bank_account_currency == second_account_currency else 1
 	)
 
 	journal_entry.insert()

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -102,8 +102,10 @@ def create_journal_entry_bts(
 	bank_debit_amount = bank_transaction.unallocated_amount if bank_transaction.deposit > 0.0 else 0.0
 	bank_credit_amount = bank_transaction.unallocated_amount if bank_transaction.withdrawal > 0.0 else 0.0
 
-	company_account = frappe.get_value("Bank Account", bank_transaction.bank_account, "account")
-	company, company_currency = frappe.get_value("Account", company_account, ["company", "account_currency"])
+	company_bank_account = frappe.get_value("Bank Account", bank_transaction.bank_account, "account")
+	company, bank_account_currency = frappe.get_value(
+		"Account", company_bank_account, ["company", "account_currency"]
+	)
 
 	second_account_type, second_account_currency = frappe.db.get_value(
 		"Account", second_account, ["account_type", "account_currency"]
@@ -113,11 +115,11 @@ def create_journal_entry_bts(
 			_("Party Type and Party is required for Receivable / Payable account {0}").format(second_account)
 		)
 
-	if second_account_currency != company_currency:
+	if second_account_currency != bank_account_currency:
 		frappe.throw(
 			_(
 				"The currency of the second account ({0}) must be the same as of the bank account ({1})"
-			).format(second_account, company_currency)
+			).format(second_account, bank_account_currency)
 		)
 
 	journal_entry = frappe.new_doc("Journal Entry")
@@ -143,7 +145,7 @@ def create_journal_entry_bts(
 				"cost_center": get_default_cost_center(company),
 			},
 			{
-				"account": company_account,
+				"account": company_bank_account,
 				"bank_account": bank_transaction.bank_account,
 				"credit_in_account_currency": bank_credit_amount,
 				"debit_in_account_currency": bank_debit_amount,
@@ -151,6 +153,12 @@ def create_journal_entry_bts(
 			},
 		],
 	)
+
+	company_currency = get_company_currency(company)
+	journal_entry.multi_currency = any(
+		currency != company_currency for currency in [bank_account_currency, second_account_currency]
+	)
+
 	journal_entry.insert()
 
 	if allow_edit:

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -3,9 +3,6 @@
 import json
 
 import frappe
-from erpnext.accounts.doctype.bank_transaction.test_bank_transaction import (
-	create_gl_account,
-)
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 	create_payment_entry,
 )
@@ -37,7 +34,7 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		)  # commits to db internally
 
 		create_bank()
-		cls.gl_account = create_gl_account("_Test Bank Reco Tool")
+		cls.gl_account = create_bank_gl_account("_Test Bank Reco Tool")
 		cls.bank_account = create_bank_account(gl_account=cls.gl_account)
 		cls.customer = create_customer(customer_name="ABC Inc.")
 
@@ -681,6 +678,54 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(first_match["name"], journal_entry.name)
 		self.assertEqual(first_match["paid_amount"], 200.0)
 
+	def test_usd_jv_against_eur_company(self):
+		"""Test if the tool can create a USD Journal Entry against a EUR company."""
+		bank = create_bank("Citi Bank USD", swift_number="CITIUS34")
+		gl_account = create_bank_gl_account("_Test USD Bank Reco Tool", "USD")
+		usd_receivable_account = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"company": "_Test Company",
+				"parent_account": "Accounts Receivable - _TC",
+				"account_type": "Receivable",
+				"is_group": 0,
+				"account_name": "USD Receivable - _TC",
+				"account_currency": "USD",
+			}
+		).insert()
+		bank_account = create_bank_account(bank.name, gl_account, "USD Account")
+		customer = create_customer(customer_name="USD Inc.", currency="USD")
+
+		bt = create_bank_transaction(
+			date=getdate(),
+			deposit=200,
+			reference_no="usd-jv-001",
+			bank_account=bank_account,
+			currency="USD",
+			description="USD Inc.",
+		)
+
+		create_journal_entry_bts(
+			bank_transaction_name=bt.name,
+			party_type="Customer",
+			party=customer,
+			posting_date=bt.date,
+			reference_number=bt.reference_number,
+			reference_date=bt.date,
+			entry_type="Bank Entry",
+			second_account=usd_receivable_account.name,
+		)
+
+		bt.reload()
+		self.assertEqual(bt.payment_entries[0].payment_document, "Journal Entry")
+
+		journal_entry = frappe.get_doc("Journal Entry", bt.payment_entries[0].payment_entry)
+
+		self.assertTrue(journal_entry.multi_currency)
+		self.assertEqual(bt.status, "Reconciled")
+		self.assertEqual(len(bt.payment_entries), 1)
+		self.assertEqual(bt.payment_entries[0].allocated_amount, 200)
+
 
 def get_pe_references(vouchers: list):
 	return frappe.get_all(
@@ -699,6 +744,7 @@ def create_bank_transaction(
 	reference_date: str | None = None,
 	bank_account: str | None = None,
 	description: str | None = None,
+	currency: str = "INR",
 ):
 	doc = frappe.get_doc(
 		{
@@ -708,7 +754,7 @@ def create_bank_transaction(
 			"date": date or frappe.utils.nowdate(),
 			"deposit": deposit or 0.0,
 			"withdrawal": withdrawal or 0.0,
-			"currency": "INR",
+			"currency": currency,
 			"bank_account": bank_account,
 			"reference_number": reference_no,
 		}
@@ -765,12 +811,27 @@ def create_bank_account(
 	return bank_account.name
 
 
-def create_bank(bank_name="Citi Bank"):
+def create_bank(bank_name: str = "Citi Bank", swift_number: str = "CITIUS33"):
 	if not frappe.db.exists("Bank", bank_name):
 		bank = frappe.new_doc("Bank")
 		bank.bank_name = bank_name
-		bank.swift_number = "CITIUS33"
+		bank.swift_number = swift_number
 		bank.insert()
 	else:
 		bank = frappe.get_doc("Bank", bank_name)
 	return bank
+
+
+def create_bank_gl_account(account_name: str = "_Test Bank - _TC", currency: str = "INR") -> str:
+	gl_account = frappe.get_doc(
+		{
+			"doctype": "Account",
+			"company": "_Test Company",
+			"parent_account": "Current Assets - _TC",
+			"account_type": "Bank",
+			"is_group": 0,
+			"account_name": account_name,
+			"account_currency": currency,
+		}
+	).insert()
+	return gl_account.name


### PR DESCRIPTION
Closes https://github.com/alyf-de/banking/issues/218

**Before:**
- ![2025-05-26 5 23 37 PM](https://github.com/user-attachments/assets/8086901d-7fa5-4938-9f14-7a440b4140fd)


**After:**
- If any of the accounts involved do not match the company currency, mark the JV as multi_currency
	![2025-05-26 5 22 46 PM](https://github.com/user-attachments/assets/867b4279-6959-4feb-a208-d7e64b1c0177)