### PR TITLE
refactor(Reco Tool): make use of hooks

### DIFF
--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -208,6 +208,7 @@ bank_reconciliation_doctypes = [
 	"Bank Transaction",
 ]
 get_matching_queries = "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank_reconciliation_tool_beta.get_matching_queries"
+get_payment_entries = "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.unpaid_vouchers.get_payment_entries"
 
 alyf_banking_custom_records = [
 	{

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -202,6 +202,11 @@ alyf_banking_property_setters = {
 	]
 }
 
+# Bank Reconciliation Doctypes are defined in the respective apps.
+# We only add "Bank Transaction" since thats not supported by ERPNext natively.
+bank_reconciliation_doctypes = [
+	"Bank Transaction",
+]
 get_matching_queries = "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank_reconciliation_tool_beta.get_matching_queries"
 
 alyf_banking_custom_records = [

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -260,6 +260,10 @@ def bulk_reconcile_vouchers(
 	reconcile_multi_party = sbool(reconcile_multi_party)
 
 	transaction: CustomBankTransaction = frappe.get_doc("Bank Transaction", bank_transaction_name)
+
+	for hook in frappe.get_hooks("get_payment_entries"):
+		vouchers = frappe.get_attr(hook)(transaction, vouchers, reconcile_multi_party) or vouchers
+
 	transaction.add_payment_entries(vouchers, reconcile_multi_party)
 	transaction.validate_duplicate_references()
 	transaction.allocate_payment_entries()

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -1,0 +1,311 @@
+"""Create Journal Entries and Payment Entries against unpaid vouchers."""
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import frappe
+from erpnext import get_default_cost_center
+from erpnext.accounts.doctype.payment_entry.payment_entry import (
+	get_payment_entry,
+	split_invoices_based_on_payment_terms,
+)
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import flt
+
+if TYPE_CHECKING:
+	from banking.overrides.bank_transaction import CustomBankTransaction
+
+DOCTYPE, DOCNAME, AMOUNT, PARTY = 0, 1, 2, 3
+
+
+def get_payment_entries(bt: "CustomBankTransaction", vouchers: list, reconcile_multi_party: bool = False):
+	"""Reconcile unpaid invoices with the Bank Transaction."""
+	if any(
+		voucher["payment_doctype"] not in ("Sales Invoice", "Purchase Invoice", "Expense Claim")
+		for voucher in vouchers
+	):
+		return
+
+	invoices_to_bill = []
+	for voucher in vouchers:
+		voucher_type, voucher_name = voucher["payment_doctype"], voucher["payment_name"]
+		if bt.is_duplicate_reference(voucher_type, voucher_name):
+			continue
+
+		outstanding_amount = get_outstanding_amount(voucher_type, voucher_name)
+		# Make PE against the unpaid invoice, link PE to Bank Transaction
+		invoices_to_bill.append((voucher_type, voucher_name, outstanding_amount, voucher.get("party")))
+
+	# Make single PE against multiple invoices
+	payments = []
+	if invoices_to_bill:
+		bt.validate_period_closing()
+		if reconcile_multi_party:
+			journal_entry = make_jv_against_invoices(bt, invoices_to_bill)
+			# payment_doctype, payment_name, amount
+			payments.append(
+				{
+					"payment_doctype": "Journal Entry",
+					"payment_name": journal_entry.name,
+					"amount": journal_entry.total_debit,
+				}
+			)
+		else:
+			payment_entry = make_pe_against_invoices(bt, invoices_to_bill)
+			payments.append(
+				{
+					"payment_doctype": "Payment Entry",
+					"payment_name": payment_entry.name,
+					"amount": payment_entry.paid_amount,
+				}
+			)
+
+	return payments
+
+
+def make_jv_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list):
+	"""Make Journal Entry against multiple invoices."""
+
+	def _attach_invoice(row: dict, journal_entry: "Document") -> None:
+		second_account = get_debtor_creditor_account(row)
+		second_account_currency = frappe.db.get_value("Account", second_account, "account_currency")
+		if second_account_currency != company_currency:
+			frappe.throw(
+				_(
+					"The currency of the second account ({0}) must be the same as of the bank account ({1})"
+				).format(second_account, company_currency)
+			)
+		journal_entry.append(
+			"accounts",
+			{
+				"account": second_account,
+				"credit_in_account_currency": row.allocated_amount if bt.deposit > 0 else 0.0,
+				"debit_in_account_currency": row.allocated_amount if bt.withdrawal > 0 else 0.0,
+				"party_type": row.get("party_type"),
+				"party": row.get("party"),
+				"cost_center": get_default_cost_center(company),
+				"reference_type": row.voucher_type,
+				"reference_name": row.voucher_no,
+			},
+		)
+
+	validate_invoices_to_bill(invoices_to_bill, allow_multi_party=True)
+
+	company_account = frappe.get_value("Bank Account", bt.bank_account, "account")
+	company, company_currency = frappe.get_value("Account", company_account, ["company", "account_currency"])
+
+	journal_entry = frappe.new_doc("Journal Entry")
+	journal_entry.voucher_type = "Bank Entry"
+	journal_entry.company = company
+	journal_entry.posting_date = bt.date
+	journal_entry.cheque_date = bt.date
+	journal_entry.cheque_no = bt.reference_number
+	journal_entry.title = bt.name
+	journal_entry.user_remark = bt.description
+
+	invoices = split_invoices_based_on_payment_terms(prepare_invoices_to_split(invoices_to_bill), bt.company)
+	adjust_and_allocate_invoices(bt, invoices, journal_entry, action=_attach_invoice)
+
+	total_allocated_amount = sum(row.allocated_amount for row in invoices)
+	journal_entry.append(
+		"accounts",
+		{
+			"account": company_account,
+			"bank_account": bt.bank_account,
+			"credit_in_account_currency": (total_allocated_amount if bt.withdrawal > 0 else 0.0),
+			"debit_in_account_currency": total_allocated_amount if bt.deposit > 0 else 0.0,
+			"cost_center": get_default_cost_center(company),
+		},
+	)
+
+	journal_entry.submit()
+	return journal_entry
+
+
+def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list):
+	"""Make Payment Entry against multiple invoices."""
+
+	def _attach_invoice(row: dict, payment_entry: "Document") -> None:
+		row.reference_doctype = row.voucher_type
+		row.reference_name = row.voucher_no
+		payment_entry.append("references", row)
+
+	validate_invoices_to_bill(invoices_to_bill)
+
+	bank_account = frappe.db.get_value("Bank Account", bt.bank_account, "account")
+	first_invoice = invoices_to_bill[0]
+	if first_invoice[DOCTYPE] == "Expense Claim":
+		from hrms.overrides.employee_payment_entry import get_payment_entry_for_employee
+
+		payment_entry = get_payment_entry_for_employee(
+			first_invoice[DOCTYPE],
+			first_invoice[DOCNAME],
+			party_amount=first_invoice[AMOUNT],
+			bank_account=bank_account,
+		)
+	else:
+		payment_entry = get_payment_entry(
+			first_invoice[DOCTYPE],
+			first_invoice[DOCNAME],
+			party_amount=first_invoice[AMOUNT],
+			bank_account=bank_account,
+			# make sure return invoice does not cause wrong payment type
+			# return SI against a deposit should be considered as "Receive" (discount)
+			# return SI against a withdrawal should be considered as "Pay" (refund)
+			payment_type="Receive" if bt.deposit > 0 else "Pay",
+		)
+	payment_entry.posting_date = bt.date
+	payment_entry.reference_no = bt.reference_number or first_invoice[DOCNAME]
+	payment_entry.reference_date = bt.date
+
+	# clear references to allocate invoices correctly with splits
+	payment_entry.references = []
+	invoices = split_invoices_based_on_payment_terms(prepare_invoices_to_split(invoices_to_bill), bt.company)
+	adjust_and_allocate_invoices(bt, invoices, payment_entry, action=_attach_invoice)
+
+	payment_entry.paid_amount = abs(
+		sum(row.allocated_amount for row in payment_entry.references)
+	)  # should not be negative
+	payment_entry.submit()
+	return payment_entry
+
+
+def prepare_invoices_to_split(invoices):
+	invoices_to_split = []
+	for invoice in invoices:
+		is_expense_claim = invoice[DOCTYPE] == "Expense Claim"
+		total_field = "grand_total" if is_expense_claim else "base_grand_total"
+		due_date_field = "posting_date" if is_expense_claim else "due_date"
+
+		invoice_data = frappe.db.get_value(
+			invoice[DOCTYPE],
+			invoice[DOCNAME],
+			[
+				"name as voucher_no",
+				"posting_date",
+				f"{total_field} as invoice_amount",
+				f"{due_date_field} as due_date",
+			],
+			as_dict=True,
+		)
+		invoice_data["outstanding_amount"] = invoice[AMOUNT]
+		invoice_data["voucher_type"] = invoice[DOCTYPE]
+		invoice_data["party"] = invoice[PARTY]
+		invoice_data["party_type"] = (
+			"Customer"
+			if invoice[DOCTYPE] == "Sales Invoice"
+			else "Supplier"
+			if invoice[DOCTYPE] == "Purchase Invoice"
+			else "Employee"
+		)
+		invoices_to_split.append(invoice_data)
+
+	return invoices_to_split
+
+
+def get_positive_and_negative_sums(bt_deposit: float, bt_unallocated: float, invoices: list):
+	"""
+	Calculate a permissible positive and negative upper limit sum for the allocation.
+	This will ensure that the allocated positive and negative amounts add up to the unallocated amount.
+	"""
+	sum_positive = (
+		sum(invoice.outstanding_amount for invoice in invoices if invoice.outstanding_amount > 0) or 0.0
+	)
+	sum_negative = (
+		abs(sum(invoice.outstanding_amount for invoice in invoices if invoice.outstanding_amount < 0)) or 0.0
+	)
+	validate_sums(bt_deposit, sum_positive, sum_negative, invoices)
+
+	# Adjust the positive sum (trim it) if overallocated
+	allocation = bt_unallocated - (sum_positive - sum_negative)
+	if allocation < 0:
+		sum_positive += allocation
+
+	return sum_positive, sum_negative
+
+
+def adjust_and_allocate_invoices(
+	bt: "CustomBankTransaction",
+	invoices: list,
+	payment_voucher: "Document",
+	action: Callable[[dict, Document], None],
+) -> None:
+	"""
+	Adjust and allocate the invoicees to the payment voucher based on
+	the unallocated amount.
+	The `payment_voucher` object is mutated by param:action.
+	"""
+	sum_postive, sum_negative = get_positive_and_negative_sums(bt.deposit, bt.unallocated_amount, invoices)
+	for row in invoices:
+		if row.outstanding_amount > 0:
+			if sum_postive <= 0:
+				continue
+			row_allocated_amount = min(row.outstanding_amount, sum_postive)
+			sum_postive -= row_allocated_amount
+		else:
+			if sum_negative <= 0:
+				continue
+			can_allocate = min(abs(row.outstanding_amount), sum_negative)
+			row_allocated_amount = -1 * can_allocate
+			sum_negative -= can_allocate
+
+		row.allocated_amount = row_allocated_amount
+		# Attach the invoice to/Mutate the payment voucher
+		action(row, payment_voucher)
+
+
+def validate_sums(bt_deposit: float, sum_positive, sum_negative, invoices):
+	"""Validate if the sum of positive and negative amounts is equal to the unallocated amount."""
+	if sum_positive and not sum_negative:
+		return
+
+	if sum_negative and not sum_positive:
+		# Only -ve invoices are allowed for opposite transactions
+		# Eg. A return SINV can be matched with a withdrawal (it is a refund)
+		invoice_doctype = "Sales Invoice" if bt_deposit > 0 else "Purchase Invoice"
+		if invoices[0]["voucher_type"] != invoice_doctype:
+			return
+
+	if sum_negative > sum_positive:
+		frappe.throw(
+			title=_("Overallocated Returns"),
+			msg=_("The allocated amount cannot be negative. Please adjust the selected return vouchers."),
+		)
+
+
+def validate_invoices_to_bill(invoices_to_bill: list, allow_multi_party: bool = False):
+	"""Validate if the invoices are of the same doctype and party."""
+	unique_doctypes = {invoice[DOCTYPE] for invoice in invoices_to_bill}
+	if len(unique_doctypes) > 1:
+		frappe.throw(frappe._("Cannot make Reconciliation Payment Entry against multiple doctypes"))
+
+	if allow_multi_party:
+		return
+
+	unique_parties = {invoice[PARTY] for invoice in invoices_to_bill}
+	if len(unique_parties) > 1:
+		frappe.throw(frappe._("Cannot make Reconciliation Payment Entry against multiple parties"))
+
+
+def get_debtor_creditor_account(invoice: dict) -> str | None:
+	"""Get the debtor or creditor (intermediate) account based on the invoice type."""
+	if invoice.get("voucher_type") == "Sales Invoice":
+		account_field = "debit_to"
+	elif invoice.get("voucher_type") == "Purchase Invoice":
+		account_field = "credit_to"
+	else:
+		account_field = "payable_account"
+	return frappe.db.get_value(invoice.get("voucher_type"), invoice.get("voucher_no"), account_field)
+
+
+def get_outstanding_amount(payment_doctype, payment_name) -> float:
+	if payment_doctype == "Expense Claim":
+		ec = frappe.get_doc(payment_doctype, payment_name)
+		return flt(
+			ec.total_sanctioned_amount - ec.total_amount_reimbursed,
+			ec.precision("total_sanctioned_amount"),
+		)
+
+	invoice = frappe.get_doc(payment_doctype, payment_name)
+	return flt(invoice.outstanding_amount, invoice.precision("outstanding_amount"))

--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -1,18 +1,8 @@
-from collections.abc import Callable
-
 import frappe
-from erpnext import get_default_cost_center
 from erpnext.accounts.doctype.bank_transaction.bank_transaction import BankTransaction
-from erpnext.accounts.doctype.payment_entry.payment_entry import (
-	get_payment_entry,
-	split_invoices_based_on_payment_terms,
-)
 from frappe import _
 from frappe.core.utils import find
-from frappe.model.document import Document
 from frappe.utils import flt, getdate
-
-DOCTYPE, DOCNAME, AMOUNT, PARTY = 0, 1, 2, 3
 
 
 class CustomBankTransaction(BankTransaction):
@@ -22,13 +12,7 @@ class CustomBankTransaction(BankTransaction):
 			frappe.throw(frappe._("Bank Transaction {0} is already fully reconciled").format(self.name))
 
 		pe_length_before = len(self.payment_entries)
-		unpaid_docs = ["Sales Invoice", "Purchase Invoice", "Expense Claim"]
-
-		# Vouchers can either all be paid or all be unpaid
-		if any(voucher["payment_doctype"] in unpaid_docs for voucher in vouchers):
-			self.reconcile_invoices(vouchers, reconcile_multi_party)
-		else:
-			self.reconcile_paid_vouchers(vouchers)
+		self.reconcile_paid_vouchers(vouchers)
 
 		if len(self.payment_entries) != pe_length_before:
 			self.save()  # runs on_update_after_submit
@@ -51,15 +35,6 @@ class CustomBankTransaction(BankTransaction):
 				).format(frappe.format(latest_period_close_date, "Date"))
 			)
 
