### PR TITLE
fix: revert to old logic for SEPA transaction IDs

### DIFF
--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -264,10 +264,9 @@ def create_sepa_bank_transaction(
 		transaction_id=(
 			# sepa_transaction.bank_reference can be None, but we can still find an ID in the XML
 			# For our test bank, the latter is a timestamp with nanosecond accuracy.
-			# sepa_transaction.bank_reference
-			# or sepa_transaction._xmlobj.Refs.TxId.text
-			# or
-			get_transaction_hash(values_to_hash)
+			sepa_transaction.bank_reference
+			or sepa_transaction._xmlobj.Refs.TxId.text
+			or get_transaction_hash(values_to_hash)
 		),
 		company=company,
 		currency=sepa_transaction.amount.currency,


### PR DESCRIPTION
Changing the way `transaction_id` is determined makes duplicate detection impossible. This reverts an unintended change that was released in [v15.18.0](https://github.com/alyf-de/banking/releases/tag/v15.18.0) and [v0.18.0](https://github.com/alyf-de/banking/releases/tag/v0.18.0).

Resolves https://github.com/alyf-de/banking/pull/235/files#r2229081035