### PR TITLE
feat(EBICS Request): "download files" button

### DIFF
--- a/banking/ebics/doctype/ebics_request/ebics_request.js
+++ b/banking/ebics/doctype/ebics_request/ebics_request.js
@@ -2,6 +2,18 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("EBICS Request", {
-	// refresh: function(frm) {
-	// }
+	refresh: function (frm) {
+		if (!frm.is_new() && frm.doc.response.includes("{")) {
+			frm.add_custom_button(__("Download response files"), () => {
+				frm.trigger("download_files");
+			});
+		}
+	},
+	download_files: function (frm) {
+		window.open(
+			`/api/method/banking.ebics.doctype.ebics_request.ebics_request.download_files?name=${encodeURIComponent(
+				frm.doc.name
+			)}`
+		);
+	},
 });

--- a/banking/ebics/doctype/ebics_request/ebics_request.py
+++ b/banking/ebics/doctype/ebics_request/ebics_request.py
@@ -50,7 +50,7 @@ def download_files(name: str):
 
 	try:
 		data = json.loads(doc.response)
-	except json.JSONDecodeError:
+	except (json.JSONDecodeError, TypeError):
 		frappe.throw(_("No data available for download."))
 
 	if not isinstance(data, dict):

--- a/banking/ebics/doctype/ebics_request/ebics_request.py
+++ b/banking/ebics/doctype/ebics_request/ebics_request.py
@@ -1,9 +1,44 @@
 # Copyright (c) 2025, ALYF GmbH and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class EBICSRequest(Document):
 	pass
+
+
+@frappe.whitelist()
+def download_files(name: str):
+	"""
+	Download the files from the EBICS Request as a zip file.
+
+	Args:
+		name: The name of the EBICS Request.
+	"""
+	import json
+	import zipfile
+	from io import BytesIO
+
+	from frappe import _
+
+	doc: EBICSRequest = frappe.get_doc("EBICS Request", name)
+	doc.check_permission()
+
+	try:
+		data = json.loads(doc.response)
+	except json.JSONDecodeError:
+		frappe.throw(_("No data available for download."))
+
+	zip_buffer = BytesIO()
+
+	zip_file = zipfile.ZipFile(zip_buffer, mode="w", compression=zipfile.ZIP_DEFLATED)
+	for file_name, file_data in data.items():
+		zip_file.writestr(file_name, file_data)
+
+	zip_file.close()
+
+	frappe.response["filecontent"] = zip_buffer.getvalue()
+	frappe.response["filename"] = f"{name}.zip"
+	frappe.response["type"] = "binary"

--- a/banking/ebics/doctype/ebics_request/ebics_request.py
+++ b/banking/ebics/doctype/ebics_request/ebics_request.py
@@ -33,11 +33,9 @@ def download_files(name: str):
 
 	zip_buffer = BytesIO()
 
-	zip_file = zipfile.ZipFile(zip_buffer, mode="w", compression=zipfile.ZIP_DEFLATED)
-	for file_name, file_data in data.items():
-		zip_file.writestr(file_name, file_data)
-
-	zip_file.close()
+	with zipfile.ZipFile(zip_buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+		for file_name, file_data in data.items():
+			zip_file.writestr(file_name, file_data)
 
 	frappe.response["filecontent"] = zip_buffer.getvalue()
 	frappe.response["filename"] = f"{name}.zip"

--- a/banking/ebics/doctype/ebics_request/ebics_request.py
+++ b/banking/ebics/doctype/ebics_request/ebics_request.py
@@ -31,6 +31,9 @@ def download_files(name: str):
 	except json.JSONDecodeError:
 		frappe.throw(_("No data available for download."))
 
+	if not isinstance(data, dict):
+		frappe.throw(_("Invalid data available for download."))
+
 	zip_buffer = BytesIO()
 
 	with zipfile.ZipFile(zip_buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zip_file:

--- a/banking/ebics/doctype/ebics_request/ebics_request.py
+++ b/banking/ebics/doctype/ebics_request/ebics_request.py
@@ -9,6 +9,28 @@ class EBICSRequest(Document):
 	pass
 
 
+def sanitize_filename(filename: str) -> str:
+	"""
+	Sanitize a filename for use in zip files by removing path components.
+
+	Args:
+		filename: The original filename from user input
+
+	Returns:
+		A sanitized filename that's safe to use
+	"""
+	from os.path import basename
+
+	if not filename or not isinstance(filename, str):
+		return "unnamed_file"
+
+	# Remove any path components to get just the basename
+	filename = basename(filename).strip()
+
+	# Fallback if filename becomes empty after sanitization
+	return filename or "unnamed_file"
+
+
 @frappe.whitelist()
 def download_files(name: str):
 	"""
@@ -38,7 +60,8 @@ def download_files(name: str):
 
 	with zipfile.ZipFile(zip_buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zip_file:
 		for file_name, file_data in data.items():
-			zip_file.writestr(file_name, file_data)
+			safe_filename = sanitize_filename(file_name)
+			zip_file.writestr(safe_filename, file_data)
 
 	frappe.response["filecontent"] = zip_buffer.getvalue()
 	frappe.response["filename"] = f"{name}.zip"


### PR DESCRIPTION
This pull request adds functionality to the **EBICS Request** form that allows users to download response files as a zip archive when available. The main changes include a new backend method for generating the zip file and frontend logic for displaying a download button and triggering the download.

**Frontend enhancements:**

* Added a "Download response files" button to the **EBICS Request** form, which appears if the document is not new and the `response` field contains JSON data. Clicking the button triggers the download of the response files.

**Backend implementation:**

* Introduced a new whitelisted Python method `download_files` in `ebics_request.py` that:
  * Checks user permissions,
  * Parses the JSON response,
  * Packages the files into a zip archive,
  * Returns the zip file as a binary response for download.