### PR TITLE
feat: redirect to Bank Reconciliation Tool Beta

### DIFF
--- a/banking/custom/bank_reconciliation_tool.js
+++ b/banking/custom/bank_reconciliation_tool.js
@@ -1,0 +1,19 @@
+frappe.ui.form.on("Bank Reconciliation Tool", {
+	refresh(frm) {
+		if (frm.no_banking_redirect) {
+			return;
+		}
+
+		frappe.confirm(
+			__("Did you mean {0}?", [
+				`<strong>${__("Bank Reconciliation Tool Beta")}</strong>`,
+			]),
+			() => {
+				frappe.set_route("Form", "Bank Reconciliation Tool Beta");
+			},
+			() => {
+				frm.no_banking_redirect = true;
+			}
+		);
+	},
+});

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -33,6 +33,7 @@ doctype_js = {
 	"Purchase Invoice": "custom/purchase_invoice.js",
 	"Employee": "custom/employee.js",
 	"Supplier": "custom/supplier.js",
+	"Bank Reconciliation Tool": "custom/bank_reconciliation_tool.js",
 }
 doctype_list_js = {"Purchase Invoice": "custom/purchase_invoice_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}


### PR DESCRIPTION
When a user accidentally opened the wrong tool, a popup offers to redirect to the right one. The "No" choice is remembered until the page is reloaded.