-	def add_to_payment_entry(self, payment_doctype, payment_name):
-		"""Add the payment entry to the bank transaction"""
-		pe = {
-			"payment_document": payment_doctype,
-			"payment_entry": payment_name,
-			"allocated_amount": 0.0,  # Temporary
-		}
-		self.append("payment_entries", pe)
-
 	def reconcile_paid_vouchers(self, vouchers):
 		"""Reconcile paid vouchers with the Bank Transaction."""
 		for voucher in vouchers:
@@ -67,266 +42,14 @@ class CustomBankTransaction(BankTransaction):
 			if self.is_duplicate_reference(voucher_type, voucher_name):
 				continue
 
-			self.add_to_payment_entry(voucher["payment_doctype"], voucher["payment_name"])
-
-	def reconcile_invoices(self, vouchers: list, reconcile_multi_party: bool = False):
-		"""Reconcile unpaid invoices with the Bank Transaction."""
-		invoices_to_bill = []
-		for voucher in vouchers:
-			voucher_type, voucher_name = voucher["payment_doctype"], voucher["payment_name"]
-			if self.is_duplicate_reference(voucher_type, voucher_name):
-				continue
-
-			outstanding_amount = get_outstanding_amount(voucher_type, voucher_name)
-			if (
-				voucher_type
-				not in (
-					"Sales Invoice",
-					"Purchase Invoice",
-					"Expense Claim",
-				)
-				and outstanding_amount == 0.0
-			):
-				frappe.throw(_("Invalid Voucher Type"))
-
-			# Make PE against the unpaid invoice, link PE to Bank Transaction
-			invoices_to_bill.append((voucher_type, voucher_name, outstanding_amount, voucher.get("party")))
-
-		# Make single PE against multiple invoices
-		if invoices_to_bill:
-			self.validate_period_closing()
-			if reconcile_multi_party:
-				payment_name = self.make_jv_against_invoices(invoices_to_bill)
-			else:
-				payment_name = self.make_pe_against_invoices(invoices_to_bill)
-
-			self.add_to_payment_entry(
-				"Journal Entry" if reconcile_multi_party else "Payment Entry", payment_name
-			)
-
-	def make_jv_against_invoices(self, invoices_to_bill: list) -> str:
-		"""Make Journal Entry against multiple invoices."""
-
-		def _attach_invoice(row: dict, journal_entry: "Document") -> None:
-			second_account = get_debtor_creditor_account(row)
-			second_account_currency = frappe.db.get_value("Account", second_account, "account_currency")
-			if second_account_currency != company_currency:
-				frappe.throw(
-					_(
-						"The currency of the second account ({0}) must be the same as of the bank account ({1})"
-					).format(second_account, company_currency)
-				)
-			journal_entry.append(
-				"accounts",
+			self.append(
+				"payment_entries",
 				{
-					"account": second_account,
-					"credit_in_account_currency": row.allocated_amount if self.deposit > 0 else 0.0,
-					"debit_in_account_currency": row.allocated_amount if self.withdrawal > 0 else 0.0,
-					"party_type": row.get("party_type"),
-					"party": row.get("party"),
-					"cost_center": get_default_cost_center(company),
-					"reference_type": row.voucher_type,
-					"reference_name": row.voucher_no,
+					"payment_document": voucher["payment_doctype"],
+					"payment_entry": voucher["payment_name"],
+					"allocated_amount": 0.0,  # Temporary
 				},
 			)
-
-		self.validate_invoices_to_bill(invoices_to_bill, allow_multi_party=True)
-
-		company_account = frappe.get_value("Bank Account", self.bank_account, "account")
-		company, company_currency = frappe.get_value(
-			"Account", company_account, ["company", "account_currency"]
-		)
-
-		journal_entry = frappe.new_doc("Journal Entry")
-		journal_entry.voucher_type = "Bank Entry"
-		journal_entry.company = company
-		journal_entry.posting_date = self.date
-		journal_entry.cheque_date = self.date
-		journal_entry.cheque_no = self.reference_number
-		journal_entry.title = self.name
-		journal_entry.user_remark = self.description
-
-		invoices = split_invoices_based_on_payment_terms(
-			self.prepare_invoices_to_split(invoices_to_bill), self.company
-		)
-		self.adjust_and_allocate_invoices(invoices, journal_entry, action=_attach_invoice)
-
-		total_allocated_amount = sum(row.allocated_amount for row in invoices)
-		journal_entry.append(
-			"accounts",
-			{
-				"account": company_account,
-				"bank_account": self.bank_account,
-				"credit_in_account_currency": (total_allocated_amount if self.withdrawal > 0 else 0.0),
-				"debit_in_account_currency": total_allocated_amount if self.deposit > 0 else 0.0,
-				"cost_center": get_default_cost_center(company),
-			},
-		)
-
-		journal_entry.submit()
-		return journal_entry.name
-
-	def make_pe_against_invoices(self, invoices_to_bill: list) -> str:
-		"""Make Payment Entry against multiple invoices."""
-
-		def _attach_invoice(row: dict, payment_entry: "Document") -> None:
-			row.reference_doctype = row.voucher_type
-			row.reference_name = row.voucher_no
-			payment_entry.append("references", row)
-
-		self.validate_invoices_to_bill(invoices_to_bill)
-
-		bank_account = frappe.db.get_value("Bank Account", self.bank_account, "account")
-		first_invoice = invoices_to_bill[0]
-		if first_invoice[DOCTYPE] == "Expense Claim":
-			from hrms.overrides.employee_payment_entry import get_payment_entry_for_employee
-
-			payment_entry = get_payment_entry_for_employee(
-				first_invoice[DOCTYPE],
-				first_invoice[DOCNAME],
-				party_amount=first_invoice[AMOUNT],
-				bank_account=bank_account,
-			)
-		else:
-			payment_entry = get_payment_entry(
-				first_invoice[DOCTYPE],
-				first_invoice[DOCNAME],
-				party_amount=first_invoice[AMOUNT],
-				bank_account=bank_account,
-				# make sure return invoice does not cause wrong payment type
-				# return SI against a deposit should be considered as "Receive" (discount)
-				# return SI against a withdrawal should be considered as "Pay" (refund)
-				payment_type="Receive" if self.deposit > 0 else "Pay",
-			)
-		payment_entry.posting_date = self.date
-		payment_entry.reference_no = self.reference_number or first_invoice[DOCNAME]
-		payment_entry.reference_date = self.date
-
-		# clear references to allocate invoices correctly with splits
-		payment_entry.references = []
-		invoices = split_invoices_based_on_payment_terms(
-			self.prepare_invoices_to_split(invoices_to_bill), self.company
-		)
-		self.adjust_and_allocate_invoices(invoices, payment_entry, action=_attach_invoice)
-
-		payment_entry.paid_amount = abs(
-			sum(row.allocated_amount for row in payment_entry.references)
-		)  # should not be negative
-		payment_entry.submit()
-		return payment_entry.name
-
-	def prepare_invoices_to_split(self, invoices):
-		invoices_to_split = []
-		for invoice in invoices:
-			is_expense_claim = invoice[DOCTYPE] == "Expense Claim"
-			total_field = "grand_total" if is_expense_claim else "base_grand_total"
-			due_date_field = "posting_date" if is_expense_claim else "due_date"
-
-			invoice_data = frappe.db.get_value(
-				invoice[DOCTYPE],
-				invoice[DOCNAME],
-				[
-					"name as voucher_no",
-					"posting_date",
-					f"{total_field} as invoice_amount",
-					f"{due_date_field} as due_date",
-				],
-				as_dict=True,
-			)
-			invoice_data["outstanding_amount"] = invoice[AMOUNT]
-			invoice_data["voucher_type"] = invoice[DOCTYPE]
-			invoice_data["party"] = invoice[PARTY]
-			invoice_data["party_type"] = (
-				"Customer"
-				if invoice[DOCTYPE] == "Sales Invoice"
-				else "Supplier"
-				if invoice[DOCTYPE] == "Purchase Invoice"
-				else "Employee"
-			)
-			invoices_to_split.append(invoice_data)
-
-		return invoices_to_split
-
-	def get_positive_and_negative_sums(self, invoices):
-		"""
-		Calculate a permissible positive and negative upper limit sum for the allocation.
-		This will ensure that the allocated positive and negative amounts add up to the unallocated amount.
-		"""
-		sum_positive = (
-			sum(invoice.outstanding_amount for invoice in invoices if invoice.outstanding_amount > 0) or 0.0
-		)
-		sum_negative = (
-			abs(sum(invoice.outstanding_amount for invoice in invoices if invoice.outstanding_amount < 0))
-			or 0.0
-		)
-		self.validate_sums(sum_positive, sum_negative, invoices)
-
-		# Adjust the positive sum (trim it) if overallocated
-		allocation = self.unallocated_amount - (sum_positive - sum_negative)
-		if allocation < 0:
-			sum_positive += allocation
-
-		return sum_positive, sum_negative
-
-	def adjust_and_allocate_invoices(
-		self,
-		invoices: list,
-		payment_voucher: "Document",
-		action: Callable[[dict, Document], None],
-	) -> None:
-		"""
-		Adjust and allocate the invoicees to the payment voucher based on
-		the unallocated amount.
-		The `payment_voucher` object is mutated by param:action.
-		"""
-		sum_postive, sum_negative = self.get_positive_and_negative_sums(invoices)
-		for row in invoices:
-			if row.outstanding_amount > 0:
-				if sum_postive <= 0:
-					continue
-				row_allocated_amount = min(row.outstanding_amount, sum_postive)
-				sum_postive -= row_allocated_amount
-			else:
-				if sum_negative <= 0:
-					continue
-				can_allocate = min(abs(row.outstanding_amount), sum_negative)
-				row_allocated_amount = -1 * can_allocate
-				sum_negative -= can_allocate
-
-			row.allocated_amount = row_allocated_amount
-			# Attach the invoice to/Mutate the payment voucher
-			action(row, payment_voucher)
-
-	def validate_sums(self, sum_positive, sum_negative, invoices):
-		"""Validate if the sum of positive and negative amounts is equal to the unallocated amount."""
-		if sum_positive and not sum_negative:
-			return
-
-		if sum_negative and not sum_positive:
-			# Only -ve invoices are allowed for opposite transactions
-			# Eg. A return SINV can be matched with a withdrawal (it is a refund)
-			invoice_doctype = "Sales Invoice" if self.deposit > 0 else "Purchase Invoice"
-			if invoices[0]["voucher_type"] != invoice_doctype:
-				return
-
-		if sum_negative > sum_positive:
-			frappe.throw(
-				title=_("Overallocated Returns"),
-				msg=_("The allocated amount cannot be negative. Please adjust the selected return vouchers."),
-			)
-
-	def validate_invoices_to_bill(self, invoices_to_bill: list, allow_multi_party: bool = False):
-		"""Validate if the invoices are of the same doctype and party."""
-		unique_doctypes = {invoice[DOCTYPE] for invoice in invoices_to_bill}
-		if len(unique_doctypes) > 1:
-			frappe.throw(frappe._("Cannot make Reconciliation Payment Entry against multiple doctypes"))
-
-		if allow_multi_party:
-			return
-
-		unique_parties = {invoice[PARTY] for invoice in invoices_to_bill}
-		if len(unique_parties) > 1:
-			frappe.throw(frappe._("Cannot make Reconciliation Payment Entry against multiple parties"))
 
 	def is_duplicate_reference(self, voucher_type, voucher_name):
 		"""Check if the reference is already added to the Bank Transaction."""
@@ -334,32 +57,6 @@ class CustomBankTransaction(BankTransaction):
 			self.payment_entries,
 			lambda x: x.payment_document == voucher_type and x.payment_entry == voucher_name,
 		)
