### PR TITLE
feat(Bank Reconciliation Tool): make bank account optional

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -57,6 +57,8 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 						method:
 							"banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank_reconciliation_tool_beta.auto_reconcile_vouchers",
 						args: {
+							company: frm.doc.company,
+							bank: frm.doc.bank,
 							bank_account: frm.doc.bank_account,
 							from_date: frm.doc.bank_statement_from_date,
 							to_date: frm.doc.bank_statement_to_date,

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -96,13 +96,6 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 	},
 
 	get_bank_transactions: function (frm) {
-		if (!frm.doc.bank_account) {
-			frappe.throw({
-				message: __("Please set the 'Bank Account' filter"),
-				title: __("Filter Required"),
-			});
-		}
-
 		frm.events.build_reconciliation_area(frm);
 	},
 
@@ -234,8 +227,6 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 	},
 
 	build_reconciliation_area: function (frm) {
-		if (!frm.doc.bank_account) return;
-
 		frappe.require("bank_reconciliation_beta.bundle.js", () => {
 			frm.panel_manager = new erpnext.accounts.bank_reconciliation.PanelManager(
 				{

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -142,11 +142,9 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 					});
 				}
 			);
-
-			frm.events.get_bank_transactions(frm);
-		} else {
-			frm.events.setup_empty_state(frm);
 		}
+
+		frm.events.get_bank_transactions(frm);
 	},
 
 	bank_statement_from_date: function (frm) {

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -127,6 +127,10 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 		});
 	},
 
+	company: function (frm) {
+		frm.events.get_bank_transactions(frm);
+	},
+
 	bank_account: function (frm) {
 		if (frm.doc.bank_account) {
 			frappe.db.get_value(

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -8,6 +8,7 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 				filters: {
 					company: doc.company,
 					is_company_account: 1,
+					bank: doc.bank,
 				},
 			};
 		});
@@ -128,6 +129,10 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 	},
 
 	company: function (frm) {
+		frm.events.get_bank_transactions(frm);
+	},
+
+	bank: function (frm) {
 		frm.events.get_bank_transactions(frm);
 	},
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -12,6 +12,16 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 				},
 			};
 		});
+
+		frm.set_query("bank", function (doc) {
+			return {
+				query:
+					"banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank_reconciliation_tool_beta.bank_query",
+				filters: {
+					company: doc.company,
+				},
+			};
+		});
 	},
 
 	onload: function (frm) {

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.json
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.json
@@ -40,8 +40,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Bank Account",
-   "options": "Bank Account",
-   "reqd": 1
+   "options": "Bank Account"
   },
   {
    "fieldname": "account_currency",
@@ -70,13 +69,13 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval: doc.bank_account && !doc.filter_by_reference_date",
+   "depends_on": "eval: !doc.filter_by_reference_date",
    "fieldname": "bank_statement_from_date",
    "fieldtype": "Date",
    "label": "From Date"
   },
   {
-   "depends_on": "eval: doc.bank_account && !doc.filter_by_reference_date",
+   "depends_on": "eval: !doc.filter_by_reference_date",
    "fieldname": "bank_statement_to_date",
    "fieldtype": "Date",
    "label": "To Date"
@@ -95,7 +94,6 @@
   },
   {
    "default": "0",
-   "depends_on": "bank_account",
    "fieldname": "filter_by_reference_date",
    "fieldtype": "Check",
    "label": "Filter by Reference Date"
@@ -113,11 +111,12 @@
    "fieldtype": "HTML"
   }
  ],
+ "grid_page_length": 50,
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-09-11 19:10:17.108955",
+ "modified": "2025-10-07 20:00:00.617187",
  "modified_by": "Administrator",
  "module": "Klarna Kosma Integration",
  "name": "Bank Reconciliation Tool Beta",
@@ -147,6 +146,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.json
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.json
@@ -8,6 +8,7 @@
  "field_order": [
   "filters_section",
   "company",
+  "bank",
   "bank_account",
   "account_currency",
   "account_opening_balance",
@@ -109,6 +110,12 @@
   {
    "fieldname": "reconciliation_action_area",
    "fieldtype": "HTML"
+  },
+  {
+   "fieldname": "bank",
+   "fieldtype": "Link",
+   "label": "Bank",
+   "options": "Bank"
   }
  ],
  "grid_page_length": 50,
