### PR TITLE
chore: pin fintech to 7.8.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # frappe -- https://github.com/frappe/frappe is installed via 'bench init'
-    "fintech~=7.8.0",
+    "fintech==7.8.8",
     "kontocheck~=6.15.0",
 ]
 


### PR DESCRIPTION
Ensure that customers install the latest fintech release and not an earlier compatible version.