### PR TITLE
refactor(set_keyring): passphrase is mandatory, sig_passphrase is optional

### DIFF
--- a/banking/ebics/manager.py
+++ b/banking/ebics/manager.py
@@ -15,7 +15,7 @@ class EBICSManager:
 		self.protocol_version = protocol_version or "H004"
 		self.country_code = country_code
 
-	def set_keyring(self, keys: dict, save_to_db: "Callable", sig_passphrase: str, passphrase: str | None):
+	def set_keyring(self, keys: dict, save_to_db: "Callable", passphrase: str, sig_passphrase: str | None):
 		from fintech.ebics import EbicsKeyRing
 
 		class CustomKeyRing(EbicsKeyRing):

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -38,8 +38,8 @@ def get_ebics_manager(
 	manager.set_keyring(
 		keys=ebics_user.get_keyring(),
 		save_to_db=ebics_user.store_keyring,
-		sig_passphrase=sig_passphrase,
 		passphrase=passphrase or ebics_user.get_passphrase(),
+		sig_passphrase=sig_passphrase,
 	)
 
 	manager.set_user(ebics_user.partner_id, ebics_user.user_id)


### PR DESCRIPTION
* Changed the `set_keyring` method in `banking/ebics/manager.py` to require `passphrase` and make `sig_passphrase` optional, swapping their order in the method signature.
* Updated the invocation of `set_keyring` in `banking/ebics/utils.py` to match the new parameter order and optionality.