-
-
-def get_outstanding_amount(payment_doctype, payment_name) -> float:
-	if payment_doctype not in ("Sales Invoice", "Purchase Invoice", "Expense Claim"):
-		return 0.0
-
-	if payment_doctype == "Expense Claim":
-		ec = frappe.get_doc(payment_doctype, payment_name)
-		return flt(
-			ec.total_sanctioned_amount - ec.total_amount_reimbursed,
-			ec.precision("total_sanctioned_amount"),
-		)
-
-	invoice = frappe.get_doc(payment_doctype, payment_name)
-	return flt(invoice.outstanding_amount, invoice.precision("outstanding_amount"))
-
-
-def get_debtor_creditor_account(invoice: dict) -> str | None:
-	"""Get the debtor or creditor (intermediate) account based on the invoice type."""
-	if invoice.get("voucher_type") == "Sales Invoice":
-		account_field = "debit_to"
-	elif invoice.get("voucher_type") == "Purchase Invoice":
-		account_field = "credit_to"
-	else:
-		account_field = "payable_account"
-	return frappe.db.get_value(invoice.get("voucher_type"), invoice.get("voucher_no"), account_field)
 
 
 def on_update_after_submit(doc, event):

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -10,7 +10,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		this.panel_manager.actions_tab = "match_voucher-tab";
 
 		this.match_field_group = new frappe.ui.FieldGroup({
-			fields: this.get_match_tab_fields(),
+			fields: await this.get_match_tab_fields(),
 			body: this.actions_panel.$tab_content,
 			card_layout: true,
 		});
