### PR TITLE
refactor(Bank Reconciliation Tool Beta): Promise and frm

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -239,7 +239,7 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 		frappe.require("bank_reconciliation_beta.bundle.js", () => {
 			frm.panel_manager = new erpnext.accounts.bank_reconciliation.PanelManager(
 				{
-					doc: frm.doc,
+					frm: frm,
 					$wrapper: frm.$reconciliation_area,
 				}
 			);

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
@@ -67,7 +67,7 @@ erpnext.accounts.bank_reconciliation.ActionsPanelManager = class ActionsPanelMan
 						actions_panel: this,
 						transaction: this.transaction,
 						panel_manager: this.panel_manager,
-						doc: this.doc,
+						frm: this.frm,
 					});
 				},
 			},
@@ -79,7 +79,7 @@ erpnext.accounts.bank_reconciliation.ActionsPanelManager = class ActionsPanelMan
 						actions_panel: this,
 						transaction: this.transaction,
 						panel_manager: this.panel_manager,
-						company: this.doc.company,
+						company: this.frm.doc.company,
 					});
 				},
 			},

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -71,11 +71,11 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				args: {
 					bank_transaction_name: this.transaction.name,
 					document_types: document_types,
-					from_date: this.doc.bank_statement_from_date,
-					to_date: this.doc.bank_statement_to_date,
-					filter_by_reference_date: this.doc.filter_by_reference_date,
-					from_reference_date: this.doc.from_reference_date,
-					to_reference_date: this.doc.to_reference_date,
+					from_date: this.frm.doc.bank_statement_from_date,
+					to_date: this.frm.doc.bank_statement_to_date,
+					filter_by_reference_date: this.frm.doc.filter_by_reference_date,
+					from_reference_date: this.frm.doc.from_reference_date,
+					to_reference_date: this.frm.doc.to_reference_date,
 				},
 			})
 			.then((result) => result.message);

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -297,7 +297,9 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		// If the vouchers have different parties prepare a prompt to reconcile multi-party
 		let parties = new Set(selected_vouchers.map((voucher) => voucher.party));
 		if (parties.size > 1) {
-			this.show_multiple_party_reconcile_prompt(selected_vouchers);
+			this.show_multiple_party_reconcile_prompt().then(() => {
+				this.bulk_reconcile_vouchers(selected_vouchers, true);
+			});
 		} else {
 			this.bulk_reconcile_vouchers(selected_vouchers, false);
 		}
@@ -329,15 +331,20 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		});
 	}
 
-	show_multiple_party_reconcile_prompt(selected_vouchers) {
-		frappe.confirm(
-			__(
-				"Are you trying to reconcile vouchers of different parties? This action will reconcile vouchers using a Journal Entry."
-			),
-			() => {
-				this.bulk_reconcile_vouchers(selected_vouchers, true);
-			}
-		);
+	show_multiple_party_reconcile_prompt() {
+		return new Promise((resolve, reject) => {
+			frappe.confirm(
+				__(
+					"Are you trying to reconcile vouchers of different parties? This action will reconcile vouchers using a Journal Entry."
+				),
+				() => {
+					resolve();
+				},
+				() => {
+					reject();
+				}
+			);
+		});
 	}
 
 	async get_match_tab_fields() {

--- a/banking/public/js/bank_reconciliation_beta/panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/panel_manager.js
@@ -39,9 +39,9 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 				method:
 					"banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank_reconciliation_tool_beta.get_bank_transactions",
 				args: {
-					bank_account: this.doc.bank_account,
-					from_date: this.doc.bank_statement_from_date,
-					to_date: this.doc.bank_statement_to_date,
+					bank_account: this.frm.doc.bank_account,
+					from_date: this.frm.doc.bank_statement_from_date,
+					to_date: this.frm.doc.bank_statement_to_date,
 					order_by: this.order || "date asc",
 				},
 				freeze: true,
@@ -104,7 +104,7 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 			new erpnext.accounts.bank_reconciliation.ActionsPanelManager({
 				$wrapper: this.$panel_wrapper,
 				transaction: this.active_transaction,
-				doc: this.doc,
+				frm: this.frm,
 				panel_manager: this,
 			});
 	}


### PR DESCRIPTION
This pull request refactors the Bank Reconciliation Tool Beta's frontend code to consistently use the `frm` (form object) instead of directly passing or referencing the `doc` (document object). This change ensures better access to both the form and its underlying document, improving extensibility. Additionally, the logic for reconciling vouchers involving multiple parties has been updated to use a promise-based confirmation dialog, streamlining asynchronous handling.

**Refactoring to use `frm` instead of `doc`:**

* Updated the initialization of `PanelManager` in `bank_reconciliation_tool_beta.js` to pass the `frm` object instead of just `doc`.
* Modified `ActionsPanelManager` and its instantiations to use `frm` for accessing document data, replacing all references to `doc` with `frm.doc` for properties like `company`.
* Updated `MatchTab` and `PanelManager` classes to consistently reference document fields via `this.frm.doc` instead of `this.doc`, ensuring all field accesses are through the form object.

**Improvements to multi-party reconciliation logic:**

* Refactored the multi-party voucher reconciliation prompt to use a promise-based `show_multiple_party_reconcile_prompt` method, allowing for cleaner asynchronous handling and ensuring `bulk_reconcile_vouchers` is only called after user confirmation. 