### PR TITLE
feat: redesign upload and auto reconcile buttons

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -46,7 +46,7 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 		});
 		frm.change_custom_button_type(__("Get Bank Transactions"), null, "primary");
 
-		frm.page.add_menu_item(__("Auto Reconcile"), function () {
+		frm.add_custom_button(__("Auto Reconcile"), function () {
 			frappe.confirm(
 				__(
 					"Auto reconcile bank transactions based on matching reference numbers?"
@@ -75,12 +75,16 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 			);
 		});
 
-		frm.page.add_menu_item(__("Upload CSV / Excel file"), () =>
-			frm.events.route_to_bank_statement_import(frm)
+		frm.add_custom_button(
+			__("Upload CSV / Excel file"),
+			() => frm.events.route_to_bank_statement_import(frm),
+			__("Upload Files")
 		);
 
-		frm.page.add_menu_item(__("Upload CAMT file"), () =>
-			show_camt_uploader(frm)
+		frm.add_custom_button(
+			__("Upload CAMT file"),
+			() => show_camt_uploader(frm),
+			__("Upload Files")
 		);
 
 		frm.$reconciliation_area = frm.get_field(


### PR DESCRIPTION
The Auto Reconcile and Upload Files buttons move out of the three dots menu into their own button/grouped Button to highlight their importance.

Closes #231 

<img width="554" alt="image" src="https://github.com/user-attachments/assets/aad0b9e8-af43-47c9-a82a-d0a716c2a8b1" />
