### PR TITLE
fix: don't set `transaction_type` to `SEPATransaction.info`

### DIFF
--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -274,7 +274,6 @@ def create_sepa_bank_transaction(
 		description="\n".join(sepa_transaction.purpose) or sepa_transaction.info,
 		deposit=max(amount, 0),
 		withdrawal=abs(min(amount, 0)),
-		transaction_type=sepa_transaction.info,
 		date=sepa_transaction.date,
 		reference_number=sepa_transaction.eref,
 		bank_party_name=sepa_transaction.ultimate_name or sepa_transaction.name,


### PR DESCRIPTION
Seems like this worked for our bank only. Other banks can have longer texts in this field, that are not the transaction type.

Resolves https://github.com/alyf-de/banking/pull/235/files#r2228751784