### PR TITLE
fix: swiss order types, refactor EBICS download

### DIFF
--- a/banking/ebics/manager.py
+++ b/banking/ebics/manager.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -6,6 +7,17 @@ if TYPE_CHECKING:
 	from fintech.ebics import (
 		EbicsClient,
 	)
+
+
+@dataclass
+class EbicsRequest:
+	"""Parameters for an EBICS download request."""
+
+	order_type: str  # e.g., "C52", "Z53", "C54"
+	camt_msg: str  # e.g., "camt.052", "camt.053", "camt.054"
+	service: str  # "STM" for statements, "EOP" for end-of-period
+	start_date: str | None = None
+	end_date: str | None = None
 
 
 class EBICSManager:
@@ -91,8 +103,11 @@ class EBICSManager:
 
 		return level_perms
 
-	def download_c52(self, start_date: str | None = None, end_date: str | None = None) -> dict:
-		"""Download Bank to Customer Account Reports (camt.052) - Intraday statements.
+	def download(self, request: EbicsRequest) -> dict:
+		"""Execute an EBICS download request.
+
+		Args:
+			request: EbicsRequest containing order type and parameters
 
 		Returns:
 			dict: The downloaded files.
@@ -100,68 +115,17 @@ class EBICSManager:
 		client = self.get_client()
 
 		if client.version != "H005":
-			if self.country_code == "CH":
-				return client.Z52(start_date, end_date)
-
-			return client.C52(start_date, end_date)
+			return client.download(request.order_type, request.start_date, request.end_date)
 
 		from fintech.ebics import BusinessTransactionFormat
 
