### PR TITLE
feat(Banking Settings): add MultiSelect "Voucher Matching Defaults"

### DIFF
--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js
@@ -2,6 +2,21 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Banking Settings", {
+	setup: (frm) => {
+		frm.trigger("set_voucher_matching_defaults_query");
+	},
+	set_voucher_matching_defaults_query: async (frm) => {
+		const document_types = await frappe.xcall(
+			"erpnext.accounts.doctype.bank_transaction.bank_transaction.get_doctypes_for_bank_reconciliation"
+		);
+		frm.set_query("voucher_matching_defaults", (doc) => {
+			return {
+				filters: {
+					name: ["in", document_types],
+				},
+			};
+		});
+	},
 	refresh: (frm) => {
 		if (frm.doc.enabled) {
 			frm.trigger("get_app_health");

--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.json
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.json
@@ -20,7 +20,8 @@
   "fintech_license_key",
   "bank_reconciliation_tab",
   "advanced_section",
-  "reference_fields"
+  "reference_fields",
+  "voucher_matching_defaults"
  ],
  "fields": [
   {
@@ -107,12 +108,20 @@
    "fieldname": "advanced_section",
    "fieldtype": "Section Break",
    "label": "Advanced"
+  },
+  {
+   "description": "These DocTypes are pre-enabled in the 'Match Voucher' tab.",
+   "fieldname": "voucher_matching_defaults",
+   "fieldtype": "Table MultiSelect",
+   "label": "Voucher Matching Defaults",
+   "options": "Voucher Matching Default"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-01-29 17:04:19.776579",
+ "modified": "2025-10-07 18:44:07.181312",
  "modified_by": "Administrator",
  "module": "Klarna Kosma Integration",
  "name": "Banking Settings",
@@ -129,6 +138,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
@@ -14,6 +14,32 @@ from banking.klarna_kosma_integration.admin import Admin
 
 
 class BankingSettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from banking.klarna_kosma_integration.doctype.banking_reference_mapping.banking_reference_mapping import (
+			BankingReferenceMapping,
+		)
+		from banking.klarna_kosma_integration.doctype.voucher_matching_default.voucher_matching_default import (
+			VoucherMatchingDefault,
+		)
+
+		admin_endpoint: DF.Data | None
+		api_token: DF.Password | None
+		customer_id: DF.Data | None
+		enable_ebics: DF.Check
+		enabled: DF.Check
+		fintech_license_key: DF.Password | None
+		fintech_licensee_name: DF.Data | None
+		reference_fields: DF.Table[BankingReferenceMapping]
+		voucher_matching_defaults: DF.TableMultiSelect[VoucherMatchingDefault]
+
+	# end: auto-generated types
 	def before_validate(self):
 		self.update_fintech_license()
 

--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
@@ -203,3 +203,14 @@ def get_latest_release_for_branch(owner: str, repo: str):
 	except Exception:
 		frappe.log_error(title=_("Banking Error"), message=_("Error while fetching releases"))
 		return None
+
+
+@frappe.whitelist()
+def get_doctypes_for_bank_reconciliation() -> dict[str, bool]:
+	"""Get Bank Reconciliation doctypes from all the apps and check if they are in the default doctypes"""
+	frappe.has_permission("Bank Reconciliation Tool Beta", throw=True)
+
+	all_doctypes = frappe.get_hooks("bank_reconciliation_doctypes")
+	settings: BankingSettings = frappe.get_single("Banking Settings")
+	default_doctypes = [row.document_type for row in settings.voucher_matching_defaults]
+	return {dt: dt in default_doctypes for dt in all_doctypes}

--- a/banking/klarna_kosma_integration/doctype/voucher_matching_default/voucher_matching_default.json
+++ b/banking/klarna_kosma_integration/doctype/voucher_matching_default/voucher_matching_default.json
@@ -1,0 +1,34 @@
+{
+ "actions": [],
+ "creation": "2025-10-07 18:41:09.722580",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "document_type"
+ ],
+ "fields": [
+  {
+   "fieldname": "document_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Document Type",
+   "options": "DocType",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-10-07 18:42:00.279989",
+ "modified_by": "Administrator",
+ "module": "Klarna Kosma Integration",
+ "name": "Voucher Matching Default",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/banking/klarna_kosma_integration/doctype/voucher_matching_default/voucher_matching_default.py
+++ b/banking/klarna_kosma_integration/doctype/voucher_matching_default/voucher_matching_default.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class VoucherMatchingDefault(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		document_type: DF.Link
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+	pass

--- a/banking/patches.txt
+++ b/banking/patches.txt
@@ -9,3 +9,4 @@ execute:frappe.delete_doc_if_exists("DocType", "Klarna Kosma Session")
 execute:frappe.delete_doc_if_exists("Custom Field", "Bank Account-kosma_account_id")
 execute:frappe.delete_doc_if_exists("Custom Field", "Bank Transaction-kosma_party_name")
 execute:from banking.install import insert_custom_records; insert_custom_records()
+banking.patches.set_voucher_matching_defaults

--- a/banking/patches/set_voucher_matching_defaults.py
+++ b/banking/patches/set_voucher_matching_defaults.py
@@ -1,0 +1,19 @@
+import frappe
+
+
+def execute():
+	"""Fill the new field _Voucher Matching Defaults_ in **Banking Settings** with the previously hardcoded defaults."""
+	banking_settings = frappe.get_single("Banking Settings")
+	if not banking_settings.voucher_matching_defaults:
+		banking_settings.extend(
+			"voucher_matching_defaults",
+			[
+				{
+					"document_type": "Sales Invoice",
+				},
+				{
+					"document_type": "Purchase Invoice",
+				},
+			],
+		)
+		banking_settings.save()

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -342,9 +342,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 
 	async get_match_tab_fields() {
 		const filters_state = this.panel_manager.actions_filters;
-		const document_types = await frappe.xcall(
-			"erpnext.accounts.doctype.bank_transaction.bank_transaction.get_doctypes_for_bank_reconciliation"
-		);
+		const document_types = Object.keys(this.panel_manager.document_types);
 		const document_types_fields = [];
 		document_types.forEach((type, index) => {
 			document_types_fields.push({

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -36,13 +36,13 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		this.actions_table.freeze();
 
 		let filter_fields = this.match_field_group.get_values();
-		let document_types = Object.keys(filter_fields).filter(
+		let new_filters = Object.keys(filter_fields).filter(
 			(field) => filter_fields[field] === 1
 		);
 
-		this.update_filters_in_state(document_types);
+		this.update_filters_in_state(new_filters);
 
-		let vouchers = await this.get_matching_vouchers(document_types);
+		let vouchers = await this.get_matching_vouchers(new_filters);
 		this.set_table_data(vouchers);
 		this.actions_table.unfreeze();
 
@@ -56,9 +56,9 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		);
 	}
 
-	update_filters_in_state(document_types) {
+	update_filters_in_state(new_filters) {
 		Object.keys(this.panel_manager.actions_filters).map((key) => {
-			let value = document_types.includes(key) ? 1 : 0;
+			let value = new_filters.includes(key) ? 1 : 0;
 			this.panel_manager.actions_filters[key] = value;
 		});
 	}

--- a/banking/public/js/bank_reconciliation_beta/panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/panel_manager.js
@@ -11,7 +11,15 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 	}
 
 	async init_panels() {
-		this.transactions = await this.get_bank_transactions();
+		const [transactions, document_types] = await Promise.all([
+			this.get_bank_transactions(),
+			frappe.xcall(
+				"banking.klarna_kosma_integration.doctype.banking_settings.banking_settings.get_doctypes_for_bank_reconciliation"
+			),
+		]);
+
+		this.transactions = transactions;
+		this.document_types = document_types;
 
 		this.$wrapper.empty();
 		this.$panel_wrapper = this.$wrapper
@@ -44,11 +52,10 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 	}
 
 	render_panels() {
-		this.set_actions_panel_default_states();
-
 		if (!this.transactions || !this.transactions.length) {
 			this.render_no_transactions();
 		} else {
+			this.set_actions_panel_default_states();
 			this.render_list_panel();
 
 			let first_transaction = this.transactions[0];
@@ -59,19 +66,15 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 	set_actions_panel_default_states() {
 		// Init actions panel states to store for persistent views
 		this.actions_tab = "match_voucher-tab";
-		this.actions_filters = {
-			payment_entry: 0,
-			journal_entry: 0,
-			purchase_invoice: 1,
-			sales_invoice: 1,
-			loan_repayment: 0,
-			loan_disbursement: 0,
-			expense_claim: 0,
-			bank_transaction: 0,
-			exact_match: 0,
-			exact_party_match: 0,
-			unpaid_invoices: 1,
-		};
+		this.actions_filters = Object.fromEntries(
+			Object.entries(this.document_types).map(([key, value]) => [
+				frappe.scrub(key),
+				value ? 1 : 0,
+			])
+		);
+		this.actions_filters.exact_match = 0;
+		this.actions_filters.exact_party_match = 0;
+		this.actions_filters.unpaid_invoices = 1;
 	}
 
 	render_no_transactions() {


### PR DESCRIPTION
This pull request introduces a new "Voucher Matching Defaults" feature to the banking integration, allowing administrators to configure which document types are pre-enabled in the bank reconciliation "Match Voucher" tab. It adds a new child DocType for these defaults, updates both backend and frontend logic to dynamically fetch and use these settings, and includes a patch to migrate existing hardcoded defaults to the new configuration.

**Voucher Matching Defaults Feature:**

- Added a new child DocType **Voucher Matching Default** and integrated it as a "Table MultiSelect" field in the **Banking Settings** DocType. This allows users to configure which document types are pre-enabled for voucher matching.
- Implemented backend logic to expose the configured voucher matching defaults via a new whitelisted method.
- Added a patch to populate the new _Voucher Matching Defaults_ field with previously hardcoded defaults (**Sales Invoice** and **Purchase Invoice**) during migration.

**Frontend/UX Updates:**

- Modified the **Banking Settings** form to filter for allowed voucher matching defaults.
- Refactored the bank reconciliation panel and match tab logic to initialize and use document types and their default states based on the new settings, replacing hardcoded values. 

**Misc**

- Updated the auto-generated type hints in `BankingSettings`.
- Renamed the `document_types` variable to `new_filters`  to accurately reflect that filters can contain settings apart from doctype, e.g. `exact_party_match`.

These changes make the voucher matching feature more configurable, allowing for better alignment with user requirements.

Ref: LKP-47