@@ -116,7 +123,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-07 20:00:00.617187",
+ "modified": "2025-10-14 17:12:13.850366",
  "modified_by": "Administrator",
  "module": "Klarna Kosma Integration",
  "name": "Bank Reconciliation Tool Beta",

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -55,6 +55,7 @@ class BankReconciliationToolBeta(Document):
 
 @frappe.whitelist()
 def get_bank_transactions(
+	company: str | None = None,
 	bank_account: str | None = None,
 	from_date: str | datetime.date | None = None,
 	to_date: str | datetime.date | None = None,
@@ -72,6 +73,9 @@ def get_bank_transactions(
 
 	if from_date:
 		filters.append(["date", ">=", from_date])
+
+	if company:
+		filters.append(["company", "=", company])
 
 	return frappe.get_list(
 		"Bank Transaction",

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -450,12 +450,9 @@ def get_linked_payments(
 	transaction: CustomBankTransaction = frappe.get_doc("Bank Transaction", bank_transaction_name)
 	transaction.check_permission("read")
 
-	if transaction.bank_account:
-		gl_account, company = frappe.db.get_value(
-			"Bank Account", transaction.bank_account, ["account", "company"]
-		)
-	else:
-		gl_account, company = None, None
+	gl_account, company = frappe.db.get_value(
+		"Bank Account", transaction.bank_account, ["account", "company"]
+	)
 
 	if isinstance(document_types, str):
 		document_types = json.loads(document_types)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -361,7 +361,9 @@ def upload_bank_statement(**args):
 
 @frappe.whitelist()
 def auto_reconcile_vouchers(
-	bank_account: str,
+	company: str | None = None,
+	bank: str | None = None,
+	bank_account: str | None = None,
 	from_date: str | datetime.date | None = None,
 	to_date: str | datetime.date | None = None,
 	filter_by_reference_date: str | bool = False,
@@ -372,7 +374,9 @@ def auto_reconcile_vouchers(
 	frappe.flags.auto_reconcile_vouchers = True
 	reconciled, partially_reconciled = set(), set()
 
-	bank_transactions = get_bank_transactions(bank_account, from_date, to_date)
+	bank_transactions = get_bank_transactions(
+		company=company, bank=bank, bank_account=bank_account, from_date=from_date, to_date=to_date
+	)
 	for transaction in bank_transactions:
 		linked_payments = get_linked_payments(
 			transaction.name,

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -63,10 +63,14 @@ def get_bank_transactions(
 ):
 	"""Return bank transactions for a bank account"""
 	filters = [
-		["bank_account", "=", bank_account] if bank_account else ["bank_account", "is", "not set"],
 		["docstatus", "=", 1],
 		["unallocated_amount", ">", 0.001],
 	]
+
+	if bank_account:
+		filters.append(["bank_account", "=", bank_account])
+	else:
+		filters.append(["bank_account", "is", "not set"])
 
 	if to_date:
 		filters.append(["date", "<=", to_date])

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1439,3 +1439,21 @@ def get_invoice_function_map(document_types: list, is_deposit: bool):
 
 	# Return the ordered function map that has a function and is in the document types
 	return {doctype: fn_map[doctype] for doctype in order if (doctype in document_types and fn_map[doctype])}
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def bank_query(doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict):
+	filters = filters or {}
+	filters.update({"is_company_account": 1, "bank": ["like", f"%{txt}%"]})
+	if company := filters.get("company"):
+		filters.update({"company": company})
+
+	results = frappe.get_list(
+		"Bank Account",
+		filters=filters,
+		pluck="bank",
+		limit_start=start,
+		limit_page_length=page_len,
+	)
+	return [(result,) for result in results]

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -70,7 +70,7 @@ def get_bank_transactions(
 	if bank_account:
 		filters.append(["bank_account", "=", bank_account])
 	else:
-		filters.append(["bank_account", "is", "not set"])
+		filters.append(["bank_account", "is", "set"])
 
 	if to_date:
 		filters.append(["date", "<=", to_date])

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -41,6 +41,7 @@ class BankReconciliationToolBeta(Document):
 
 		account_currency: DF.Link | None
 		account_opening_balance: DF.Currency
+		bank: DF.Link | None
 		bank_account: DF.Link | None
 		bank_statement_closing_balance: DF.Currency
 		bank_statement_from_date: DF.Date | None
@@ -56,6 +57,7 @@ class BankReconciliationToolBeta(Document):
 @frappe.whitelist()
 def get_bank_transactions(
 	company: str | None = None,
+	bank: str | None = None,
 	bank_account: str | None = None,
 	from_date: str | datetime.date | None = None,
 	to_date: str | datetime.date | None = None,
@@ -80,6 +82,10 @@ def get_bank_transactions(
 
 	if company:
 		filters.append(["company", "=", company])
+
+	if bank:
+		bank_accounts = frappe.get_list("Bank Account", filters={"bank": bank}, pluck="name")
+		filters.append(["bank_account", "in", bank_accounts])
 
 	return frappe.get_list(
 		"Bank Transaction",

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -31,19 +31,38 @@ MAX_QUERY_RESULTS = 150
 
 
 class BankReconciliationToolBeta(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		account_currency: DF.Link | None
+		account_opening_balance: DF.Currency
+		bank_account: DF.Link | None
+		bank_statement_closing_balance: DF.Currency
+		bank_statement_from_date: DF.Date | None
+		bank_statement_to_date: DF.Date | None
+		company: DF.Link | None
+		filter_by_reference_date: DF.Check
+		from_reference_date: DF.Date | None
+		to_reference_date: DF.Date | None
+	# end: auto-generated types
 	pass
 
 
 @frappe.whitelist()
 def get_bank_transactions(
-	bank_account: str,
+	bank_account: str | None = None,
 	from_date: str | datetime.date | None = None,
 	to_date: str | datetime.date | None = None,
 	order_by: str | datetime.date | None = "date asc",
 ):
 	"""Return bank transactions for a bank account"""
 	filters = [
-		["bank_account", "=", bank_account],
+		["bank_account", "=", bank_account] if bank_account else ["bank_account", "is", "not set"],
 		["docstatus", "=", 1],
 		["unallocated_amount", ">", 0.001],
 	]
@@ -406,9 +425,12 @@ def get_linked_payments(
 	transaction: CustomBankTransaction = frappe.get_doc("Bank Transaction", bank_transaction_name)
 	transaction.check_permission("read")
 
-	gl_account, company = frappe.db.get_value(
-		"Bank Account", transaction.bank_account, ["account", "company"]
-	)
+	if transaction.bank_account:
+		gl_account, company = frappe.db.get_value(
+			"Bank Account", transaction.bank_account, ["account", "company"]
+		)
+	else:
+		gl_account, company = None, None
 
 	if isinstance(document_types, str):
 		document_types = json.loads(document_types)

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
@@ -30,8 +30,10 @@ erpnext.accounts.bank_reconciliation.ActionsPanelManager = class ActionsPanelMan
 				.find(".actions-panel");
 		}
 
+		// Reduce z-index from 5 to 3 so it doesn't overlap Link dropdowns from
+		// the filter area above.
 		this.$actions_container.append(`
-			<div class="form-tabs-list">
+			<div class="form-tabs-list" style="z-index: 3;">
 				<ul class="nav form-tabs" role="tablist" aria-label="Action Tabs">
 				</ul>
 			</div>

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
@@ -56,6 +56,7 @@ erpnext.accounts.bank_reconciliation.ActionsPanelManager = class ActionsPanelMan
 						actions_panel: this,
 						transaction: this.transaction,
 						panel_manager: this.panel_manager,
+						frm: this.frm,
 					});
 				},
 			},

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js
@@ -78,6 +78,15 @@ erpnext.accounts.bank_reconciliation.DetailsTab = class DetailsTab {
 				read_only: 1,
 			},
 			{
+				label: __("Bank Account"),
+				fieldname: "bank_account",
+				fieldtype: "Link",
+				options: "Bank Account",
+				default: this.transaction.bank_account,
+				read_only: 1,
+				hidden: this.frm.doc.bank_account ? 1 : 0,
+			},
+			{
 				label: __("Date"),
 				fieldname: "date",
 				fieldtype: "Date",

--- a/banking/public/js/bank_reconciliation_beta/panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/panel_manager.js
@@ -31,6 +31,7 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 				method:
 					"banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank_reconciliation_tool_beta.get_bank_transactions",
 				args: {
+					company: this.doc.company,
 					bank_account: this.doc.bank_account,
 					from_date: this.doc.bank_statement_from_date,
 					to_date: this.doc.bank_statement_to_date,

--- a/banking/public/js/bank_reconciliation_beta/panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/panel_manager.js
@@ -39,7 +39,8 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 				method:
 					"banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank_reconciliation_tool_beta.get_bank_transactions",
 				args: {
-          company: this.frm.doc.company,
+					company: this.frm.doc.company,
+					bank: this.frm.doc.bank,
 					bank_account: this.frm.doc.bank_account,
 					from_date: this.frm.doc.bank_statement_from_date,
 					to_date: this.frm.doc.bank_statement_to_date,


### PR DESCRIPTION
> We have 18 regular bank accounts and then another 3 "currency exchanges", each with 19 currencies. I would have to create 75 bank accounts (the accounts are already there) and then the accountant would have to regularly go through all the accounts and see if there is anything there.

Decision:

- You'll need to create all the necessary **Bank Accounts**.
- The burden on the accountant is lessened by making the _Bank Account_ filter optional. Instead, we rely on the existing _Company_ filter and a new _Bank_ filter.
- If the _Bank Account_ filter is not set, we show a _Bank Account_ field in the _Details_ tab, to maintain clarity regarding which account a transaction belongs to.

<details>
<summary>Outdated feature request</summary>

> I also wanted to use the Reconciliation Tool for “pseudo entries” (i.e., with my custom actions). A non-specific entry comes in and the accountant then has to post the exact entry. It may be that no bank account can be included because it is a different (non-bank) case.

Problems to solve:

- When matching unpaid vouchers or creating paid vouchers, we need an _Against Account_ (an **Account** of type "Bank") to create the corresponding **Payment Entry** or **Journal Entry**.
    -> Ask for this every time, or don't show these options in the first place?
- When matching paid vouchers we need an _Against Account_ (an **Account** of type "Bank") to find the matching vouchers. Otherwise we'd just have to show all of them.
- _Company_ is not a mandatory field in **Bank Transaction**. Add a **Property Setter**? [#50009](https://github.com/frappe/erpnext/pull/50009)

Decision: “Pseudo entries” Will not be supported. 

</details>

Ref: LKP-47