### PR TITLE
fix: add date rank for unpaid PI and SI

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1258,8 +1258,6 @@ def get_unpaid_pi_matching_query(
 
 	rank_expression = ref_rank + party_match + amount_rank + date_rank + name_match + ref_match + 1
 
-	# We skip date rank as the date of an unpaid bill is mostly
-	# earlier than the date of the bank transaction
 	query = (
 		frappe.qb.from_(purchase_invoice)
 		.select(

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1074,7 +1074,12 @@ def get_unpaid_si_matching_query(
 		else Cast(0, "int")
 	)
 
-	rank_expression = ref_rank + party_rank + amount_rank + name_match + ref_match + 1
+	date_condition = (sales_invoice.posting_date == common_filters.date) | (
+		sales_invoice.due_date == common_filters.date
+	)
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+
+	rank_expression = ref_rank + party_rank + amount_rank + date_rank + name_match + ref_match + 1
 
 	query = (
 		frappe.qb.from_(sales_invoice)
@@ -1092,6 +1097,7 @@ def get_unpaid_si_matching_query(
 			sales_invoice.currency,
 			party_rank.as_("party_match"),
 			amount_rank.as_("amount_match"),
+			date_rank.as_("date_match"),
 			name_match.as_("name_in_desc_match"),
 			(ref_match).as_("ref_in_desc_match"),
 			(ref_rank).as_("reference_number_match"),
@@ -1243,7 +1249,14 @@ def get_unpaid_pi_matching_query(
 		else Cast(0, "int")
 	)
 
-	rank_expression = ref_rank + party_match + amount_rank + name_match + ref_match + 1
+	date_condition = (
+		(purchase_invoice.posting_date == common_filters.date)
+		| (purchase_invoice.due_date == common_filters.date)
+		| (purchase_invoice.bill_date == common_filters.date)
+	)
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+
+	rank_expression = ref_rank + party_match + amount_rank + date_rank + name_match + ref_match + 1
 
 	# We skip date rank as the date of an unpaid bill is mostly
 	# earlier than the date of the bank transaction
@@ -1263,6 +1276,7 @@ def get_unpaid_pi_matching_query(
 			purchase_invoice.currency,
 			party_match.as_("party_match"),
 			amount_rank.as_("amount_match"),
+			date_rank.as_("date_match"),
 			name_match.as_("name_in_desc_match"),
 			ref_match.as_("ref_in_desc_match"),
 			ref_rank.as_("reference_number_match"),

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -586,7 +586,7 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(len(matched_vouchers), 2)
 		self.assertEqual(first_match["reference_no"], si.custom_ref_no)
 		self.assertEqual(first_match["name"], si.name)
-		self.assertEqual(first_match["rank"], 4)
+		self.assertEqual(first_match["rank"], 5)
 		self.assertEqual(first_match["ref_in_desc_match"], 1)
 		self.assertEqual(first_match["reference_number_match"], 1)
 		self.assertEqual(second_match["ref_in_desc_match"], 0)
@@ -594,7 +594,7 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		#  Check if ranking across another SI is correct
 		self.assertEqual(second_match["reference_no"], si2.custom_ref_no)
 		self.assertEqual(second_match["name"], si2.name)
-		self.assertEqual(second_match["rank"], 1)
+		self.assertEqual(second_match["rank"], 2)
 		self.assertEqual(second_match["ref_in_desc_match"], 0)
 
 	def test_no_configurable_reference_field(self):
@@ -629,7 +629,7 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(len(matched_vouchers), 1)
 		self.assertEqual(first_match["reference_no"], si.name)
 		self.assertEqual(first_match["name"], si.name)
-		self.assertEqual(first_match["rank"], 2)
+		self.assertEqual(first_match["rank"], 3)
 		self.assertEqual(first_match["amount_match"], 1)
 		self.assertEqual(first_match["ref_in_desc_match"], 0)
 


### PR DESCRIPTION
This might be slightly confusing, since we rank on multiple different date fields but show only one. Still, it should improve matching accuracy.

Resolves #237