### PR TITLE
feat: bump fintech to 7.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,3 @@ Install [via Frappe Cloud](https://frappecloud.com/marketplace/apps/banking) or 
 bench get-app https://github.com/alyf-de/banking.git
 bench --site <sitename> install-app banking
 ```
-
-If you want to use ebics on Apple Silicon, the runtime library must be signed manually:
-
-```bash
-# python3.11
-sudo codesign --force --deep --sign - env/lib/python3.11/site-packages/fintech/runtime/darwin/aarch64/pyarmor_runtime.so
-
-# python3.10
-sudo codesign --force --deep --sign - env/lib/python3.10/site-packages/fintech/pytransform/platforms/darwin/aarch64/_pytransform.dylib
-```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # frappe -- https://github.com/frappe/frappe is installed via 'bench init'
-    "fintech~=7.7.0"
+    "fintech~=7.8.0"
 ]
 
 [build-system]


### PR DESCRIPTION
v7.8.4 added support for deviating loaders (eg. Pyinstaller) -> codesign on macOS is no longer required
v7.8.5 added support parsing MT940 files created by ING Netherlands
