### PR TITLE
feat(Purchase Invoice): enable employee payments independent of Business Trip

### DIFF
--- a/banking/custom/purchase_invoice.py
+++ b/banking/custom/purchase_invoice.py
@@ -32,7 +32,6 @@ def make_sepa_payment_order(source_name: str, target_doc=None):
 		pi = source_parent
 		pay_to_employee = all(
 			(
-				hasattr(pi, "business_trip") and pi.business_trip,
 				hasattr(pi, "business_trip_employee") and pi.business_trip_employee,
 				hasattr(pi, "pay_to_employee") and pi.pay_to_employee,
 			)
@@ -93,7 +92,9 @@ def _get_employee_purpose(purchase_invoice: "PurchaseInvoice"):
 		for ref in [purchase_invoice.supplier_name, purchase_invoice.bill_no, purchase_invoice.bill_date]
 		if ref
 	)
-	return f"{invoice_reference} ({purchase_invoice.business_trip})".strip()
+	if purchase_invoice.business_trip:
+		invoice_reference += f" ({purchase_invoice.business_trip})"
+	return invoice_reference
 
 
 def _get_recipients_bank_account(purchase_invoice: "PurchaseInvoice", pay_to_employee: bool):

--- a/banking/custom/purchase_invoice.py
+++ b/banking/custom/purchase_invoice.py
@@ -94,7 +94,7 @@ def _get_employee_purpose(purchase_invoice: "PurchaseInvoice"):
 	)
 	if purchase_invoice.business_trip:
 		invoice_reference += f" ({purchase_invoice.business_trip})"
-	return invoice_reference
+	return invoice_reference.strip()
 
 
 def _get_recipients_bank_account(purchase_invoice: "PurchaseInvoice", pay_to_employee: bool):


### PR DESCRIPTION
With this PR: https://github.com/alyf-de/erpnext_germany/pull/91
Employee payments don't necessarily need to be linked to a **Business Trip**. 
Example: Employee paid for coffee for the office.