-		c52_btf = BusinessTransactionFormat(
-			service="STM",  # Statement service
-			msg_name="camt.052",
+		btf = BusinessTransactionFormat(
+			service=request.service,
+			msg_name=request.camt_msg,
 			scope=self.country_code,
 			container="ZIP",
 		)
-		return client.BTD(c52_btf, start_date, end_date)
-
-	def download_c53(self, start_date: str | None = None, end_date: str | None = None) -> dict:
-		"""Download Bank to Customer Statements (camt.053) - End of period statements.
-
-		Returns:
-			dict: The downloaded files.
-		"""
-		client = self.get_client()
-
-		if client.version != "H005":
-			if self.country_code == "CH":
-				return client.Z53(start_date, end_date)
-
-			return client.C53(start_date, end_date)
-
-		from fintech.ebics import BusinessTransactionFormat
-
-		c53_btf = BusinessTransactionFormat(
-			service="EOP",  # End of Period service
-			msg_name="camt.053",
-			scope=self.country_code,
-			container="ZIP",
-		)
-		return client.BTD(c53_btf, start_date, end_date)
-
-	def download_c54(self, start_date: str | None = None, end_date: str | None = None) -> dict:
-		"""Download Bank to Customer Debit Credit Notifications (camt.054) - Batch transaction details.
-
-		Returns:
-			dict: The downloaded files.
-		"""
-		client = self.get_client()
-
-		if client.version != "H005":
-			if self.country_code == "CH":
-				return client.Z54(start_date, end_date)
-
-			return client.C54(start_date, end_date)
-
-		from fintech.ebics import BusinessTransactionFormat
-
-		c54_btf = BusinessTransactionFormat(
-			service="STM",  # Statement service
-			msg_name="camt.054",
-			scope=self.country_code,
-			container="ZIP",
-		)
-		return client.BTD(c54_btf, start_date, end_date)
+		return client.BTD(btf, request.start_date, request.end_date)
 
 	def confirm_download(self, success: bool = True):
 		"""Confirm the receipt of previously executed downloads.

--- a/banking/ebics/manager.py
+++ b/banking/ebics/manager.py
@@ -95,7 +95,16 @@ class EBICSManager:
 		# Collect all order types for the specified level
 		level_perms = []
 		for permission in permissions:
-			if permission.get("@AuthorisationLevel", level) == level:
+			if self.protocol_version == "H005":
+				if permission.get("AdminOrderType") == "BTD":
+					level_perms.append(
+						(
+							"BTD",
+							permission.get("Service", {}).get("ServiceName"),
+							permission.get("Service", {}).get("MsgName"),
+						)
+					)
+			elif permission.get("@AuthorisationLevel", level) == level:
 				order_types = permission.get("OrderTypes")
 				if isinstance(order_types, str):
 					# Split if it's a space-separated string

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -108,8 +108,7 @@ def execute_ebics_download(
 			("BTD", ebics_request.service, ebics_request.camt_msg),
 		)
 
-	# Log the request
-	request = log_request(
+	request_log = log_request(
 		ebics_user,
 		ebics_request.order_type,
 		requested_by,
@@ -122,7 +121,7 @@ def execute_ebics_download(
 	try:
 		xml_files = manager.download(ebics_request)
 
-		request.db_set(
+		request_log.db_set(
 			{
 				"status": "Successful",
 				"response": json.dumps(
@@ -133,9 +132,9 @@ def execute_ebics_download(
 		)
 		return xml_files
 	except fintech.ebics.EbicsNoDataAvailable:
-		request.db_set({"status": "Successful", "response": "No Data Available"})
+		request_log.db_set({"status": "Successful", "response": "No Data Available"})
 	except Exception as e:
-		request.db_set({"status": "Failed", "response": str(e)})
+		request_log.db_set({"status": "Failed", "response": str(e)})
 		frappe.log_error(
 			title=_("Banking Error"),
 			reference_doctype="EBICS User",

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -79,6 +79,74 @@ def get_request_map(country_code: str, start_date: str, end_date: str):
 	}
 
 
+def execute_ebics_download(
+	manager: EBICSManager,
+	ebics_user: str,
+	ebics_request: EbicsRequest,
+	requested_by: Literal["User", "System"],
+) -> dict | None:
+	"""Execute a single EBICS download request with logging and error handling.
+
+	Args:
+		manager: The EBICS manager instance
+		ebics_user: The EBICS User name
+		ebics_request: The request to execute
+		requested_by: Who initiated the request
+
+	Returns:
+		dict: The downloaded XML files, or None if failed or no data available
+	"""
+	permitted_types = manager.get_permitted_order_types()
+
+	# Validate permissions based on protocol version
+	if manager.protocol_version == "H004":
+		validated_perms(ebics_user, permitted_types, ebics_request.order_type)
+	elif manager.protocol_version == "H005":
+		validated_perms(
+			ebics_user,
+			permitted_types,
+			("BTD", ebics_request.service, ebics_request.camt_msg),
+		)
+
+	# Log the request
+	request = log_request(
+		ebics_user,
+		ebics_request.order_type,
+		requested_by,
+		{
+			"start_date": ebics_request.start_date,
+			"end_date": ebics_request.end_date,
+		},
+	)
+
+	try:
+		xml_files = manager.download(ebics_request)
+
+		request.db_set(
+			{
+				"status": "Successful",
+				"response": json.dumps(
+					{file_name: file.decode() for file_name, file in xml_files.items()},
+					indent=2,
+				),
+			}
+		)
+		return xml_files
+
+	except fintech.ebics.EbicsNoDataAvailable:
+		request.db_set({"status": "Successful", "response": "No Data Available"})
+		return None
+
+	except Exception as e:
+		request.db_set({"status": "Failed", "response": str(e)})
+		frappe.log_error(
+			title=_("Banking Error"),
+			reference_doctype="EBICS User",
+			reference_name=ebics_user,
+		)
+		return None
+
+
 def sync_ebics_transactions(
 	ebics_user: str,
 	requested_by: Literal["User", "System"],
@@ -97,58 +165,19 @@ def sync_ebics_transactions(
 	request_map = get_request_map(manager.country_code, start_date, end_date)
 	main_request = request_map["intraday"] if intraday else request_map["statement"]
 
-	request = log_request(
-		ebics_user,
-		main_request.order_type,
-		requested_by,
-		{
-			"start_date": start_date,
-			"end_date": end_date,
-		},
-	)
-
-	permitted_types = manager.get_permitted_order_types()
-	main_xml, batch_xml = None, None
-	try:
-		if manager.protocol_version == "H004":
-			# TODO: implement logic for H004
-			validated_perms(user.name, permitted_types, main_request.order_type)
-		elif manager.protocol_version == "H005":
-			validated_perms(user.name, permitted_types, ("BTD", main_request.service, main_request.camt_msg))
-		main_xml = manager.download(main_request)
-
-		if user.download_batch_transactions:
-			batch_request = request_map["batch"]
-			if manager.protocol_version == "H004":
-				validated_perms(user.name, permitted_types, batch_request.order_type)
-			elif manager.protocol_version == "H005":
-				validated_perms(
-					user.name, permitted_types, ("BTD", batch_request.service, batch_request.camt_msg)
-				)
-			batch_xml = manager.download(batch_request)
-
-		request.db_set(
-			{
-				"status": "Successful",
-				"response": json.dumps(
-					{file_name: file.decode() for file_name, file in main_xml.items()},
-					indent=2,
-				),
-			}
-		)
-	except fintech.ebics.EbicsNoDataAvailable:
-		request.db_set({"status": "Successful", "response": "No Data Available"})
-		return
-	except Exception as e:
-		request.db_set({"status": "Failed", "response": str(e)})
-		frappe.log_error(
-			title=_("Banking Error"),
-			reference_doctype="EBICS User",
-			reference_name=ebics_user,
-		)
+	# Download main statements
+	main_xml = execute_ebics_download(manager, user.name, main_request, requested_by)
+	if not main_xml:
 		return
 
-	# Keep the request log, no matter what happens next.
+	# Download batch transactions if enabled
+	batch_xml = None
+	if user.download_batch_transactions:
+		batch_request = request_map["batch"]
+		batch_xml = execute_ebics_download(manager, user.name, batch_request, requested_by)
+		# Continue even if batch download fails - main_xml is what matters
+
+	# Keep the request logs, no matter what happens next.
 	frappe.db.commit()
 
 	# We want to process either all documents or none. If we fail to process one, we
@@ -177,8 +206,8 @@ def sync_ebics_transactions(
 		frappe.db.rollback()
 		frappe.log_error(
 			title=_("Banking Error"),
-			reference_doctype="EBICS Request",
-			reference_name=request.name,
+			reference_doctype="EBICS User",
+			reference_name=user.name,
 		)
 		manager.confirm_download(success=False)
 		return

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -132,11 +132,8 @@ def execute_ebics_download(
 			}
 		)
 		return xml_files
-
 	except fintech.ebics.EbicsNoDataAvailable:
 		request.db_set({"status": "Successful", "response": "No Data Available"})
-		return None
-
 	except Exception as e:
 		request.db_set({"status": "Failed", "response": str(e)})
 		frappe.log_error(
@@ -144,7 +141,8 @@ def execute_ebics_download(
 			reference_doctype="EBICS User",
 			reference_name=ebics_user,
 		)
-		return None
+
+	return None
 
 
 def sync_ebics_transactions(

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -69,7 +69,6 @@ def sync_ebics_transactions(
 	permitted_types = manager.get_permitted_order_types()
 	validate_permitted_types(user, permitted_types, intraday)
 
-	with_c54 = user.download_batch_transactions and set(permitted_types).intersection({"C54", "Z54"})
 	request = log_request(
 		ebics_user,
 		("Z52" if manager.country_code == "CH" else "C52")
@@ -89,7 +88,7 @@ def sync_ebics_transactions(
 		else:
 			main_xml = manager.download_c53(start_date, end_date)
 
-		if with_c54:
+		if user.download_batch_transactions:
 			batch_xml = manager.download_c54(start_date, end_date)
 
 		request.db_set(
@@ -174,11 +173,7 @@ def validate_permitted_types(user, permitted_types, intraday: bool):
 			reference_name=user.name,
 		)
 
-	if (
-		not intraday
-		and user.download_batch_transactions
-		and not set(permitted_types).intersection({"C54", "Z54"})
-	):
+	if user.download_batch_transactions and not set(permitted_types).intersection({"C54", "Z54"}):
 		frappe.log_error(
 			title=_("Banking Error"),
 			message=_(

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -84,6 +84,7 @@ def execute_ebics_download(
 	ebics_user: str,
 	ebics_request: EbicsRequest,
 	requested_by: Literal["User", "System"],
+	permitted_types: list[str],
 ) -> dict | None:
 	"""Execute a single EBICS download request with logging and error handling.
 
@@ -92,13 +93,11 @@ def execute_ebics_download(
 		ebics_user: The EBICS User name
 		ebics_request: The request to execute
 		requested_by: Who initiated the request
+		permitted_types: List of permitted order types for validation
 
 	Returns:
 		dict: The downloaded XML files, or None if failed or no data available
 	"""
-	permitted_types = manager.get_permitted_order_types()
-
-	# Validate permissions based on protocol version
 	if manager.protocol_version == "H004":
 		validated_perms(ebics_user, permitted_types, ebics_request.order_type)
 	elif manager.protocol_version == "H005":
@@ -162,8 +161,11 @@ def sync_ebics_transactions(
 	request_map = get_request_map(manager.country_code, start_date, end_date)
 	main_request = request_map["intraday"] if intraday else request_map["statement"]
 
+	# Get permitted types once - they don't change across downloads
+	permitted_types = manager.get_permitted_order_types()
+
 	# Download main statements
-	main_xml = execute_ebics_download(manager, user.name, main_request, requested_by)
+	main_xml = execute_ebics_download(manager, user.name, main_request, requested_by, permitted_types)
 	if not main_xml:
 		return
 
@@ -171,7 +173,7 @@ def sync_ebics_transactions(
 	batch_xml = None
 	if user.download_batch_transactions:
 		batch_request = request_map["batch"]
-		batch_xml = execute_ebics_download(manager, user.name, batch_request, requested_by)
+		batch_xml = execute_ebics_download(manager, user.name, batch_request, requested_by, permitted_types)
 		# Continue even if batch download fails - main_xml is what matters
 
 	# Keep the request logs, no matter what happens next.

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -69,10 +69,12 @@ def sync_ebics_transactions(
 	permitted_types = manager.get_permitted_order_types()
 	validate_permitted_types(user, permitted_types, intraday)
 
-	with_c54 = user.download_batch_transactions and "C54" in permitted_types
+	with_c54 = user.download_batch_transactions and set(permitted_types).intersection({"C54", "Z54"})
 	request = log_request(
 		ebics_user,
-		"C52" if intraday else "C53",
+		("Z52" if manager.country_code == "CH" else "C52")
+		if intraday
+		else ("Z53" if manager.country_code == "CH" else "C53"),
 		requested_by,
 		{
 			"start_date": start_date,
@@ -152,7 +154,7 @@ def sync_ebics_transactions(
 def validate_permitted_types(user, permitted_types, intraday: bool):
 	# Not sure yet, how reliable permitted types are. For now, we just log an error
 	# instead of raising an exception or returning.
-	if intraday and "C52" not in permitted_types:
+	if intraday and not set(permitted_types).intersection({"C52", "Z52"}):
 		frappe.log_error(
 			title=_("Banking Error"),
 			message=_(
@@ -162,7 +164,7 @@ def validate_permitted_types(user, permitted_types, intraday: bool):
 			reference_name=user.name,
 		)
 
-	if not intraday and "C53" not in permitted_types:
+	if not intraday and not set(permitted_types).intersection({"C53", "Z53"}):
 		frappe.log_error(
 			title=_("Banking Error"),
 			message=_(
@@ -172,7 +174,11 @@ def validate_permitted_types(user, permitted_types, intraday: bool):
 			reference_name=user.name,
 		)
 
-	if not intraday and user.download_batch_transactions and "C54" not in permitted_types:
+	if (
+		not intraday
+		and user.download_batch_transactions
+		and not set(permitted_types).intersection({"C54", "Z54"})
+	):
 		frappe.log_error(
 			title=_("Banking Error"),
 			message=_(

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _
 from frappe.utils.data import get_link_to_form
 
-from banking.ebics.manager import EBICSManager
+from banking.ebics.manager import EBICSManager, EbicsRequest
 from banking.ebics.types import MT940Statement, MT940Transaction
 
 if TYPE_CHECKING:
@@ -51,13 +51,31 @@ def get_ebics_manager(
 	return manager
 
 
-def get_order_types(country_code: str):
-	"""Get order types for the given country. Switzerland uses Z-types, others use C-types."""
+def get_request_map(country_code: str, start_date: str, end_date: str):
+	"""Get EbicsRequest for the given country. Switzerland uses Z-types, others use C-types."""
 	prefix = "Z" if country_code == "CH" else "C"
 	return {
-		"intraday": f"{prefix}52",
-		"statement": f"{prefix}53",
-		"batch": f"{prefix}54",
+		"intraday": EbicsRequest(
+			order_type=f"{prefix}52",
+			camt_msg="camt.052",
+			service="STM",
+			start_date=start_date,
+			end_date=end_date,
+		),
+		"statement": EbicsRequest(
+			order_type=f"{prefix}53",
+			camt_msg="camt.053",
+			service="EOP",
+			start_date=start_date,
+			end_date=end_date,
+		),
+		"batch": EbicsRequest(
+			order_type=f"{prefix}54",
+			camt_msg="camt.054",
+			service="STM",
+			start_date=start_date,
+			end_date=end_date,
+		),
 	}
 
 
@@ -76,12 +94,12 @@ def sync_ebics_transactions(
 		CAMTDocument,
 	)  # import possible only after manager is initialized
 
-	order_types = get_order_types(manager.country_code)
-	main_order_type = order_types["intraday"] if intraday else order_types["statement"]
+	request_map = get_request_map(manager.country_code, start_date, end_date)
+	main_request = request_map["intraday"] if intraday else request_map["statement"]
 
 	request = log_request(
 		ebics_user,
-		main_order_type,
+		main_request.order_type,
 		requested_by,
 		{
 			"start_date": start_date,
@@ -92,16 +110,13 @@ def sync_ebics_transactions(
 	permitted_types = manager.get_permitted_order_types()
 	main_xml, batch_xml = None, None
 	try:
-		validated_perms(user.name, permitted_types, main_order_type)
-
-		if intraday:
-			main_xml = manager.download_c52(start_date, end_date)
-		else:
-			main_xml = manager.download_c53(start_date, end_date)
+		validated_perms(user.name, permitted_types, main_request.order_type)
+		main_xml = manager.download(main_request)
 
 		if user.download_batch_transactions:
-			validated_perms(user.name, permitted_types, order_types["batch"])
-			batch_xml = manager.download_c54(start_date, end_date)
+			batch_request = request_map["batch"]
+			validated_perms(user.name, permitted_types, batch_request.order_type)
+			batch_xml = manager.download(batch_request)
 
 		request.db_set(
 			{

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -51,7 +51,9 @@ def get_ebics_manager(
 	return manager
 
 
-def get_request_map(country_code: str, start_date: str, end_date: str):
+def get_request_map(
+	country_code: str | None = None, start_date: str | None = None, end_date: str | None = None
+) -> dict[str, EbicsRequest]:
 	"""Get EbicsRequest for the given country. Switzerland uses Z-types, others use C-types."""
 	prefix = "Z" if country_code == "CH" else "C"
 	return {

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -110,12 +110,21 @@ def sync_ebics_transactions(
 	permitted_types = manager.get_permitted_order_types()
 	main_xml, batch_xml = None, None
 	try:
-		validated_perms(user.name, permitted_types, main_request.order_type)
+		if manager.protocol_version == "H004":
+			# TODO: implement logic for H004
+			validated_perms(user.name, permitted_types, main_request.order_type)
+		elif manager.protocol_version == "H005":
+			validated_perms(user.name, permitted_types, ("BTD", main_request.service, main_request.camt_msg))
 		main_xml = manager.download(main_request)
 
 		if user.download_batch_transactions:
 			batch_request = request_map["batch"]
-			validated_perms(user.name, permitted_types, batch_request.order_type)
+			if manager.protocol_version == "H004":
+				validated_perms(user.name, permitted_types, batch_request.order_type)
+			elif manager.protocol_version == "H005":
+				validated_perms(
+					user.name, permitted_types, ("BTD", batch_request.service, batch_request.camt_msg)
+				)
 			batch_xml = manager.download(batch_request)
 
 		request.db_set(
@@ -185,7 +194,7 @@ def validated_perms(ebis_user, permitted_types, required_type):
 			title=_("Banking Warning"),
 			message=_(
 				"It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
-			).format(required_type, ", ".join(permitted_types)),
+			).format(required_type, ", ".join(str(t) for t in permitted_types)),
 			reference_doctype="EBICS User",
 			reference_name=ebis_user,
 		)

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -51,6 +51,16 @@ def get_ebics_manager(
 	return manager
 
 
+def get_order_types(country_code: str):
+	"""Get order types for the given country. Switzerland uses Z-types, others use C-types."""
+	prefix = "Z" if country_code == "CH" else "C"
+	return {
+		"intraday": f"{prefix}52",
+		"statement": f"{prefix}53",
+		"batch": f"{prefix}54",
+	}
+
+
 def sync_ebics_transactions(
 	ebics_user: str,
 	requested_by: Literal["User", "System"],
@@ -66,29 +76,31 @@ def sync_ebics_transactions(
 		CAMTDocument,
 	)  # import possible only after manager is initialized
 
-	permitted_types = manager.get_permitted_order_types()
-	validate_permitted_types(user, permitted_types, intraday)
+	order_types = get_order_types(manager.country_code)
+	main_order_type = order_types["intraday"] if intraday else order_types["statement"]
 
 	request = log_request(
 		ebics_user,
-		("Z52" if manager.country_code == "CH" else "C52")
-		if intraday
-		else ("Z53" if manager.country_code == "CH" else "C53"),
+		main_order_type,
 		requested_by,
 		{
 			"start_date": start_date,
 			"end_date": end_date,
 		},
 	)
+
+	permitted_types = manager.get_permitted_order_types()
 	main_xml, batch_xml = None, None
 	try:
-		# Use the manager's download methods which handle protocol version automatically
+		validated_perms(user.name, permitted_types, main_order_type)
+
 		if intraday:
 			main_xml = manager.download_c52(start_date, end_date)
 		else:
 			main_xml = manager.download_c53(start_date, end_date)
 
 		if user.download_batch_transactions:
+			validated_perms(user.name, permitted_types, order_types["batch"])
 			batch_xml = manager.download_c54(start_date, end_date)
 
 		request.db_set(
@@ -150,37 +162,17 @@ def sync_ebics_transactions(
 	manager.confirm_download(success=True)
 
 
-def validate_permitted_types(user, permitted_types, intraday: bool):
+def validated_perms(ebis_user, permitted_types, required_type):
 	# Not sure yet, how reliable permitted types are. For now, we just log an error
 	# instead of raising an exception or returning.
-	if intraday and not set(permitted_types).intersection({"C52", "Z52"}):
+	if required_type not in permitted_types:
 		frappe.log_error(
-			title=_("Banking Error"),
+			title=_("Banking Warning"),
 			message=_(
-				"It seems like EBICS User {0} lacks permission 'C52' for downloading intraday transactions. The permitted types are: {1}."
-			).format(user.name, ", ".join(permitted_types)),
+				"It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
+			).format(required_type, ", ".join(permitted_types)),
 			reference_doctype="EBICS User",
-			reference_name=user.name,
-		)
-
-	if not intraday and not set(permitted_types).intersection({"C53", "Z53"}):
-		frappe.log_error(
-			title=_("Banking Error"),
-			message=_(
-				"It seems like EBICS User {0} lacks permission 'C52' for downloading booked bank statements. The permitted types are: {1}."
-			).format(user.name, ", ".join(permitted_types)),
-			reference_doctype="EBICS User",
-			reference_name=user.name,
-		)
-
-	if user.download_batch_transactions and not set(permitted_types).intersection({"C54", "Z54"}):
-		frappe.log_error(
-			title=_("Banking Error"),
-			message=_(
-				"EBICS User {0} lacks permission 'C54' for downloading batch transactions. The permitted types are: {1}."
-			).format(user.name, ", ".join(permitted_types)),
-			reference_doctype="EBICS User",
-			reference_name=user.name,
+			reference_name=ebis_user,
 		)
 
 

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -216,7 +216,7 @@ def sync_ebics_transactions(
 	manager.confirm_download(success=True)
 
 
-def validated_perms(ebis_user, permitted_types, required_type):
+def validated_perms(ebics_user, permitted_types, required_type):
 	# Not sure yet, how reliable permitted types are. For now, we just log an error
 	# instead of raising an exception or returning.
 	if required_type not in permitted_types:
@@ -226,7 +226,7 @@ def validated_perms(ebis_user, permitted_types, required_type):
 				"It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 			).format(required_type, ", ".join(str(t) for t in permitted_types)),
 			reference_doctype="EBICS User",
-			reference_name=ebis_user,
+			reference_name=ebics_user,
 		)
 
 


### PR DESCRIPTION
This pull request refactors the EBICS transaction download logic to make it more modular, maintainable, and extensible. It introduces a new `EbicsRequest` data class to encapsulate download parameters, consolidates multiple download methods into a single generic `download` method, and updates utility code to use these new abstractions. The permission validation logic is also streamlined for clarity and flexibility.

**Core refactoring of download logic:**

* Introduced a new `@dataclass EbicsRequest` in `banking/ebics/manager.py` to encapsulate all parameters needed for an EBICS download request, making the code more structured and easier to extend.
* Replaced the three separate methods (`download_c52`, `download_c53`, `download_c54`) in `EBICSManager` with a single, generic `download` method that takes an `EbicsRequest` and handles all supported order types and protocol versions.

**Utility improvements and code simplification:**

* Added a `get_request_map` function in `banking/ebics/utils.py` to generate `EbicsRequest` objects for each supported order type, handling country-specific logic for order type prefixes.
* Refactored `sync_ebics_transactions` to use the new request mapping and generic download method, simplifying logic and reducing code duplication.
* Consolidated and simplified permission validation into a single `validated_perms` function, improving error logging and making permission checks more flexible for different order types.

Resolves #298