### PR TITLE
feat(Bank Reconciliation Tool Beta): before_reconcile hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,14 @@ Use the extra values in the `get_payment_entries` hook:
 from banking.overrides.bank_transaction import CustomBankTransaction
 
 
-def get_payment_entries(bt: CustomBankTransaction, vouchers: list, reconcile_multi_party: bool = False, extra_params: dict | None = None, *args, **kwargs,):
+def get_payment_entries(
+	bt: CustomBankTransaction,
+	vouchers: list,
+	reconcile_multi_party: bool = False,
+	extra_params: dict | None = None,
+	*args,
+	**kwargs,
+):
 	"""Reconcile vouchers with the Bank Transaction.
 
 	Accepts a bank transaction and a list of (unpaid) vouchers to reconcile.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,55 @@ Install [via Frappe Cloud](https://frappecloud.com/marketplace/apps/banking) or 
 bench get-app https://github.com/alyf-de/banking.git
 bench --site <sitename> install-app banking
 ```
+
+## Customize
+
+Ask the user for extra values before reconciling:
+
+```js
+frappe.ui.form.on("Bank Reconciliation Tool Beta", {
+	before_reconcile: function (frm, transaction, selected_vouchers) {
+		return new Promise((resolve, reject) => {
+			frappe.prompt([
+				{
+					label: __("My Fieldname"),
+					fieldname: "my_fieldname",
+					fieldtype: "Data",
+				},
+			], (values) => {
+				// {my_fieldname: "My Value"}
+				resolve(values);
+			});
+		});
+	},
+});
+```
+
+Use the extra values in the `get_payment_entries` hook:
+
+```python
+from banking.overrides.bank_transaction import CustomBankTransaction
+
+
+def get_payment_entries(bt: CustomBankTransaction, vouchers: list, reconcile_multi_party: bool = False, extra_params: dict | None = None, *args, **kwargs,):
+	"""Reconcile vouchers with the Bank Transaction.
+
+	Accepts a bank transaction and a list of (unpaid) vouchers to reconcile.
+
+	Returns a list of (paid) vouchers to add to the bank transaction.
+	"""
+	assert extra_params["my_fieldname"] == "My Value"
+
+	return [
+		{
+			"payment_doctype": "Journal Entry",
+			"payment_name": "JE-123",
+			"amount": 100,
+		},
+		{
+			"payment_doctype": "Payment Entry",
+			"payment_name": "PE-123",
+			"amount": 100,
+		},
+	]
+```

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -267,7 +267,8 @@ def bulk_reconcile_vouchers(
 
 	for hook in frappe.get_hooks("get_payment_entries"):
 		vouchers = (
-			frappe.get_attr(hook)(transaction, vouchers, reconcile_multi_party, extra_params) or vouchers
+			frappe.get_attr(hook)(transaction, vouchers, reconcile_multi_party, extra_params=extra_params)
+			or vouchers
 		)
 
 	transaction.add_payment_entries(vouchers, reconcile_multi_party)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -247,7 +247,7 @@ def bulk_reconcile_vouchers(
 	bank_transaction_name: str,
 	vouchers: str | list[dict],
 	reconcile_multi_party: bool = False,
-	extra_params: dict | None = None,
+	extra_params: str | dict | None = None,
 ) -> "CustomBankTransaction":
 	"""
 	Reconcile multiple vouchers with a bank transaction.

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -247,6 +247,7 @@ def bulk_reconcile_vouchers(
 	bank_transaction_name: str,
 	vouchers: str | list[dict],
 	reconcile_multi_party: bool = False,
+	extra_params: dict | None = None,
 ) -> "CustomBankTransaction":
 	"""
 	Reconcile multiple vouchers with a bank transaction.
@@ -257,12 +258,17 @@ def bulk_reconcile_vouchers(
 	if isinstance(vouchers, str):
 		vouchers = json.loads(vouchers)
 
+	if isinstance(extra_params, str):
+		extra_params = json.loads(extra_params)
+
 	reconcile_multi_party = sbool(reconcile_multi_party)
 
 	transaction: CustomBankTransaction = frappe.get_doc("Bank Transaction", bank_transaction_name)
 
 	for hook in frappe.get_hooks("get_payment_entries"):
-		vouchers = frappe.get_attr(hook)(transaction, vouchers, reconcile_multi_party) or vouchers
+		vouchers = (
+			frappe.get_attr(hook)(transaction, vouchers, reconcile_multi_party, extra_params) or vouchers
+		)
 
 	transaction.add_payment_entries(vouchers, reconcile_multi_party)
 	transaction.validate_duplicate_references()

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -19,7 +19,13 @@ if TYPE_CHECKING:
 DOCTYPE, DOCNAME, AMOUNT, PARTY = 0, 1, 2, 3
 
 
-def get_payment_entries(bt: "CustomBankTransaction", vouchers: list, reconcile_multi_party: bool = False):
+def get_payment_entries(
+	bt: "CustomBankTransaction",
+	vouchers: list,
+	reconcile_multi_party: bool = False,
+	*args,
+	**kwargs,
+):
 	"""Reconcile unpaid invoices with the Bank Transaction."""
 	if any(
 		voucher["payment_doctype"] not in ("Sales Invoice", "Purchase Invoice", "Expense Claim")

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -20,7 +20,12 @@ DOCTYPE, DOCNAME, AMOUNT, PARTY = 0, 1, 2, 3
 
 
 def get_payment_entries(
-	bt: "CustomBankTransaction", vouchers: list, reconcile_multi_party: bool = False, *args, **kwargs
+	bt: "CustomBankTransaction",
+	vouchers: list,
+	reconcile_multi_party: bool = False,
+	extra_params: dict | None = None,
+	*args,
+	**kwargs,
 ):
 	"""Reconcile unpaid invoices with the Bank Transaction."""
 	if any(

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -20,11 +20,7 @@ DOCTYPE, DOCNAME, AMOUNT, PARTY = 0, 1, 2, 3
 
 
 def get_payment_entries(
-	bt: "CustomBankTransaction",
-	vouchers: list,
-	reconcile_multi_party: bool = False,
-	*args,
-	**kwargs,
+	bt: "CustomBankTransaction", vouchers: list, reconcile_multi_party: bool = False, *args, **kwargs
 ):
 	"""Reconcile unpaid invoices with the Bank Transaction."""
 	if any(

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -300,7 +300,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		);
 		let extra_params = {};
 		for (const handler of handlers.new_style) {
-			let result = await handler(this.transaction, selected_vouchers);
+			let result = await handler(this.frm, this.transaction, selected_vouchers);
 			if (result) {
 				extra_params = { ...extra_params, ...result };
 			}

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -257,7 +257,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		});
 	}
 
-	reconcile_selected_vouchers() {
+	async reconcile_selected_vouchers() {
 		const me = this;
 		let selected_vouchers = [];
 		let selected_map = this.actions_table.rowmanager.checkMap;
@@ -294,18 +294,34 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			return;
 		}
 
+		const handlers = await cur_frm.script_manager.get_handlers(
+			"before_reconcile",
+			"Bank Reconciliation Tool Beta"
+		);
+		let extra_params = {};
+		for (const handler of handlers.new_style) {
+			let result = await handler(this.transaction, selected_vouchers);
+			if (result) {
+				extra_params = { ...extra_params, ...result };
+			}
+		}
+
 		// If the vouchers have different parties prepare a prompt to reconcile multi-party
 		let parties = new Set(selected_vouchers.map((voucher) => voucher.party));
 		if (parties.size > 1) {
 			this.show_multiple_party_reconcile_prompt().then(() => {
-				this.bulk_reconcile_vouchers(selected_vouchers, true);
+				this.bulk_reconcile_vouchers(selected_vouchers, true, extra_params);
 			});
 		} else {
-			this.bulk_reconcile_vouchers(selected_vouchers, false);
+			this.bulk_reconcile_vouchers(selected_vouchers, false, extra_params);
 		}
 	}
 
-	bulk_reconcile_vouchers(selected_vouchers, reconcile_multi_party) {
+	bulk_reconcile_vouchers(
+		selected_vouchers,
+		reconcile_multi_party,
+		extra_params
+	) {
 		let me = this;
 		frappe.call({
 			method:
@@ -314,6 +330,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				bank_transaction_name: this.transaction.name,
 				vouchers: selected_vouchers,
 				reconcile_multi_party: reconcile_multi_party,
+				extra_params: extra_params,
 			},
 			freeze: true,
 			freeze_message: __("Reconciling ..."),

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -271,6 +271,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 					payment_name: row[this.position_of("Voucher")].content,
 					amount: this.get_amount_from_row(row),
 					party: row[this.position_of("Party")].content,
+					reference_no: row[this.position_of("Reference")].content,
 				});
 			}
 		});

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -294,7 +294,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			return;
 		}
 
-		const handlers = await cur_frm.script_manager.get_handlers(
+		const handlers = await this.frm.script_manager.get_handlers(
 			"before_reconcile",
 			"Bank Reconciliation Tool Beta"
 		);


### PR DESCRIPTION
This pull request introduces a mechanism to allow custom user input before reconciling bank vouchers and passes this extra data through the reconciliation process. The main changes enable frontend customization hooks, extend backend reconciliation logic to accept additional parameters, and update documentation with usage examples.

**Customization and Extensibility:**

* Added support for a `before_reconcile` hook in the frontend, allowing custom prompts to collect extra user input before reconciliation. The collected data (`extra_params`) is then passed through the reconciliation workflow. 
* Updated the backend reconciliation method `bulk_reconcile_vouchers` to accept and process the new `extra_params` argument.
* Modified the `get_payment_entries` hook signature to accept additional arguments, enabling custom logic based on the extra parameters provided by the frontend.

**Documentation:**

* Expanded the `README.md` with code samples for customizing the reconciliation process, including how to prompt the user for additional values and use them in backend hooks.