@@ -340,90 +340,32 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		);
 	}
 
-	get_match_tab_fields() {
+	async get_match_tab_fields() {
 		const filters_state = this.panel_manager.actions_filters;
+		const document_types = await frappe.xcall(
+			"erpnext.accounts.doctype.bank_transaction.bank_transaction.get_doctypes_for_bank_reconciliation"
+		);
+		const document_types_fields = [];
+		document_types.forEach((type, index) => {
+			document_types_fields.push({
+				label: __(type),
+				fieldname: frappe.scrub(type),
+				fieldtype: "Check",
+				default: filters_state[frappe.scrub(type)],
+				onchange: (e) => {
+					this.populate_matching_vouchers(e);
+				},
+			});
+
+			// Add column break after every 2 fields
+			if ((index + 1) % 2 === 0 && index !== document_types.length - 1) {
+				document_types_fields.push({
+					fieldtype: "Column Break",
+				});
+			}
+		});
 		return [
-			{
-				label: __("Payment Entry"),
-				fieldname: "payment_entry",
-				fieldtype: "Check",
-				default: filters_state.payment_entry,
-				onchange: (e) => {
-					this.populate_matching_vouchers(e);
-				},
-			},
-			{
-				label: __("Journal Entry"),
-				fieldname: "journal_entry",
-				fieldtype: "Check",
-				default: filters_state.journal_entry,
-				onchange: (e) => {
-					this.populate_matching_vouchers(e);
-				},
-			},
-			{
-				fieldtype: "Column Break",
-			},
-			{
-				label: __("Purchase Invoice"),
-				fieldname: "purchase_invoice",
-				fieldtype: "Check",
-				default: filters_state.purchase_invoice,
-				onchange: (e) => {
-					this.populate_matching_vouchers(e);
-				},
-			},
-			{
-				label: __("Sales Invoice"),
-				fieldname: "sales_invoice",
-				fieldtype: "Check",
-				default: filters_state.sales_invoice,
-				onchange: (e) => {
-					this.populate_matching_vouchers(e);
-				},
-			},
-			{
-				fieldtype: "Column Break",
-			},
-			{
-				label: __("Loan Repayment"),
-				fieldname: "loan_repayment",
-				fieldtype: "Check",
-				default: filters_state.loan_repayment,
-				onchange: (e) => {
-					this.populate_matching_vouchers(e);
-				},
-			},
-			{
-				label: __("Loan Disbursement"),
-				fieldname: "loan_disbursement",
-				fieldtype: "Check",
-				default: filters_state.loan_disbursement,
-				onchange: (e) => {
-					this.populate_matching_vouchers(e);
-				},
-			},
-			{
-				fieldtype: "Column Break",
-			},
-			{
-				label: __("Expense Claim"),
-				fieldname: "expense_claim",
-				fieldtype: "Check",
-				default: filters_state.expense_claim,
-				onchange: (e) => {
-					this.populate_matching_vouchers(e);
-				},
-			},
-			{
-				label: __("Bank Transaction"),
-				fieldname: "bank_transaction",
-				fieldtype: "Check",
-				default: filters_state.bank_transaction,
-				onchange: (e) => {
-					this.populate_matching_vouchers(e);
-				},
-			},
+			...document_types_fields,
 			{
 				fieldtype: "Section Break",
 			},


### PR DESCRIPTION
The hook `bank_reconciliation_doctypes` is used by ERPNext, HRMS and Lending to publish DocyTpes that are available for bank reconciliation. By considering values from this hook, we (1) offer only installed app's DocTypes and (2) make reconciliation extensible.

We introduce a second hook `get_payment_entries` that can be used to convert unpaid to paid vouchers before passing them to **Bank Transaction**. This reduces our customization of `BankTransaction` while also making this logic extensible by other apps, for their custom voucher DocTypes.

Todo:

- [x] add docs https://github.com/alyf-de/banking/wiki/Interaction-with-other-Apps#your-app
- [x] manual testing
- [x] update translations (after merge)
 
Ref: LKP-47