### PR TITLE
feat(EBICS User): separate settings for "Download Batch Transactions"

### DIFF
--- a/banking/ebics/doctype/ebics_user/ebics_user.json
+++ b/banking/ebics/doctype/ebics_user/ebics_user.json
@@ -13,8 +13,9 @@
   "company",
   "country",
   "bank",
-  "split_batch_transactions",
   "intraday_sync",
+  "download_batch_transactions",
+  "split_batch_transactions",
   "section_break_qjlc",
   "partner_id",
   "user_id",
@@ -152,6 +153,13 @@
    "label": "Protocol Version",
    "options": "H004\nH005",
    "read_only_depends_on": "initialized"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, <code>camt.054</code> files are downloaded and merged with <code>camt.052</code> or <code>camt.053</code> files.",
+   "fieldname": "download_batch_transactions",
+   "fieldtype": "Check",
+   "label": "Download Batch Transactions"
   }
  ],
  "links": [
@@ -160,7 +168,7 @@
    "link_fieldname": "ebics_user"
   }
  ],
- "modified": "2025-06-25 19:33:58.402007",
+ "modified": "2025-10-08 15:37:25.273496",
  "modified_by": "Administrator",
  "module": "EBICS",
  "name": "EBICS User",

--- a/banking/ebics/doctype/ebics_user/ebics_user.py
+++ b/banking/ebics/doctype/ebics_user/ebics_user.py
@@ -14,6 +14,32 @@ from banking.klarna_kosma_integration.admin import Admin
 
 
 class EBICSUser(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		bank: DF.Link | None
+		bank_keys_activated: DF.Check
+		company: DF.Link | None
+		country: DF.Link | None
+		download_batch_transactions: DF.Check
+		full_name: DF.Data | None
+		initialized: DF.Check
+		intraday_sync: DF.Check
+		keyring: DF.Code | None
+		needs_certificates: DF.Check
+		partner_id: DF.Data | None
+		passphrase: DF.Password | None
+		protocol_version: DF.Literal["H004", "H005"]
+		split_batch_transactions: DF.Check
+		start_date: DF.Date | None
+		user_id: DF.Data | None
+
+	# end: auto-generated types
 	def validate(self):
 		if self.country:
 			self.validate_country_code()

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -69,7 +69,7 @@ def sync_ebics_transactions(
 	permitted_types = manager.get_permitted_order_types()
 	validate_permitted_types(user, permitted_types, intraday)
 
-	with_c54 = user.split_batch_transactions and "C54" in permitted_types
+	with_c54 = user.download_batch_transactions and "C54" in permitted_types
 	request = log_request(
 		ebics_user,
 		"C52" if intraday else "C53",
@@ -172,11 +172,11 @@ def validate_permitted_types(user, permitted_types, intraday: bool):
 			reference_name=user.name,
 		)
 
-	if not intraday and user.split_batch_transactions and "C54" not in permitted_types:
+	if not intraday and user.download_batch_transactions and "C54" not in permitted_types:
 		frappe.log_error(
 			title=_("Banking Error"),
 			message=_(
-				"EBICS User {0} lacks permission 'C54' for splitting batch transactions. The permitted types are: {1}."
+				"EBICS User {0} lacks permission 'C54' for downloading batch transactions. The permitted types are: {1}."
 			).format(user.name, ", ".join(permitted_types)),
 			reference_doctype="EBICS User",
 			reference_name=user.name,

--- a/banking/patches.txt
+++ b/banking/patches.txt
@@ -10,3 +10,4 @@ execute:frappe.delete_doc_if_exists("Custom Field", "Bank Account-kosma_account_
 execute:frappe.delete_doc_if_exists("Custom Field", "Bank Transaction-kosma_party_name")
 execute:from banking.install import insert_custom_records; insert_custom_records()
 banking.patches.set_voucher_matching_defaults
+banking.patches.download_batch_transactions

--- a/banking/patches/download_batch_transactions.py
+++ b/banking/patches/download_batch_transactions.py
@@ -1,0 +1,10 @@
+import frappe
+
+
+def execute():
+	"""Enable _Download Batch Transactions_ checkbox for all EBICS Users that have _Split Batch Transactions_ enabled.
+
+	This is required in order to keep the same behavior after introducing this new setting.
+	"""
+	for user in frappe.get_all("EBICS User", filters={"split_batch_transactions": 1}, pluck="name"):
+		frappe.db.set_value("EBICS User", user, "download_batch_transactions", 1)


### PR DESCRIPTION

This pull request introduces a new _Download Batch Transactions_ option for **EBICS Users**, updates the related data model, and migrates existing users to preserve previous behavior. The changes also update the logic for handling batch transaction downloads and permissions, ensuring a smooth transition to the new setting.

**EBICS User model and settings changes:**

* Added a new `download_batch_transactions` checkbox field to the **EBICS User** doctype, allowing users to control whether `camt.054` files are downloaded and merged.
* Auto-generated type hints for the new and existing fields in the `EBICSUser` Python class. 

**Business logic updates:**

* Changed logic in `sync_ebics_transactions` and `validate_permitted_types` to use the new `download_batch_transactions` field instead of `split_batch_transactions` for handling batch transaction downloads and permission checks.

**Data migration and patches:**

* Added a patch (`banking/patches/download_batch_transactions.py`) to enable `download_batch_transactions` for all existing EBICS Users who previously had `split_batch_transactions` enabled, preserving their workflow.

Ref: DRC-158