### PR TITLE
fix: Multi currency support

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.md
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.md
@@ -1,234 +1,203 @@
-# Bank Reconciliation Tool Beta Behaviours
+# Bank Reconciliation Tool Beta Testing Guide
 
-Cases and expected behaviours for clarity in testing
+A comprehensive guide for testing the Bank Reconciliation Tool's behavior and edge cases.
 
+## Testing Match Tab Voucher Visibility
 
-## Match Tab Visible Vouchers
+### Withdrawal Bank Transactions
 
-### Withdrawal Bank Transaction
+The visibility of vouchers depends on which filters are checked:
 
-Depending on multiple checked filters:
-- **Purchase Invoice**:
-    - _Unpaid Invoices_: Unpaid PInvs including returns(outstanding >< 0), Unpaid **return** SInvs
-    - _Without Unpaid Invoices_: PInvs with `is_paid` checked and no clearance date (among other basic filters)
-- **Sales Invoice**:
-    - _Unpaid Invoices_: Unpaid SInvs including returns(outstanding >< 0), Unpaid **return** PInvs
-    - _Without Unpaid Invoices_: SInvs with no clearance date and paid via POS (among other basic filters)
-- **Expense Claim**: Unpaid expense claims. Visible only if _Unpaid Vouchers_ is checked
+**Purchase Invoice Matching:**
+- With _Unpaid Invoices_ checked: Shows unpaid Purchase Invoices (outstanding ≠ 0), including returns, plus unpaid return Sales Invoices
+- Without _Unpaid Invoices_ checked: Shows paid Purchase Invoices (`is_paid = 1`) that lack a clearance date
 
-The rest is self explanatory and _only depends on the doctype filter being checked_.
+**Sales Invoice Matching:**
+- With _Unpaid Invoices_ checked: Shows unpaid Sales Invoices (outstanding ≠ 0), including returns, plus unpaid return Purchase Invoices
+- Without _Unpaid Invoices_ checked: Shows Sales Invoices without clearance dates that were paid via POS
 
+**Expense Claim Matching:**
+- Shows unpaid expense claims
+- Only visible when _Unpaid Vouchers_ filter is checked
 
-## Multi-Currency Reconciliation Behaviour
+**Other Voucher Types:**
+- Visibility depends solely on whether the corresponding doctype filter is checked
 
-### Key Currency Field Relationships
+## Multi-Currency Reconciliation Testing
+
+### Understanding Currency Fields
 
 **Invoice Currency Fields:**
-- `outstanding_amount`: Always in **company currency** (e.g., INR), regardless of invoice currency
-- `grand_total`: In **invoice currency** (e.g., USD, EUR, GBP)
-- `base_grand_total`: Invoice amount converted to **company currency** (e.g., INR)
+- `outstanding_amount`: In the party account currency (currency of the receivable/payable account)
+- `grand_total`: In the invoice's own currency (e.g., USD, EUR, GBP)
+- `base_grand_total`: In company's default currency (all `base_*` fields are in company currency)
 - `party_account_currency`: Currency of the receivable/payable account used
-- `conversion_rate`: Exchange rate from invoice currency to company currency
+- `conversion_rate`: Exchange rate from invoice currency to party account currency
 
 **Bank Transaction Fields:**
-- `currency`: Bank account currency (can be different from company currency)
-- `unallocated_amount`: In bank account currency
-- `deposit`/`withdrawal`: In bank account currency
-- `payment_entries[].allocated_amount`: In **bank account currency** (not company currency!)
+- `currency`: Bank account currency (may differ from company currency)
+- `unallocated_amount`, `deposit`, `withdrawal`: All in bank account currency
+- `payment_entries[].allocated_amount`: In bank account currency
 
-### Cross-Currency Reconciliation Logic
+### How Currency Matching Works
 
-**When Bank Currency = Company Currency (e.g., INR bank, INR company):**
+**When Bank Currency Equals Company Currency:**
+- Invoice matching uses `outstanding_amount` for comparison
+- Both Payment Entry amounts are in company currency
+- Partial payments are allowed
 
-1. **Invoice Matching** (`bank_reconciliation_tool_beta.py` lines 1092-1141):
-   - If `bank_currency == company_currency`: Use `outstanding_amount` for matching
-   - If `bank_currency != company_currency`: Use `grand_total` for matching
-   - **Constraint**: Cross-currency requires `outstanding_amount == base_grand_total` (full invoice only)
+**When Bank Currency Differs from Company Currency:**
+- Invoice matching uses `grand_total` for comparison
+- Requires full invoice amount: `outstanding_amount == base_grand_total`
+- Partial payments are NOT allowed (prevents exchange rate issues)
+- Must enable multi-currency flag to match invoices in different currencies
 
-2. **Payment Entry Creation** (`unpaid_vouchers.py` lines 135-192):
-   - Calls `get_payment_entry()` from ERPNext with `bank_account` parameter
-   - Clears references, then calls `adjust_and_allocate_invoices()`
-   - Sets amounts:
-     - For `Receive`: `paid_amount = sum(allocated_amount)`, `received_amount = bt.allocated_amount`
-     - For `Pay`: `received_amount = sum(allocated_amount)`, `paid_amount = bt.allocated_amount`
-   - **Both amounts are in company currency (INR)** when bank is in company currency
-   - Sets exchange rate: `source_exchange_rate` or `target_exchange_rate` depending on payment type
+### Payment Entry Structure Examples
 
-3. **Allocation Logic** (`unpaid_vouchers.py` lines 261-308):
-   - Calculates `row_allocated_amount` in bank currency
-   - Converts to company currency: `row.allocated_amount = row_allocated_amount * conversion_rate`
-   - **Result**: `allocated_amount` in Payment Entry Reference is always in **company currency**
+**Example 1: USD Invoice with INR Bank**
+- Invoice: 100 USD (9000 INR base_grand_total at rate 90)
+- Bank Transaction: 9000 INR
+- Payment Entry:
+  - `paid_amount`: 9000 INR (in receivable account currency)
+  - `received_amount`: 9000 INR (in bank account currency)
+  - `references[].allocated_amount`: 9000 INR (in receivable account currency)
+  - Bank Transaction `allocated_amount`: 9000 INR
 
-### Payment Entry Multi-Currency Structure
+**Example 2: USD Invoice with USD Bank**
+- Invoice: 100 USD (9000 INR base at rate 90)
+- Bank Transaction: 100 USD
+- Payment Entry:
+  - `paid_amount`: 9000 INR (in receivable account currency)
+  - `received_amount`: 100 USD (bank account in USD)
+  - `references[].allocated_amount`: 9000 INR (in receivable account currency)
+  - Bank Transaction `allocated_amount`: 100 USD
 
-**Example: USD Invoice (100 USD) + INR Bank (9000 INR), conversion_rate=90**
+**Key Rule**: Payment Entry `paid_amount` and `received_amount` follow the currencies of `paid_from` and `paid_to` accounts respectively. The `references[].allocated_amount` is in the receivable/payable account currency (party account currency).
 
-```
-Payment Entry:
-  payment_type: "Receive"
-  paid_from: Debtors - _TC (receivable account)
-  paid_from_account_currency: INR (from invoice.party_account_currency)
-  paid_to: Bank Account - _TC (bank account)
-  paid_to_account_currency: INR
-  paid_amount: 9000 (in paid_from_account_currency = INR)
-  received_amount: 9000 (in paid_to_account_currency = INR)
-  
-  references[0]:
-    reference_name: SI-00001
-    allocated_amount: 9000 INR (always in company currency!)
+### Journal Entry Considerations
 
-Bank Transaction:
-  payment_entries[0]:
-    allocated_amount: 9000 (in bank account currency = INR)
-```
-
-**Example: USD Invoice (100 USD) + USD Bank (100 USD), conversion_rate=90**
-
-```
-Invoice:
-  grand_total: 100 USD
-  base_grand_total: 9000 INR (100 * 90)
-  party_account_currency: INR (receivable account is in company currency)
-
-Payment Entry:
-  payment_type: "Receive"
-  paid_from: Debtors - _TC (receivable account in INR)
-  paid_from_account_currency: INR
-  paid_to: USD Bank Account - _TC (bank account in USD)
-  paid_to_account_currency: USD
-  paid_amount: 9000 (in paid_from_account_currency = INR)
-  received_amount: 100 (in paid_to_account_currency = USD)
-  
-  references[0]:
-    reference_name: SI-00001
-    allocated_amount: 9000 INR (always in company currency!)
-
-Bank Transaction:
-  currency: USD
-  deposit: 100 USD
-  payment_entries[0]:
-    allocated_amount: 100 (in bank account currency = USD)
-```
-
-**Key Insight**: 
-- Payment Entry `paid_amount` is in `paid_from_account_currency`
-- Payment Entry `received_amount` is in `paid_to_account_currency`
-- Payment Entry `references[].allocated_amount` is in **company currency (INR)**
-- Bank Transaction `payment_entries[].allocated_amount` is in **bank account currency**
-
-**Important**: The Payment Entry's paid/received amounts depend on which accounts are used (paid_from and paid_to), not directly on invoice or company currency.
-
-### Journal Entry Multi-Currency Structure
-
-**For multi-party reconciliation** (`unpaid_vouchers.py` lines 76-132):
+For multi-party reconciliation:
 - Creates Journal Entry instead of Payment Entry
-- **Constraint**: All account currencies must match bank account currency
-- Sets `multi_currency = 1` if any account currency differs from company currency
-- All amounts in `accounts[]` are in company currency (converted via `allocated_amount`)
+- All account currencies must match the bank account currency
+- Sets `multi_currency = 1` if any account differs from company currency
+- All `accounts[]` amounts are converted to company currency
 
 ### Testing Multi-Currency Scenarios
 
-**Test Setup:**
-- Company: "_Test Company" with currency **INR**
-- Conversion rates: USD=90 INR, EUR=100 INR
-- Use `party_account_currency` from invoice to verify Payment Entry account currencies
+**Recommended Test Setup:**
+- Company currency: INR
+- Test currencies: USD (rate: 90), EUR (rate: 100)
+- Create matching bank accounts in each currency
 
 **Common Test Pattern:**
 ```python
-# Create USD customer and invoice
-usd_customer = create_customer("Customer", currency="USD")
-si = create_sales_invoice(rate=100, currency="USD", conversion_rate=90, ...)
+# Create invoice in foreign currency
+customer = create_customer("Test Customer", currency="USD")
+invoice = create_sales_invoice(
+    rate=100, 
+    currency="USD", 
+    conversion_rate=90
+)
 
-# Create INR bank transaction matching base_grand_total
-bt = create_bank_transaction(deposit=si.base_grand_total, currency="INR", ...)
+# Create bank transaction matching base_grand_total
+bt = create_bank_transaction(
+    deposit=invoice.base_grand_total,
+    currency="INR"
+)
 
-# Reconcile
-bulk_reconcile_vouchers(bt.name, json.dumps([{"payment_doctype": "Sales Invoice", "payment_name": si.name}]))
+# Perform reconciliation
+bulk_reconcile_vouchers(
+    bt.name, 
+    json.dumps([{
+        "payment_doctype": "Sales Invoice",
+        "payment_name": invoice.name
+    }])
+)
 
-# Verify amounts
-self.assertEqual(si.grand_total, 100.0)  # USD
-self.assertEqual(si.base_grand_total, 9000.0)  # INR
-self.assertEqual(pe.paid_amount, 9000.0)  # INR
-self.assertEqual(pe.references[0].allocated_amount, 9000.0)  # INR (not USD!)
+# Verify currency conversions
+assert invoice.grand_total == 100.0  # USD
+assert invoice.base_grand_total == 9000.0  # INR
+assert payment_entry.paid_amount == 9000.0  # INR
+assert payment_entry.references[0].allocated_amount == 9000.0  # Party account currency
 ```
 
-### Important Constraints
+### Critical Constraints to Test
 
-1. **Full Invoice Only for Cross-Currency**: 
-   - Lines 1140-1141, 1333-1334: `outstanding_amount == base_grand_total`
-   - **Critical**: This constraint is ONLY applied when `bank_currency != company_currency`
-   - Partial payments not supported for cross-currency reconciliation
-   - **Scenarios**:
-     - ✅ EUR bank + USD invoice (constraint applied): Only full invoices matched
-     - ✅ INR bank + USD invoice (constraint NOT applied): Partial invoices can be matched
-     - The constraint protects against exchange rate issues when bank ≠ company currency
+**1. Full Invoice Requirement for Cross-Currency:**
+- Applies only when bank currency ≠ company currency
+- Invoices must be fully outstanding: `outstanding_amount == base_grand_total`
+- Partially paid invoices are excluded to avoid exchange rate complexities
+- Test scenarios:
+  - ✅ EUR bank + USD invoice: Constraint applies (only full invoices match)
+  - ✅ INR bank + USD invoice: Constraint does NOT apply (partial matching allowed)
 
-2. **Multi-Currency Flag**:
-   - Line 592: `common_filters.multi_currency = "multi_currency" in document_types`
-   - Controls whether cross-currency invoices are matched
-   - **Without flag**: Query filters to `invoice.currency == bank.currency` (line 1134)
-   - **With flag**: Allows matching invoices in different currency (lines 1136-1141)
-   - Example: To match USD invoice with INR bank, flag must be enabled
+**2. Multi-Currency Flag:**
+- Controls whether cross-currency invoice matching is enabled
+- Without flag: Only matches invoices where `invoice.currency == bank.currency`
+- With flag: Allows matching invoices in different currencies (with constraints)
+- Test both states to verify filtering behavior
 
-3. **Journal Entry Currency Validation**:
-   - Lines 82-87 in `unpaid_vouchers.py`: Account currencies must match for Journal Entry creation
-   - Multi-party multi-currency requires all accounts in same currency as bank
+**3. Journal Entry Currency Validation:**
+- For multi-party reconciliation via Journal Entry
+- All accounts must be in the same currency as the bank account
+- Validation fails if account currencies don't match
 
-4. **Return Invoice Handling** (`unpaid_vouchers.py` lines 179-190):
-   - For `Pay` type: `received_amount = abs(sum(allocated_amount))`, `paid_amount = bt.allocated_amount`
-   - For `Receive` type: `paid_amount = abs(sum(allocated_amount))`, `received_amount = bt.allocated_amount`
-   - The `abs()` function ensures Payment Entry amounts are always positive
-   - However, `references[].allocated_amount` remains negative for return invoices
+**4. Return Invoice Handling:**
+- Payment Entry amounts (`paid_amount`, `received_amount`) are always positive
+- Uses `abs()` on summed allocated amounts
+- However, `references[].allocated_amount` remains negative for returns
+- Ensures proper accounting while maintaining sign in references
 
-## Test Case Corrections (October 2025)
+### Testing Return Invoices
 
-During test review, three critical issues were identified and corrected:
+When testing return/credit note scenarios:
+- Verify Payment Entry amounts are positive values
+- Check that reference allocated amounts are negative
+- Test with both same-currency and cross-currency setups
+- Confirm exchange rates are applied correctly
 
-### 1. Return Invoice Amount Handling (`test_usd_return_invoice_inr_bank`)
+### Cross-Currency Test Checklist
 
-**Issue**: Test had ambiguous expectations for Payment Entry amounts with return invoices.
+To properly test cross-currency constraints:
+- [ ] Use a bank account in a currency different from company currency (e.g., EUR bank with INR company)
+- [ ] Create invoices in a third currency (e.g., USD)
+- [ ] Test with fully outstanding invoices (should match)
+- [ ] Test with partially paid invoices (should NOT match)
+- [ ] Verify multi-currency flag enables/disables cross-currency matching
+- [ ] Check that same-currency bank accounts (INR bank + INR company) allow partial payments regardless of invoice currency
 
-**Resolution**: 
-- Clarified that `abs()` is applied per `unpaid_vouchers.py` lines 179-183
-- Payment Entry amounts (`paid_amount`, `received_amount`) are positive even for returns
-- Only `references[].allocated_amount` remains negative (-9000 INR)
-- This is correct behavior per the spec
+### Common Testing Pitfalls
 
-### 2. Cross-Currency Constraint Test (`test_cross_currency_full_amount_constraint`)
+**Pitfall 1: Wrong Currency Combination**
+- Using bank currency = company currency won't trigger cross-currency constraints
+- Use EUR or USD bank accounts for proper cross-currency testing
 
-**Issue**: Original test used INR bank + USD invoice, but constraint wasn't triggered.
+**Pitfall 2: Ambiguous Test Expectations**
+- Clearly distinguish between Payment Entry amounts (always positive) and reference amounts (can be negative)
+- Verify both the Payment Entry fields and Bank Transaction allocated amounts
 
-**Root Cause**: 
-- Constraint `outstanding_amount == base_grand_total` only applies when `bank_currency != company_currency`
-- Original test: INR bank = INR company → constraint NOT applied ❌
-- The constraint is meant to protect against exchange rate issues when converting bank currency to company currency
+**Pitfall 3: Missing Flag Verification**
+- Always test both with and without multi-currency flag enabled
+- Verify expected behavior changes between states
 
-**Resolution**:
-- Changed to EUR bank + USD invoice (both ≠ INR company)
-- Now constraint IS applied ✅
-- Test verifies partially paid invoices are excluded when `bank_currency != company_currency`
-- Properly creates partial payment to violate constraint (outstanding: 4500, base_grand_total: 9000)
+**Pitfall 4: Partial Payment Scenarios**
+- Create actual partial payments (not just modified outstanding amounts)
+- Verify constraint applies based on bank currency vs company currency relationship
 
-### 3. Multi-Currency Flag Behavior (`test_multi_currency_flag_in_get_linked_payments`)
+### Best Practices for Test Design
 
-**Issue**: Test only checked that results were booleans, didn't verify actual behavior.
+1. **Use Descriptive Test Names**: Include currencies involved (e.g., `test_usd_invoice_eur_bank_full_amount_only`)
 
-**Resolution**:
-- Added explicit assertions with clear failure messages
-- **Without flag**: USD invoice NOT found for INR bank (currency filter applied)
-- **With flag**: USD invoice IS found for INR bank (cross-currency enabled)
-- Verifies matched invoice meets constraint (`paid_amount == base_grand_total`)
+2. **Test Currency Combinations Systematically**:
+   - Same currency: INR invoice + INR bank
+   - Invoice differs: USD invoice + INR bank
+   - Bank differs: USD invoice + EUR bank
+   - All differ: USD invoice + EUR bank + INR company
 
-### Key Learnings
+3. **Verify All Amount Fields**: Check `grand_total`, `base_grand_total`, `outstanding_amount`, `paid_amount`, `received_amount`, and all allocated amounts
 
-1. **Constraint Application**: The cross-currency constraint is currency-pair-specific:
-   - Applied when: `bank_currency ≠ company_currency`
-   - Not applied when: `bank_currency = company_currency` (even if invoice currency differs)
+4. **Test Both Positive and Negative Cases**: Verify both successful matches and expected failures
 
-2. **Multi-Currency Flag**: Essential for cross-currency reconciliation:
-   - Enables matching invoices with currency different from bank currency
-   - Works in conjunction with the full-invoice constraint
+5. **Include Edge Cases**: Returns, partial payments, multi-party reconciliation, exchange rate variations
 
-3. **Test Design**: Cross-currency tests must use appropriate currency combinations:
-   - Use non-company-currency bank accounts to trigger constraints
-   - Verify both positive (constraint satisfied) and negative (constraint violated) cases
+6. **Assert with Clear Messages**: Use descriptive assertion messages that explain what behavior is being verified

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.md
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.md
@@ -17,3 +17,218 @@ Depending on multiple checked filters:
 - **Expense Claim**: Unpaid expense claims. Visible only if _Unpaid Vouchers_ is checked
 
 The rest is self explanatory and _only depends on the doctype filter being checked_.
+
+
+## Multi-Currency Reconciliation Behaviour
+
+### Key Currency Field Relationships
+
+**Invoice Currency Fields:**
+- `outstanding_amount`: Always in **company currency** (e.g., INR), regardless of invoice currency
+- `grand_total`: In **invoice currency** (e.g., USD, EUR, GBP)
+- `base_grand_total`: Invoice amount converted to **company currency** (e.g., INR)
+- `party_account_currency`: Currency of the receivable/payable account used
+- `conversion_rate`: Exchange rate from invoice currency to company currency
+
+**Bank Transaction Fields:**
+- `currency`: Bank account currency (can be different from company currency)
+- `unallocated_amount`: In bank account currency
+- `deposit`/`withdrawal`: In bank account currency
+- `payment_entries[].allocated_amount`: In **bank account currency** (not company currency!)
+
+### Cross-Currency Reconciliation Logic
+
+**When Bank Currency = Company Currency (e.g., INR bank, INR company):**
+
+1. **Invoice Matching** (`bank_reconciliation_tool_beta.py` lines 1092-1141):
+   - If `bank_currency == company_currency`: Use `outstanding_amount` for matching
+   - If `bank_currency != company_currency`: Use `grand_total` for matching
+   - **Constraint**: Cross-currency requires `outstanding_amount == base_grand_total` (full invoice only)
+
+2. **Payment Entry Creation** (`unpaid_vouchers.py` lines 135-192):
+   - Calls `get_payment_entry()` from ERPNext with `bank_account` parameter
+   - Clears references, then calls `adjust_and_allocate_invoices()`
+   - Sets amounts:
+     - For `Receive`: `paid_amount = sum(allocated_amount)`, `received_amount = bt.allocated_amount`
+     - For `Pay`: `received_amount = sum(allocated_amount)`, `paid_amount = bt.allocated_amount`
+   - **Both amounts are in company currency (INR)** when bank is in company currency
+   - Sets exchange rate: `source_exchange_rate` or `target_exchange_rate` depending on payment type
+
+3. **Allocation Logic** (`unpaid_vouchers.py` lines 261-308):
+   - Calculates `row_allocated_amount` in bank currency
+   - Converts to company currency: `row.allocated_amount = row_allocated_amount * conversion_rate`
+   - **Result**: `allocated_amount` in Payment Entry Reference is always in **company currency**
+
+### Payment Entry Multi-Currency Structure
+
+**Example: USD Invoice (100 USD) + INR Bank (9000 INR), conversion_rate=90**
+
+```
+Payment Entry:
+  payment_type: "Receive"
+  paid_from: Debtors - _TC (receivable account)
+  paid_from_account_currency: INR (from invoice.party_account_currency)
+  paid_to: Bank Account - _TC (bank account)
+  paid_to_account_currency: INR
+  paid_amount: 9000 (in paid_from_account_currency = INR)
+  received_amount: 9000 (in paid_to_account_currency = INR)
+  
+  references[0]:
+    reference_name: SI-00001
+    allocated_amount: 9000 INR (always in company currency!)
+
+Bank Transaction:
+  payment_entries[0]:
+    allocated_amount: 9000 (in bank account currency = INR)
+```
+
+**Example: USD Invoice (100 USD) + USD Bank (100 USD), conversion_rate=90**
+
+```
+Invoice:
+  grand_total: 100 USD
+  base_grand_total: 9000 INR (100 * 90)
+  party_account_currency: INR (receivable account is in company currency)
+
+Payment Entry:
+  payment_type: "Receive"
+  paid_from: Debtors - _TC (receivable account in INR)
+  paid_from_account_currency: INR
+  paid_to: USD Bank Account - _TC (bank account in USD)
+  paid_to_account_currency: USD
+  paid_amount: 9000 (in paid_from_account_currency = INR)
+  received_amount: 100 (in paid_to_account_currency = USD)
+  
+  references[0]:
+    reference_name: SI-00001
+    allocated_amount: 9000 INR (always in company currency!)
+
+Bank Transaction:
+  currency: USD
+  deposit: 100 USD
+  payment_entries[0]:
+    allocated_amount: 100 (in bank account currency = USD)
+```
+
+**Key Insight**: 
+- Payment Entry `paid_amount` is in `paid_from_account_currency`
+- Payment Entry `received_amount` is in `paid_to_account_currency`
+- Payment Entry `references[].allocated_amount` is in **company currency (INR)**
+- Bank Transaction `payment_entries[].allocated_amount` is in **bank account currency**
+
+**Important**: The Payment Entry's paid/received amounts depend on which accounts are used (paid_from and paid_to), not directly on invoice or company currency.
+
+### Journal Entry Multi-Currency Structure
+
+**For multi-party reconciliation** (`unpaid_vouchers.py` lines 76-132):
+- Creates Journal Entry instead of Payment Entry
+- **Constraint**: All account currencies must match bank account currency
+- Sets `multi_currency = 1` if any account currency differs from company currency
+- All amounts in `accounts[]` are in company currency (converted via `allocated_amount`)
+
+### Testing Multi-Currency Scenarios
+
+**Test Setup:**
+- Company: "_Test Company" with currency **INR**
+- Conversion rates: USD=90 INR, EUR=100 INR
+- Use `party_account_currency` from invoice to verify Payment Entry account currencies
+
+**Common Test Pattern:**
+```python
+# Create USD customer and invoice
+usd_customer = create_customer("Customer", currency="USD")
+si = create_sales_invoice(rate=100, currency="USD", conversion_rate=90, ...)
+
+# Create INR bank transaction matching base_grand_total
+bt = create_bank_transaction(deposit=si.base_grand_total, currency="INR", ...)
+
+# Reconcile
+bulk_reconcile_vouchers(bt.name, json.dumps([{"payment_doctype": "Sales Invoice", "payment_name": si.name}]))
+
+# Verify amounts
+self.assertEqual(si.grand_total, 100.0)  # USD
+self.assertEqual(si.base_grand_total, 9000.0)  # INR
+self.assertEqual(pe.paid_amount, 9000.0)  # INR
+self.assertEqual(pe.references[0].allocated_amount, 9000.0)  # INR (not USD!)
+```
+
+### Important Constraints
+
+1. **Full Invoice Only for Cross-Currency**: 
+   - Lines 1140-1141, 1333-1334: `outstanding_amount == base_grand_total`
+   - **Critical**: This constraint is ONLY applied when `bank_currency != company_currency`
+   - Partial payments not supported for cross-currency reconciliation
+   - **Scenarios**:
+     - ✅ EUR bank + USD invoice (constraint applied): Only full invoices matched
+     - ✅ INR bank + USD invoice (constraint NOT applied): Partial invoices can be matched
+     - The constraint protects against exchange rate issues when bank ≠ company currency
+
+2. **Multi-Currency Flag**:
+   - Line 592: `common_filters.multi_currency = "multi_currency" in document_types`
+   - Controls whether cross-currency invoices are matched
+   - **Without flag**: Query filters to `invoice.currency == bank.currency` (line 1134)
+   - **With flag**: Allows matching invoices in different currency (lines 1136-1141)
+   - Example: To match USD invoice with INR bank, flag must be enabled
+
+3. **Journal Entry Currency Validation**:
+   - Lines 82-87 in `unpaid_vouchers.py`: Account currencies must match for Journal Entry creation
+   - Multi-party multi-currency requires all accounts in same currency as bank
+
+4. **Return Invoice Handling** (`unpaid_vouchers.py` lines 179-190):
+   - For `Pay` type: `received_amount = abs(sum(allocated_amount))`, `paid_amount = bt.allocated_amount`
+   - For `Receive` type: `paid_amount = abs(sum(allocated_amount))`, `received_amount = bt.allocated_amount`
+   - The `abs()` function ensures Payment Entry amounts are always positive
+   - However, `references[].allocated_amount` remains negative for return invoices
+
+## Test Case Corrections (October 2025)
+
+During test review, three critical issues were identified and corrected:
+
+### 1. Return Invoice Amount Handling (`test_usd_return_invoice_inr_bank`)
+
+**Issue**: Test had ambiguous expectations for Payment Entry amounts with return invoices.
+
+**Resolution**: 
+- Clarified that `abs()` is applied per `unpaid_vouchers.py` lines 179-183
+- Payment Entry amounts (`paid_amount`, `received_amount`) are positive even for returns
+- Only `references[].allocated_amount` remains negative (-9000 INR)
+- This is correct behavior per the spec
+
+### 2. Cross-Currency Constraint Test (`test_cross_currency_full_amount_constraint`)
+
+**Issue**: Original test used INR bank + USD invoice, but constraint wasn't triggered.
+
+**Root Cause**: 
+- Constraint `outstanding_amount == base_grand_total` only applies when `bank_currency != company_currency`
+- Original test: INR bank = INR company → constraint NOT applied ❌
+- The constraint is meant to protect against exchange rate issues when converting bank currency to company currency
+
+**Resolution**:
+- Changed to EUR bank + USD invoice (both ≠ INR company)
+- Now constraint IS applied ✅
+- Test verifies partially paid invoices are excluded when `bank_currency != company_currency`
+- Properly creates partial payment to violate constraint (outstanding: 4500, base_grand_total: 9000)
+
+### 3. Multi-Currency Flag Behavior (`test_multi_currency_flag_in_get_linked_payments`)
+
+**Issue**: Test only checked that results were booleans, didn't verify actual behavior.
+
+**Resolution**:
+- Added explicit assertions with clear failure messages
+- **Without flag**: USD invoice NOT found for INR bank (currency filter applied)
+- **With flag**: USD invoice IS found for INR bank (cross-currency enabled)
+- Verifies matched invoice meets constraint (`paid_amount == base_grand_total`)
+
+### Key Learnings
+
+1. **Constraint Application**: The cross-currency constraint is currency-pair-specific:
+   - Applied when: `bank_currency ≠ company_currency`
+   - Not applied when: `bank_currency = company_currency` (even if invoice currency differs)
+
+2. **Multi-Currency Flag**: Essential for cross-currency reconciliation:
+   - Enables matching invoices with currency different from bank currency
+   - Works in conjunction with the full-invoice constraint
+
+3. **Test Design**: Cross-currency tests must use appropriate currency combinations:
+   - Use non-company-currency bank accounts to trigger constraints
+   - Verify both positive (constraint satisfied) and negative (constraint violated) cases

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1082,7 +1082,12 @@ def get_unpaid_si_matching_query(
 		else Cast(0, "int")
 	)
 
-	rank_expression = ref_rank + party_rank + amount_rank + name_match + ref_match + 1
+	date_condition = (sales_invoice.posting_date == common_filters.date) | (
+		sales_invoice.due_date == common_filters.date
+	)
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+
+	rank_expression = ref_rank + party_rank + amount_rank + date_rank + name_match + ref_match + 1
 
 	company_currency = frappe.get_value("Company", company, "default_currency")
 	if currency == company_currency:
@@ -1267,7 +1272,14 @@ def get_unpaid_pi_matching_query(
 		else Cast(0, "int")
 	)
 
-	rank_expression = ref_rank + party_match + amount_rank + name_match + ref_match + 1
+	date_condition = (
+		(purchase_invoice.posting_date == common_filters.date)
+		| (purchase_invoice.due_date == common_filters.date)
+		| (purchase_invoice.bill_date == common_filters.date)
+	)
+	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+
+	rank_expression = ref_rank + party_match + amount_rank + date_rank + name_match + ref_match + 1
 
 	company_currency = frappe.get_value("Company", company, "default_currency")
 	if currency == company_currency:
@@ -1277,8 +1289,6 @@ def get_unpaid_pi_matching_query(
 		paid_amount_field = purchase_invoice.grand_total
 		currency_field = purchase_invoice.currency
 
-	# We skip date rank as the date of an unpaid bill is mostly
-	# earlier than the date of the bank transaction
 	query = (
 		frappe.qb.from_(purchase_invoice)
 		.select(

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -13,7 +13,7 @@ from erpnext.accounts.utils import get_account_currency
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
-from frappe.query_builder.functions import Cast, Coalesce, Sum, Abs
+from frappe.query_builder.functions import Cast, Coalesce, Sum
 from frappe.utils import cint, flt, sbool
 from pypika import Order
 
@@ -582,7 +582,6 @@ def get_matching_queries(
 	is_deposit = transaction.deposit > 0.0
 
 	common_filters.exact_party_match = "exact_party_match" in (document_types or [])
-	common_filters.multi_currency = "multi_currency" in (document_types or [])
 	common_filters.description = transaction.description
 
 	if "payment_entry" in document_types:
@@ -1030,14 +1029,13 @@ def get_si_matching_query(
 		.where(sip.clearance_date.isnull())
 		.where(sip.account == common_filters.bank_account)
 		.where(amount_filter)
+		.where(si.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
-	if not common_filters.multi_currency:
-		query = query.where(si.currency == currency)
 
 	return query
 
@@ -1090,7 +1088,7 @@ def get_unpaid_si_matching_query(
 			rank_expression.as_("rank"),
 			ConstantColumn("Sales Invoice").as_("doctype"),
 			sales_invoice.name.as_("name"),
-			Abs(paid_amount_field).as_("paid_amount"),
+			paid_amount_field.as_("paid_amount"),
 			sales_invoice[reference_field or "name"].as_("reference_no"),
 			sales_invoice.posting_date.as_("reference_date"),
 			sales_invoice.customer.as_("party"),
@@ -1107,6 +1105,7 @@ def get_unpaid_si_matching_query(
 		.where(sales_invoice.docstatus == 1)
 		.where(sales_invoice.company == company)  # because we do not have bank account check
 		.where(sales_invoice.outstanding_amount != 0.0)
+		.where(sales_invoice.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1117,8 +1116,6 @@ def get_unpaid_si_matching_query(
 		query = query.where(sales_invoice.outstanding_amount == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
-	if not common_filters.multi_currency:
-		query = query.where(sales_invoice.currency == currency)
 	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
 	if currency != company_currency:
 		query = query.where(sales_invoice.outstanding_amount == sales_invoice.base_grand_total)
@@ -1205,14 +1202,13 @@ def get_pi_matching_query(
 		.where(purchase_invoice.clearance_date.isnull())
 		.where(purchase_invoice.cash_bank_account == common_filters.bank_account)
 		.where(amount_filter)
+		.where(purchase_invoice.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
-	if not common_filters.multi_currency:
-		query = query.where(purchase_invoice.currency == currency)
 
 	return query
 
@@ -1272,7 +1268,7 @@ def get_unpaid_pi_matching_query(
 			rank_expression.as_("rank"),
 			ConstantColumn("Purchase Invoice").as_("doctype"),
 			purchase_invoice.name.as_("name"),
-			Abs(paid_amount_field).as_("paid_amount"),
+			paid_amount_field.as_("paid_amount"),
 			purchase_invoice[reference_field].as_("reference_no"),
 			purchase_invoice.bill_date.as_("reference_date"),
 			purchase_invoice.supplier.as_("party"),
@@ -1290,6 +1286,7 @@ def get_unpaid_pi_matching_query(
 		.where(purchase_invoice.company == company)
 		.where(purchase_invoice.outstanding_amount != 0.0)
 		.where(purchase_invoice.is_paid == 0)
+		.where(purchase_invoice.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1300,8 +1297,6 @@ def get_unpaid_pi_matching_query(
 		query = query.where(purchase_invoice.outstanding_amount == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
-	if not common_filters.multi_currency:
-		query = query.where(purchase_invoice.currency == currency)
 	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
 	if currency != company_currency:
 		query = query.where(purchase_invoice.outstanding_amount == purchase_invoice.base_grand_total)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1048,6 +1048,31 @@ def get_si_matching_query(
 	return query
 
 
+def apply_unpaid_invoice_currency_filters(
+	query, invoice_doctype, currency: str, company_currency: str, common_filters: frappe._dict
+):
+	"""Apply shared currency and amount rules for unpaid invoices.
+
+	- If multi-currency is disabled, restrict to exact transaction currency
+	- If multi-currency is enabled and transaction currency differs from company currency,
+	  allow both invoice currency and company currency
+	- If transaction currency differs from company currency, only support full invoice amounts
+	  to avoid exchange rate issues
+	"""
+	if not common_filters.multi_currency:
+		query = query.where(invoice_doctype.currency == currency)
+	elif currency != company_currency:
+		query = query.where(
+			(invoice_doctype.currency == currency) | (invoice_doctype.currency == company_currency)
+		)
+
+	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
+	if currency != company_currency:
+		query = query.where(invoice_doctype.outstanding_amount == invoice_doctype.base_grand_total)
+
+	return query
+
+
 def get_unpaid_si_matching_query(
 	exact_match: bool,
 	currency: str,
@@ -1130,15 +1155,10 @@ def get_unpaid_si_matching_query(
 		query = query.where(sales_invoice.outstanding_amount == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
-	if not common_filters.multi_currency:
-		query = query.where(sales_invoice.currency == currency)
-	elif currency != company_currency:
-		query = query.where(
-			(sales_invoice.currency == currency) | (sales_invoice.currency == company_currency)
-		)
-	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
-	if currency != company_currency:
-		query = query.where(sales_invoice.outstanding_amount == sales_invoice.base_grand_total)
+
+	query = apply_unpaid_invoice_currency_filters(
+		query, sales_invoice, currency, company_currency, common_filters
+	)
 
 	return query
 
@@ -1323,15 +1343,10 @@ def get_unpaid_pi_matching_query(
 		query = query.where(purchase_invoice.outstanding_amount == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
-	if not common_filters.multi_currency:
-		query = query.where(purchase_invoice.currency == currency)
-	elif currency != company_currency:
-		query = query.where(
-			(purchase_invoice.currency == currency) | (purchase_invoice.currency == company_currency)
-		)
-	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
-	if currency != company_currency:
-		query = query.where(purchase_invoice.outstanding_amount == purchase_invoice.base_grand_total)
+
+	query = apply_unpaid_invoice_currency_filters(
+		query, purchase_invoice, currency, company_currency, common_filters
+	)
 
 	return query
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -13,7 +13,7 @@ from erpnext.accounts.utils import get_account_currency
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
-from frappe.query_builder.functions import Cast, Coalesce, Sum
+from frappe.query_builder.functions import Cast, Coalesce, Sum, Abs
 from frappe.utils import cint, flt, sbool
 from pypika import Order
 
@@ -582,6 +582,7 @@ def get_matching_queries(
 	is_deposit = transaction.deposit > 0.0
 
 	common_filters.exact_party_match = "exact_party_match" in (document_types or [])
+	common_filters.multi_currency = "multi_currency" in (document_types or [])
 	common_filters.description = transaction.description
 
 	if "payment_entry" in document_types:
@@ -1029,13 +1030,14 @@ def get_si_matching_query(
 		.where(sip.clearance_date.isnull())
 		.where(sip.account == common_filters.bank_account)
 		.where(amount_filter)
-		.where(si.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
+	if not common_filters.multi_currency:
+		query = query.where(si.currency == currency)
 
 	return query
 
@@ -1074,12 +1076,13 @@ def get_unpaid_si_matching_query(
 		else Cast(0, "int")
 	)
 
-	date_condition = (sales_invoice.posting_date == common_filters.date) | (
-		sales_invoice.due_date == common_filters.date
-	)
-	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+	rank_expression = ref_rank + party_rank + amount_rank + name_match + ref_match + 1
 
-	rank_expression = ref_rank + party_rank + amount_rank + date_rank + name_match + ref_match + 1
+	company_currency = frappe.get_value("Company", company, "default_currency")
+	if currency == company_currency:
+		paid_amount_field = sales_invoice.outstanding_amount
+	else:
+		paid_amount_field = sales_invoice.grand_total
 
 	query = (
 		frappe.qb.from_(sales_invoice)
@@ -1087,7 +1090,7 @@ def get_unpaid_si_matching_query(
 			rank_expression.as_("rank"),
 			ConstantColumn("Sales Invoice").as_("doctype"),
 			sales_invoice.name.as_("name"),
-			sales_invoice.outstanding_amount.as_("paid_amount"),
+			Abs(paid_amount_field).as_("paid_amount"),
 			sales_invoice[reference_field or "name"].as_("reference_no"),
 			sales_invoice.posting_date.as_("reference_date"),
 			sales_invoice.customer.as_("party"),
@@ -1097,7 +1100,6 @@ def get_unpaid_si_matching_query(
 			sales_invoice.currency,
 			party_rank.as_("party_match"),
 			amount_rank.as_("amount_match"),
-			date_rank.as_("date_match"),
 			name_match.as_("name_in_desc_match"),
 			(ref_match).as_("ref_in_desc_match"),
 			(ref_rank).as_("reference_number_match"),
@@ -1105,7 +1107,6 @@ def get_unpaid_si_matching_query(
 		.where(sales_invoice.docstatus == 1)
 		.where(sales_invoice.company == company)  # because we do not have bank account check
 		.where(sales_invoice.outstanding_amount != 0.0)
-		.where(sales_invoice.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1116,6 +1117,11 @@ def get_unpaid_si_matching_query(
 		query = query.where(sales_invoice.outstanding_amount == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
+	if not common_filters.multi_currency:
+		query = query.where(sales_invoice.currency == currency)
+	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
+	if currency != company_currency:
+		query = query.where(sales_invoice.outstanding_amount == sales_invoice.base_grand_total)
 
 	return query
 
@@ -1199,13 +1205,14 @@ def get_pi_matching_query(
 		.where(purchase_invoice.clearance_date.isnull())
 		.where(purchase_invoice.cash_bank_account == common_filters.bank_account)
 		.where(amount_filter)
-		.where(purchase_invoice.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
 
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
+	if not common_filters.multi_currency:
+		query = query.where(purchase_invoice.currency == currency)
 
 	return query
 
@@ -1249,22 +1256,23 @@ def get_unpaid_pi_matching_query(
 		else Cast(0, "int")
 	)
 
-	date_condition = (
-		(purchase_invoice.posting_date == common_filters.date)
-		| (purchase_invoice.due_date == common_filters.date)
-		| (purchase_invoice.bill_date == common_filters.date)
-	)
-	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
+	rank_expression = ref_rank + party_match + amount_rank + name_match + ref_match + 1
 
-	rank_expression = ref_rank + party_match + amount_rank + date_rank + name_match + ref_match + 1
+	company_currency = frappe.get_value("Company", company, "default_currency")
+	if currency == company_currency:
+		paid_amount_field = purchase_invoice.outstanding_amount
+	else:
+		paid_amount_field = purchase_invoice.grand_total
 
+	# We skip date rank as the date of an unpaid bill is mostly
+	# earlier than the date of the bank transaction
 	query = (
 		frappe.qb.from_(purchase_invoice)
 		.select(
 			rank_expression.as_("rank"),
 			ConstantColumn("Purchase Invoice").as_("doctype"),
 			purchase_invoice.name.as_("name"),
-			purchase_invoice.outstanding_amount.as_("paid_amount"),
+			Abs(paid_amount_field).as_("paid_amount"),
 			purchase_invoice[reference_field].as_("reference_no"),
 			purchase_invoice.bill_date.as_("reference_date"),
 			purchase_invoice.supplier.as_("party"),
@@ -1274,7 +1282,6 @@ def get_unpaid_pi_matching_query(
 			purchase_invoice.currency,
 			party_match.as_("party_match"),
 			amount_rank.as_("amount_match"),
-			date_rank.as_("date_match"),
 			name_match.as_("name_in_desc_match"),
 			ref_match.as_("ref_in_desc_match"),
 			ref_rank.as_("reference_number_match"),
@@ -1283,7 +1290,6 @@ def get_unpaid_pi_matching_query(
 		.where(purchase_invoice.company == company)
 		.where(purchase_invoice.outstanding_amount != 0.0)
 		.where(purchase_invoice.is_paid == 0)
-		.where(purchase_invoice.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1294,6 +1300,11 @@ def get_unpaid_pi_matching_query(
 		query = query.where(purchase_invoice.outstanding_amount == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
+	if not common_filters.multi_currency:
+		query = query.where(purchase_invoice.currency == currency)
+	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
+	if currency != company_currency:
+		query = query.where(purchase_invoice.outstanding_amount == purchase_invoice.base_grand_total)
 
 	return query
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -13,7 +13,7 @@ from erpnext.accounts.utils import get_account_currency
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
-from frappe.query_builder.functions import Cast, Coalesce, Sum, Abs
+from frappe.query_builder.functions import Cast, Coalesce, Sum
 from frappe.utils import cint, flt, sbool
 from pypika import Order
 
@@ -1121,7 +1121,9 @@ def get_unpaid_si_matching_query(
 	if not common_filters.multi_currency:
 		query = query.where(sales_invoice.currency == currency)
 	elif currency != company_currency:
-		query = query.where((sales_invoice.currency == currency) | (sales_invoice.currency == company_currency))
+		query = query.where(
+			(sales_invoice.currency == currency) | (sales_invoice.currency == company_currency)
+		)
 	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
 	if currency != company_currency:
 		query = query.where(sales_invoice.outstanding_amount == sales_invoice.base_grand_total)
@@ -1307,7 +1309,9 @@ def get_unpaid_pi_matching_query(
 	if not common_filters.multi_currency:
 		query = query.where(purchase_invoice.currency == currency)
 	elif currency != company_currency:
-		query = query.where((purchase_invoice.currency == currency) | (purchase_invoice.currency == company_currency))
+		query = query.where(
+			(purchase_invoice.currency == currency) | (purchase_invoice.currency == company_currency)
+		)
 	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
 	if currency != company_currency:
 		query = query.where(purchase_invoice.outstanding_amount == purchase_invoice.base_grand_total)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -13,7 +13,7 @@ from erpnext.accounts.utils import get_account_currency
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
-from frappe.query_builder.functions import Cast, Coalesce, Sum
+from frappe.query_builder.functions import Cast, Coalesce, Sum, Abs
 from frappe.utils import cint, flt, sbool
 from pypika import Order
 
@@ -582,6 +582,7 @@ def get_matching_queries(
 	is_deposit = transaction.deposit > 0.0
 
 	common_filters.exact_party_match = "exact_party_match" in (document_types or [])
+	common_filters.multi_currency = "multi_currency" in (document_types or [])
 	common_filters.description = transaction.description
 
 	if "payment_entry" in document_types:
@@ -1079,8 +1080,10 @@ def get_unpaid_si_matching_query(
 	company_currency = frappe.get_value("Company", company, "default_currency")
 	if currency == company_currency:
 		paid_amount_field = sales_invoice.outstanding_amount
+		currency_field = ConstantColumn(company_currency).as_("currency")
 	else:
 		paid_amount_field = sales_invoice.grand_total
+		currency_field = sales_invoice.currency
 
 	query = (
 		frappe.qb.from_(sales_invoice)
@@ -1095,7 +1098,7 @@ def get_unpaid_si_matching_query(
 			ConstantColumn("Customer").as_("party_type"),
 			sales_invoice.customer_name.as_("party_name"),
 			sales_invoice.posting_date,
-			sales_invoice.currency,
+			currency_field,
 			party_rank.as_("party_match"),
 			amount_rank.as_("amount_match"),
 			name_match.as_("name_in_desc_match"),
@@ -1105,7 +1108,6 @@ def get_unpaid_si_matching_query(
 		.where(sales_invoice.docstatus == 1)
 		.where(sales_invoice.company == company)  # because we do not have bank account check
 		.where(sales_invoice.outstanding_amount != 0.0)
-		.where(sales_invoice.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1116,6 +1118,10 @@ def get_unpaid_si_matching_query(
 		query = query.where(sales_invoice.outstanding_amount == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
+	if not common_filters.multi_currency:
+		query = query.where(sales_invoice.currency == currency)
+	elif currency != company_currency:
+		query = query.where((sales_invoice.currency == currency) | (sales_invoice.currency == company_currency))
 	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
 	if currency != company_currency:
 		query = query.where(sales_invoice.outstanding_amount == sales_invoice.base_grand_total)
@@ -1257,8 +1263,10 @@ def get_unpaid_pi_matching_query(
 	company_currency = frappe.get_value("Company", company, "default_currency")
 	if currency == company_currency:
 		paid_amount_field = purchase_invoice.outstanding_amount
+		currency_field = ConstantColumn(company_currency).as_("currency")
 	else:
 		paid_amount_field = purchase_invoice.grand_total
+		currency_field = purchase_invoice.currency
 
 	# We skip date rank as the date of an unpaid bill is mostly
 	# earlier than the date of the bank transaction
@@ -1275,7 +1283,7 @@ def get_unpaid_pi_matching_query(
 			ConstantColumn("Supplier").as_("party_type"),
 			purchase_invoice.supplier_name.as_("party_name"),
 			purchase_invoice.posting_date,
-			purchase_invoice.currency,
+			currency_field,
 			party_match.as_("party_match"),
 			amount_rank.as_("amount_match"),
 			name_match.as_("name_in_desc_match"),
@@ -1286,7 +1294,6 @@ def get_unpaid_pi_matching_query(
 		.where(purchase_invoice.company == company)
 		.where(purchase_invoice.outstanding_amount != 0.0)
 		.where(purchase_invoice.is_paid == 0)
-		.where(purchase_invoice.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1297,6 +1304,10 @@ def get_unpaid_pi_matching_query(
 		query = query.where(purchase_invoice.outstanding_amount == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
+	if not common_filters.multi_currency:
+		query = query.where(purchase_invoice.currency == currency)
+	elif currency != company_currency:
+		query = query.where((purchase_invoice.currency == currency) | (purchase_invoice.currency == company_currency))
 	# In case that the invoice is not the company currency, only support full invoice amounts (avoiding exchange rate issues)
 	if currency != company_currency:
 		query = query.where(purchase_invoice.outstanding_amount == purchase_invoice.base_grand_total)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -33,9 +33,12 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 			"Sales Invoice", dict(fieldname="custom_ref_no", label="Ref No", fieldtype="Data")
 		)  # commits to db internally
 
-		create_bank()
+		# Create a single shared bank for all tests
+		cls.test_bank = create_bank("Test Bank Shared", "TESTBANK01")
+
+		# Create default INR bank account
 		cls.gl_account = create_bank_gl_account("_Test Bank Reco Tool")
-		cls.bank_account = create_bank_account(gl_account=cls.gl_account)
+		cls.bank_account = create_bank_account(bank_name=cls.test_bank.name, gl_account=cls.gl_account)
 		cls.customer = create_customer(customer_name="ABC Inc.")
 
 		cls.create_item(cls, item_name="Reco Item", company="_Test Company", warehouse="Finished Goods - _TC")
@@ -680,7 +683,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 
 	def test_usd_jv_against_eur_company(self):
 		"""Test if the tool can create a USD Journal Entry against a EUR company."""
-		bank = create_bank("Citi Bank USD", swift_number="CITIUS34")
 		gl_account = create_bank_gl_account("_Test USD Bank Reco Tool", "USD")
 		usd_receivable_account = frappe.get_doc(
 			{
@@ -693,7 +695,7 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 				"account_currency": "USD",
 			}
 		).insert()
-		bank_account = create_bank_account(bank.name, gl_account, "USD Account")
+		bank_account = create_bank_account(self.test_bank.name, gl_account, "USD Account")
 		customer = create_customer(customer_name="USD Inc.", currency="USD")
 
 		bt = create_bank_transaction(
@@ -725,6 +727,583 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(bt.status, "Reconciled")
 		self.assertEqual(len(bt.payment_entries), 1)
 		self.assertEqual(bt.payment_entries[0].allocated_amount, 200)
+
+	def test_usd_invoice_usd_bank_same_currency(self):
+		"""Test USD invoice + USD bank transaction (same currency baseline)."""
+		# Create USD bank setup (reuse shared bank)
+		usd_gl_account = create_bank_gl_account("_Test USD Bank Account", "USD")
+		usd_bank_account = create_bank_account(self.test_bank.name, usd_gl_account, "USD Account")
+		usd_customer = create_customer("USD Customer", currency="USD")
+
+		# Create USD invoice and USD bank transaction
+		si = create_sales_invoice(
+			rate=100,
+			currency="USD",
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+			conversion_rate=90,
+		)
+
+		self.assertEqual(si.grand_total, 100.0)  # USD
+		self.assertEqual(si.base_grand_total, 9000.0)  # INR
+
+		bt = create_bank_transaction(
+			deposit=100,
+			currency="USD",
+			bank_account=usd_bank_account,
+			reference_no="usd-same-001",
+		)
+
+		# Reconcile using existing bulk_reconcile_vouchers pattern
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps([{"payment_doctype": "Sales Invoice", "payment_name": si.name}]),
+		)
+
+		bt.reload()
+		si.reload()
+		self.assertEqual(len(bt.payment_entries), 1)
+		self.assertEqual(bt.payment_entries[0].allocated_amount, 100)
+		self.assertEqual(bt.status, "Reconciled")
+		self.assertEqual(si.outstanding_amount, 0)
+
+		# Verify Payment Entry structure and amounts for same currency
+		pe = frappe.get_doc("Payment Entry", bt.payment_entries[0].payment_entry)
+		self.assertEqual(pe.payment_type, "Receive")
+		self.assertEqual(len(pe.references), 1)
+		self.assertEqual(pe.references[0].reference_name, si.name)
+
+		# Verify Payment Entry amounts depend on account currencies
+		self.assertEqual(pe.paid_amount, si.base_grand_total)
+		self.assertEqual(pe.received_amount, si.grand_total)
+		self.assertEqual(pe.references[0].allocated_amount, si.base_grand_total)
+
+		# Verify Payment Entry account currencies
+		self.assertEqual(pe.paid_from_account_currency, si.party_account_currency)
+		self.assertEqual(pe.paid_to_account_currency, "USD")
+
+		# Bank transaction allocated amount matches bank currency
+		self.assertEqual(bt.payment_entries[0].allocated_amount, si.grand_total)
+
+	def test_usd_invoice_inr_bank_cross_currency_pe(self):
+		"""Test USD invoice + INR bank transaction via Payment Entry."""
+		inr_gl_account = create_bank_gl_account("_Test INR Bank Account", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR Account")
+		usd_customer = create_customer("USD Customer Cross", currency="USD")
+
+		si = create_sales_invoice(
+			rate=100,
+			currency="USD",
+			conversion_rate=90,
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+		bt = create_bank_transaction(
+			deposit=si.base_grand_total,
+			currency="INR",
+			bank_account=inr_bank_account,
+			reference_no="inr-cross-001",
+		)
+
+		# Reconcile and verify PE creation
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps([{"payment_doctype": "Sales Invoice", "payment_name": si.name}]),
+		)
+
+		bt.reload()
+		si.reload()
+		self.assertEqual(len(bt.payment_entries), 1)
+		self.assertEqual(bt.payment_entries[0].payment_document, "Payment Entry")
+		self.assertEqual(bt.status, "Reconciled")
+		self.assertEqual(si.outstanding_amount, 0)
+
+		# Verify Payment Entry has multi-currency setup and correct amounts
+		pe = frappe.get_doc("Payment Entry", bt.payment_entries[0].payment_entry)
+		self.assertEqual(pe.payment_type, "Receive")
+		self.assertTrue(len(pe.references) > 0)
+		self.assertEqual(pe.references[0].reference_name, si.name)
+
+		# Verify Payment Entry amounts are in company currency
+		self.assertEqual(pe.paid_amount, si.base_grand_total)
+		self.assertEqual(pe.received_amount, si.base_grand_total)
+		self.assertEqual(pe.references[0].allocated_amount, si.base_grand_total)
+
+		# Verify Bank Transaction allocation
+		self.assertEqual(bt.payment_entries[0].allocated_amount, si.base_grand_total)
+
+		# Verify Payment Entry account currencies
+		self.assertEqual(pe.paid_from_account_currency, si.party_account_currency)
+		self.assertEqual(pe.paid_to_account_currency, "INR")
+
+		# Verify conversion calculations
+		self.assertEqual(si.grand_total, 100.0)
+		self.assertEqual(si.base_grand_total, 9000.0)
+		self.assertEqual(pe.paid_amount, 9000.0)
+		self.assertEqual(pe.received_amount, 9000.0)
+		self.assertEqual(pe.references[0].allocated_amount, 9000.0)
+
+	def test_multi_currency_flag_in_get_linked_payments(self):
+		"""Test multi_currency flag behavior in get_linked_payments.
+
+		Without multi_currency flag, query filters to same currency only.
+		With multi_currency flag, allows cross-currency matches (with constraint).
+		"""
+		# Setup cross-currency scenario: USD invoice, INR bank
+		inr_gl_account = create_bank_gl_account("_Test INR Bank Flag", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR Flag Account")
+		usd_customer = create_customer("USD Customer Flag", currency="USD")
+
+		si = create_sales_invoice(
+			rate=100,
+			currency="USD",
+			conversion_rate=90,  # 1 USD = 90 INR
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+		bt = create_bank_transaction(
+			deposit=si.base_grand_total,  # 9000 INR
+			currency="INR",
+			bank_account=inr_bank_account,
+			reference_no="flag-test-001",
+		)
+
+		# Test without multi_currency flag
+		matches_without = get_linked_payments(
+			bt.name,
+			["sales_invoice", "unpaid_invoices"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+
+		# Test with multi_currency flag
+		matches_with = get_linked_payments(
+			bt.name,
+			["sales_invoice", "unpaid_invoices", "multi_currency"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+
+		# Verify results
+		self.assertIsInstance(matches_without, list)
+		self.assertIsInstance(matches_with, list)
+
+		# Verify behavior difference
+		invoice_found_without = any(match["name"] == si.name for match in matches_without)
+		invoice_found_with = any(match["name"] == si.name for match in matches_with)
+
+		# Without flag: USD invoice should NOT be found for INR bank
+		self.assertFalse(
+			invoice_found_without, "USD invoice should NOT be found for INR bank without multi_currency flag"
+		)
+
+		# With flag: USD invoice SHOULD be found for INR bank
+		self.assertTrue(
+			invoice_found_with, "USD invoice SHOULD be found for INR bank with multi_currency flag"
+		)
+
+		# Verify matched invoice has correct amount
+		if invoice_found_with:
+			matched_invoice = next(match for match in matches_with if match["name"] == si.name)
+			self.assertEqual(matched_invoice["paid_amount"], si.base_grand_total)
+
+	def test_multiple_usd_invoices_inr_bank_pe(self):
+		"""Test multiple USD invoices + INR bank transaction."""
+		inr_gl_account = create_bank_gl_account("_Test INR Bank Multi", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR Multi Account")
+		usd_customer = create_customer("USD Customer Multi", currency="USD")
+
+		si1 = create_sales_invoice(
+			rate=60,
+			currency="USD",
+			conversion_rate=90,
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+		si2 = create_sales_invoice(
+			rate=40,
+			currency="USD",
+			conversion_rate=90,
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+		total_base_amount = si1.base_grand_total + si2.base_grand_total
+		bt = create_bank_transaction(
+			deposit=total_base_amount,
+			currency="INR",
+			bank_account=inr_bank_account,
+			reference_no="multi-usd-001",
+		)
+
+		# Reconcile both invoices against single INR transaction
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps(
+				[
+					{"payment_doctype": "Sales Invoice", "payment_name": si1.name},
+					{"payment_doctype": "Sales Invoice", "payment_name": si2.name},
+				]
+			),
+		)
+
+		bt.reload()
+		si1.reload()
+		si2.reload()
+		self.assertEqual(len(bt.payment_entries), 1)
+		self.assertEqual(bt.status, "Reconciled")
+		self.assertEqual(si1.outstanding_amount, 0)
+		self.assertEqual(si2.outstanding_amount, 0)
+
+		# Verify Payment Entry references both invoices with correct amounts
+		pe = frappe.get_doc("Payment Entry", bt.payment_entries[0].payment_entry)
+		self.assertEqual(len(pe.references), 2)
+		reference_names = [ref.reference_name for ref in pe.references]
+		self.assertIn(si1.name, reference_names)
+		self.assertIn(si2.name, reference_names)
+
+		# Verify Payment Entry amounts are in company currency
+		total_base_amount = si1.base_grand_total + si2.base_grand_total
+		self.assertEqual(pe.paid_amount, total_base_amount)
+		self.assertEqual(pe.received_amount, total_base_amount)
+		self.assertEqual(pe.paid_amount, 9000.0)
+		self.assertEqual(pe.received_amount, 9000.0)
+
+		# Verify individual allocations
+		for ref in pe.references:
+			if ref.reference_name == si1.name:
+				self.assertEqual(ref.allocated_amount, si1.base_grand_total)
+				self.assertEqual(ref.allocated_amount, 5400.0)
+			elif ref.reference_name == si2.name:
+				self.assertEqual(ref.allocated_amount, si2.base_grand_total)
+				self.assertEqual(ref.allocated_amount, 3600.0)
+
+		# Verify invoice base amounts
+		self.assertEqual(si1.base_grand_total, 5400.0)
+		self.assertEqual(si2.base_grand_total, 3600.0)
+
+	def test_usd_return_invoice_inr_bank(self):
+		"""Test USD return invoice + INR bank transaction."""
+		inr_gl_account = create_bank_gl_account("_Test INR Bank Return", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR Return Account")
+		usd_customer = create_customer("USD Customer Return", currency="USD")
+
+		return_si = create_sales_invoice(
+			rate=100,
+			qty=-1,
+			currency="USD",
+			conversion_rate=90,
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+			is_return=1,
+		)
+		bt = create_bank_transaction(
+			withdrawal=abs(return_si.base_grand_total),
+			currency="INR",
+			bank_account=inr_bank_account,
+			reference_no="return-usd-001",
+		)
+
+		# Reconcile and verify negative amounts handled correctly
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps([{"payment_doctype": "Sales Invoice", "payment_name": return_si.name}]),
+		)
+
+		bt.reload()
+		return_si.reload()
+		self.assertEqual(len(bt.payment_entries), 1)
+		self.assertEqual(bt.status, "Reconciled")
+		self.assertEqual(return_si.outstanding_amount, 0)
+
+		# Verify Payment Entry handles negative amounts correctly
+		pe = frappe.get_doc("Payment Entry", bt.payment_entries[0].payment_entry)
+		self.assertEqual(pe.payment_type, "Pay")  # Should be Pay for return/refund
+		self.assertEqual(len(pe.references), 1)
+		self.assertEqual(pe.references[0].reference_name, return_si.name)
+
+		# Verify multi-currency amounts for return invoice
+		# For Pay type: received_amount = abs(sum(allocated_amount)), paid_amount = bt.allocated_amount
+		# The abs() function ensures PE amounts are positive even though allocated_amount is negative
+		self.assertEqual(pe.received_amount, abs(return_si.base_grand_total))
+		self.assertEqual(pe.paid_amount, abs(return_si.base_grand_total))
+		self.assertEqual(pe.references[0].allocated_amount, return_si.base_grand_total)
+
+		# Verify return invoice amounts are negative
+		self.assertLess(return_si.grand_total, 0)
+		self.assertLess(return_si.base_grand_total, 0)
+		self.assertLess(pe.references[0].allocated_amount, 0)
+
+		# Verify Payment Entry amounts are in company currency and positive
+		self.assertEqual(pe.paid_amount, 9000.0)
+		self.assertEqual(pe.received_amount, 9000.0)
+
+	def test_cross_currency_full_amount_constraint(self):
+		"""Test outstanding_amount == base_grand_total constraint for cross-currency.
+
+		The constraint 'outstanding_amount == base_grand_total' is applied when:
+		  bank_currency != company_currency
+		This ensures only full invoice amounts are matched for cross-currency scenarios
+		to avoid exchange rate issues.
+		"""
+		eur_gl_account = create_bank_gl_account("_Test EUR Bank Constraint", "EUR")
+		eur_bank_account = create_bank_account(self.test_bank.name, eur_gl_account, "EUR Constraint Account")
+		usd_customer = create_customer("USD Customer Constraint", currency="USD")
+
+		si = create_sales_invoice(
+			rate=100,
+			currency="USD",
+			conversion_rate=90,
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+
+		# Verify initial state: constraint satisfied
+		si.reload()
+		self.assertEqual(si.outstanding_amount, si.base_grand_total)
+
+		# Make partial payment to violate constraint
+		# This will make outstanding_amount != base_grand_total
+		inr_gl_temp = create_bank_gl_account("_Test INR Temp", "INR")
+		create_bank_account(self.test_bank.name, inr_gl_temp, "INR Temp Account")
+
+		# Create and submit partial payment entry linked to the invoice
+		pe_partial = create_payment_entry(
+			payment_type="Receive",
+			party_type="Customer",
+			party=usd_customer,
+			paid_from="Debtors - _TC",
+			paid_to=inr_gl_temp,
+			paid_amount=4500,
+			received_amount=4500,
+		)
+		pe_partial.append(
+			"references",
+			{
+				"reference_doctype": "Sales Invoice",
+				"reference_name": si.name,
+				"allocated_amount": 4500,
+			},
+		)
+		pe_partial.insert()
+		pe_partial.submit()
+
+		si.reload()
+		# Verify constraint is now violated after partial payment
+		self.assertLess(si.outstanding_amount, si.base_grand_total)
+		self.assertEqual(si.outstanding_amount, 4500.0)
+		self.assertEqual(si.base_grand_total, 9000.0)
+
+		# Create EUR bank transaction
+		bt = create_bank_transaction(
+			deposit=50.0,
+			currency="EUR",
+			bank_account=eur_bank_account,
+			reference_no="constraint-test-001",
+		)
+
+		# Test get_linked_payments with multi_currency flag
+		# The invoice should NOT be found due to constraint violation
+		matches = get_linked_payments(
+			bt.name,
+			["sales_invoice", "unpaid_invoices", "multi_currency"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+
+		# Verify the partially paid invoice is NOT matched due to constraint
+		invoice_found = any(match["name"] == si.name for match in matches)
+		self.assertFalse(
+			invoice_found,
+			"Partially paid invoice should NOT be matched when bank_currency != company_currency",
+		)
+
+	def test_mixed_currency_invoices_inr_bank(self):
+		"""Test mixed currency invoices (USD + GBP) with INR bank.
+
+		Note: A single Payment Entry can only be created against invoices from the same customer.
+		For multiple customers, use multi-party Journal Entry reconciliation instead.
+		This test uses the same customer with multiple currency invoices.
+		"""
+		inr_gl_account = create_bank_gl_account("_Test INR Bank Mixed", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR Mixed Account")
+
+		mixed_customer = create_customer("Mixed Currency Customer")
+
+		usd_si = create_sales_invoice(
+			rate=100,
+			currency="USD",
+			conversion_rate=90,
+			warehouse="Finished Goods - _TC",
+			customer=mixed_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+		gbp_si = create_sales_invoice(
+			rate=80,
+			currency="GBP",
+			conversion_rate=100,
+			warehouse="Finished Goods - _TC",
+			customer=mixed_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+
+		# Verify invoice amounts after creation
+		self.assertEqual(usd_si.grand_total, 100.0)
+		self.assertEqual(usd_si.base_grand_total, 9000.0)
+		self.assertEqual(gbp_si.grand_total, 80.0)
+		self.assertEqual(gbp_si.base_grand_total, 8000.0)
+
+		total_base_amount = usd_si.base_grand_total + gbp_si.base_grand_total
+		bt = create_bank_transaction(
+			deposit=total_base_amount,
+			currency="INR",
+			bank_account=inr_bank_account,
+			reference_no="mixed-curr-001",
+		)
+
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps(
+				[
+					{"payment_doctype": "Sales Invoice", "payment_name": usd_si.name},
+					{"payment_doctype": "Sales Invoice", "payment_name": gbp_si.name},
+				]
+			),
+		)
+
+		bt.reload()
+		usd_si.reload()
+		gbp_si.reload()
+
+		self.assertGreater(len(bt.payment_entries), 0)
+		self.assertEqual(usd_si.outstanding_amount, 0)
+		self.assertEqual(gbp_si.outstanding_amount, 0)
+
+		# Verify Payment Entry amounts
+		pe = frappe.get_doc("Payment Entry", bt.payment_entries[0].payment_entry)
+		expected_total_base = usd_si.base_grand_total + gbp_si.base_grand_total
+
+		self.assertEqual(pe.received_amount, expected_total_base)
+		self.assertEqual(pe.received_amount, 17000.0)
+		self.assertEqual(len(pe.references), 2)
+
+	def test_multi_party_multi_currency_jv(self):
+		"""Test multi-party Journal Entry with different currency invoices."""
+		inr_gl_account = create_bank_gl_account("_Test INR Multi Party", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR Multi Party Account")
+
+		usd_customer = create_customer("USD Customer Party", currency="USD")
+		eur_customer = create_customer("EUR Customer Party", currency="EUR")
+
+		usd_si = create_sales_invoice(
+			rate=100,
+			currency="USD",
+			conversion_rate=90,
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+		eur_si = create_sales_invoice(
+			rate=50,
+			currency="EUR",
+			conversion_rate=100,
+			warehouse="Finished Goods - _TC",
+			customer=eur_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+
+		# Verify invoice amounts after creation
+		self.assertEqual(usd_si.grand_total, 100.0)
+		self.assertEqual(usd_si.base_grand_total, 9000.0)
+		self.assertEqual(eur_si.grand_total, 50.0)
+		self.assertEqual(eur_si.base_grand_total, 5000.0)
+
+		total_base_amount = usd_si.base_grand_total + eur_si.base_grand_total
+		bt = create_bank_transaction(
+			deposit=total_base_amount,
+			currency="INR",
+			bank_account=inr_bank_account,
+			reference_no="multi-party-curr-001",
+		)
+
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps(
+				[
+					{
+						"payment_doctype": "Sales Invoice",
+						"payment_name": usd_si.name,
+						"party": usd_customer,
+					},
+					{
+						"payment_doctype": "Sales Invoice",
+						"payment_name": eur_si.name,
+						"party": eur_customer,
+					},
+				]
+			),
+			reconcile_multi_party=True,
+		)
+
+		bt.reload()
+		usd_si.reload()
+		eur_si.reload()
+
+		self.assertEqual(len(bt.payment_entries), 1)
+		self.assertEqual(bt.payment_entries[0].payment_document, "Journal Entry")
+		self.assertEqual(bt.status, "Reconciled")
+
+		je = frappe.get_doc("Journal Entry", bt.payment_entries[0].payment_entry)
+		self.assertEqual(je.voucher_type, "Bank Entry")
+		self.assertGreaterEqual(len(je.accounts), 3)
+
+		# Verify multi_currency flag is False
+		# All JE accounts are in company currency even though invoices are USD/EUR
+		self.assertFalse(je.multi_currency)
+
+		# Verify Journal Entry totals
+		expected_total = usd_si.base_grand_total + eur_si.base_grand_total
+		self.assertEqual(je.total_debit, expected_total)
+		self.assertEqual(je.total_credit, expected_total)
+		self.assertEqual(je.total_debit, 14000.0)
+		self.assertEqual(je.total_credit, 14000.0)
+
+		# Verify individual account entries
+		bank_account_found = False
+		usd_account_found = False
+		eur_account_found = False
+
+		for account in je.accounts:
+			if account.account == inr_gl_account:
+				self.assertEqual(account.debit_in_account_currency, 14000.0)
+				bank_account_found = True
+			elif account.reference_name == usd_si.name:
+				self.assertEqual(account.credit_in_account_currency, 9000.0)
+				usd_account_found = True
+			elif account.reference_name == eur_si.name:
+				self.assertEqual(account.credit_in_account_currency, 5000.0)
+				eur_account_found = True
+
+		self.assertTrue(bank_account_found)
+		self.assertTrue(usd_account_found)
+		self.assertTrue(eur_account_found)
 
 
 def get_pe_references(vouchers: list):

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -6,10 +6,14 @@ import frappe
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 	create_payment_entry,
 )
+from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import (
+	make_purchase_invoice,
+)
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
 	create_sales_invoice,
 )
 from erpnext.accounts.test.accounts_mixin import AccountsTestMixin
+from erpnext.controllers.tests.test_accounts_controller import make_supplier as _make_supplier
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, getdate
@@ -534,6 +538,12 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(je.total_debit, 150)
 		self.assertEqual(je.total_credit, 150)
 
+		# All JE account currencies must match bank account currency
+		bank_gl = frappe.db.get_value("Bank Account", bt.bank_account, "account")
+		bank_currency = frappe.db.get_value("Account", bank_gl, "account_currency")
+		for row in je.accounts:
+			self.assertEqual(row.account_currency, bank_currency)
+
 		self.assertEqual(len(bt.payment_entries), 1)
 		self.assertEqual(bt.payment_entries[0].allocated_amount, 150)
 		self.assertEqual(bt.status, "Reconciled")
@@ -681,8 +691,8 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(first_match["name"], journal_entry.name)
 		self.assertEqual(first_match["paid_amount"], 200.0)
 
-	def test_usd_jv_against_eur_company(self):
-		"""Test if the tool can create a USD Journal Entry against a EUR company."""
+	def test_usd_jv_against_foreign_currency_setup(self):
+		"""Test if the tool can create a USD Journal Entry against a non-company currency bank."""
 		gl_account = create_bank_gl_account("_Test USD Bank Reco Tool", "USD")
 		usd_receivable_account = frappe.get_doc(
 			{
@@ -727,6 +737,176 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(bt.status, "Reconciled")
 		self.assertEqual(len(bt.payment_entries), 1)
 		self.assertEqual(bt.payment_entries[0].allocated_amount, 200)
+
+	def test_usd_invoice_inr_bank_partial_allowed(self):
+		"""INR bank (company currency) allows partial against USD invoice (base amounts)."""
+		inr_gl_account = create_bank_gl_account("_Test INR Bank Partial", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR Partial Account")
+		usd_customer = create_customer("USD Cust Partial", currency="USD")
+
+		si = create_sales_invoice(
+			rate=100,
+			currency="USD",
+			conversion_rate=90,
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+
+		bt = create_bank_transaction(
+			deposit=4500.0,
+			currency="INR",
+			bank_account=inr_bank_account,
+			reference_no="inr-partial-001",
+		)
+
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps([{"payment_doctype": "Sales Invoice", "payment_name": si.name}]),
+		)
+
+		bt.reload()
+		si.reload()
+		self.assertEqual(si.base_grand_total, 9000.0)
+		self.assertEqual(si.outstanding_amount, 4500.0)
+		self.assertEqual(bt.payment_entries[0].allocated_amount, 4500.0)
+		self.assertEqual(bt.unallocated_amount, 0.0)
+
+	def test_paid_purchase_invoice_visible_without_unpaid_filter(self):
+		"""Paid Purchase Invoices without clearance date should appear when unpaid filter is off."""
+		inr_gl_account = create_bank_gl_account("_Test INR Bank PI Paid", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR PI Paid Account")
+		bt = create_bank_transaction(withdrawal=100.0, currency="INR", bank_account=inr_bank_account)
+
+		# Ensure supplier exists to avoid missing payment terms template
+		_make_supplier("_Test Supplier")
+
+		pi = make_purchase_invoice(
+			qty=1,
+			rate=100,
+			is_paid=1,
+			cash_bank_account=inr_gl_account,
+			item="Reco Item",
+			supplier_warehouse="Finished Goods - _TC",
+			warehouse="Finished Goods - _TC",
+			uom="Nos",
+			cost_center="Main - _TC",
+			expense_account="Cost of Goods Sold - _TC",
+		)
+		pi.reload()
+
+		matches = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["purchase_invoice"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		pi_names = [m["name"] for m in matches if m["doctype"] == "Purchase Invoice"]
+		self.assertIn(pi.name, pi_names)
+
+		# With unpaid filter, paid PI should not be listed under unpaid invoices
+		matches_unpaid = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["purchase_invoice", "unpaid_invoices"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		pi_names_unpaid = [m["name"] for m in matches_unpaid if m["doctype"] == "Purchase Invoice"]
+		self.assertNotIn(pi.name, pi_names_unpaid)
+
+	def test_expense_claims_visible_only_with_unpaid_filter(self):
+		"""Expense Claims should appear only when unpaid filter is on for withdrawals."""
+		inr_gl_account = create_bank_gl_account("_Test INR Bank EC", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR EC Account")
+		bt = create_bank_transaction(withdrawal=200.0, currency="INR", bank_account=inr_bank_account)
+
+		ec = make_expense_claim(
+			payable_account=frappe.db.get_value("Company", bt.company, "default_payable_account"),
+			amount=200,
+			sanctioned_amount=200,
+			company=bt.company,
+			account="Travel Expenses - _TC",
+		)
+
+		# Without unpaid filter, should not show
+		matches_no_unpaid = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["expense_claim"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		ec_names = [m.get("name") for m in matches_no_unpaid if m.get("doctype") == "Expense Claim"]
+		self.assertEqual(len(ec_names), 0)
+
+		# With unpaid filter, should show
+		matches_with_unpaid = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["expense_claim", "unpaid_invoices"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		ec_names_unpaid = [m.get("name") for m in matches_with_unpaid if m.get("doctype") == "Expense Claim"]
+		self.assertIn(ec.name, ec_names_unpaid)
+
+	def test_withdrawal_shows_unpaid_return_sales_invoice(self):
+		"""Withdrawal BT with unpaid filter should list return Sales Invoices (unpaid)."""
+		inr_gl_account = create_bank_gl_account("_Test INR Bank Return SI", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR Return SI Account")
+		bt = create_bank_transaction(withdrawal=100.0, currency="INR", bank_account=inr_bank_account)
+
+		customer = create_customer()
+		return_si = create_sales_invoice(
+			rate=100,
+			qty=-1,
+			warehouse="Finished Goods - _TC",
+			customer=customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+			is_return=1,
+		)
+
+		matches = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["sales_invoice", "unpaid_invoices"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		si_names = [m["name"] for m in matches if m["doctype"] == "Sales Invoice"]
+		self.assertIn(return_si.name, si_names)
+
+	def test_get_linked_payments_uses_grand_total_when_bank_currency_differs(self):
+		"""When bank currency != company currency, unpaid SI matching uses grand_total."""
+		usd_gl_account = create_bank_gl_account("_Test USD Bank GL", "USD")
+		usd_bank_account = create_bank_account(self.test_bank.name, usd_gl_account, "USD Bank GL Account")
+		usd_customer = create_customer("USD Cust GT", currency="USD")
+
+		si = create_sales_invoice(
+			rate=100,
+			currency="USD",
+			conversion_rate=90,
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+
+		bt = create_bank_transaction(
+			deposit=10.0,
+			currency="USD",
+			bank_account=usd_bank_account,
+			reference_no="usd-grandtotal-001",
+		)
+
+		matches = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["sales_invoice", "unpaid_invoices", "multi_currency"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		matched = next((m for m in matches if m["doctype"] == "Sales Invoice" and m["name"] == si.name), None)
+		self.assertIsNotNone(matched)
+		self.assertEqual(matched["paid_amount"], si.grand_total)
 
 	def test_usd_invoice_usd_bank_same_currency(self):
 		"""Test USD invoice + USD bank transaction (same currency baseline)."""
@@ -1304,6 +1484,50 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertTrue(bank_account_found)
 		self.assertTrue(usd_account_found)
 		self.assertTrue(eur_account_found)
+
+	def test_multi_party_je_currency_mismatch_raises(self):
+		"""Multi-party JE should raise if an invoice receivable currency != bank currency."""
+		inr_gl_account = create_bank_gl_account("_Test INR Bank JE Mismatch", "INR")
+		inr_bank_account = create_bank_account(self.test_bank.name, inr_gl_account, "INR JE Mismatch Account")
+		usd_receivable = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"company": "_Test Company",
+				"parent_account": "Accounts Receivable - _TC",
+				"account_type": "Receivable",
+				"is_group": 0,
+				"account_name": "US Debtors - _TC",
+				"account_currency": "USD",
+			}
+		).insert()
+		usd_customer = create_customer("USD Mismatch Cust", currency="USD")
+
+		usd_si = create_sales_invoice(
+			rate=100,
+			currency="USD",
+			conversion_rate=90,
+			warehouse="Finished Goods - _TC",
+			customer=usd_customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+			debit_to=usd_receivable.name,
+		)
+
+		bt = create_bank_transaction(
+			deposit=usd_si.base_grand_total,
+			currency="INR",
+			bank_account=inr_bank_account,
+			reference_no="je-curr-mismatch-001",
+		)
+
+		with self.assertRaises(frappe.ValidationError):
+			bulk_reconcile_vouchers(
+				bt.name,
+				json.dumps(
+					[{"payment_doctype": "Sales Invoice", "payment_name": usd_si.name, "party": usd_customer}]
+				),
+				reconcile_multi_party=True,
+			)
 
 
 def get_pe_references(vouchers: list):

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -173,18 +173,14 @@ def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list
 		payment_entry.received_amount = abs(
 			sum(row.allocated_amount for row in payment_entry.references)
 		)  # should not be negative
-		frappe.msgprint(str(bt.__dict__))
 		payment_entry.paid_amount = bt.allocated_amount
 		payment_entry.source_exchange_rate = get_exchange_rate(bt.currency, company_currency, bt.date)
 	else:
 		payment_entry.paid_amount = abs(
 			sum(row.allocated_amount for row in payment_entry.references)
 		)  # should not be negative
-		frappe.msgprint(str(bt.__dict__))
 		payment_entry.received_amount = bt.allocated_amount
 		payment_entry.target_exchange_rate = get_exchange_rate(bt.currency, company_currency, bt.date)
-	# frappe.msgprint(payment_entry.__dict__)
-	# frappe.throw(str(payment_entry.as_dict()))
 	payment_entry.submit()
 	return payment_entry
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -9,14 +9,11 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import (
 	get_payment_entry,
 	split_invoices_based_on_payment_terms,
 )
-from erpnext.accounts.doctype.bank_transaction.bank_transaction import get_clearance_details
+from erpnext.accounts.utils import get_currency_precision
+from erpnext.setup.utils import get_exchange_rate
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import flt
-
-from erpnext.setup.utils import get_exchange_rate
-
-from erpnext.accounts.utils import get_currency_precision
 
 if TYPE_CHECKING:
 	from banking.overrides.bank_transaction import CustomBankTransaction
@@ -186,8 +183,8 @@ def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list
 		frappe.msgprint(str(bt.__dict__))
 		payment_entry.received_amount = bt.allocated_amount
 		payment_entry.target_exchange_rate = get_exchange_rate(bt.currency, company_currency, bt.date)
-	#frappe.msgprint(payment_entry.__dict__)
-	#frappe.throw(str(payment_entry.as_dict()))
+	# frappe.msgprint(payment_entry.__dict__)
+	# frappe.throw(str(payment_entry.as_dict()))
 	payment_entry.submit()
 	return payment_entry
 
@@ -225,19 +222,23 @@ def prepare_invoices_to_split(invoices):
 	return invoices_to_split
 
 
-def get_positive_and_negative_sums(bt_deposit: float, bt_unallocated: float, invoices: list, bt_company_currency_match):
+def get_positive_and_negative_sums(
+	bt_deposit: float, bt_unallocated: float, invoices: list, bt_company_currency_match
+):
 	"""
 	Calculate a permissible positive and negative upper limit sum for the allocation.
 	This will ensure that the allocated positive and negative amounts add up to the unallocated amount.
 	"""
-	
+
 	sum_positive = 0.0
 	sum_negative = 0.0
 	for invoice in invoices:
 		if bt_company_currency_match:
 			conversion_rate = 1.0
 		else:
-			conversion_rate = frappe.get_value(invoice.voucher_type, invoice.voucher_no, "conversion_rate") or 1.0
+			conversion_rate = (
+				frappe.get_value(invoice.voucher_type, invoice.voucher_no, "conversion_rate") or 1.0
+			)
 
 		if invoice.outstanding_amount > 0:
 			sum_positive = sum_positive + (invoice.outstanding_amount / conversion_rate)
@@ -266,14 +267,16 @@ def adjust_and_allocate_invoices(
 	The `payment_voucher` object is mutated by param:action.
 	Only same currency allocations are supported: BT Currency == Invoice Currency
 	"""
-	
+
 	company_currency = frappe.get_value("Company", bt.company, "default_currency")
 	if bt.currency == company_currency:
 		bt_company_currency_match = True
 	else:
 		bt_company_currency_match = False
 
-	sum_positive, sum_negative = get_positive_and_negative_sums(bt.deposit, bt.unallocated_amount, invoices, bt_company_currency_match)
+	sum_positive, sum_negative = get_positive_and_negative_sums(
+		bt.deposit, bt.unallocated_amount, invoices, bt_company_currency_match
+	)
 	currency_precision = get_currency_precision() or 2
 
 	for row in invoices:

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -9,9 +9,14 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import (
 	get_payment_entry,
 	split_invoices_based_on_payment_terms,
 )
+from erpnext.accounts.doctype.bank_transaction.bank_transaction import get_clearance_details
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import flt
+
+from erpnext.setup.utils import get_exchange_rate
+
+from erpnext.accounts.utils import get_currency_precision
 
 if TYPE_CHECKING:
 	from banking.overrides.bank_transaction import CustomBankTransaction
@@ -164,15 +169,25 @@ def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list
 	invoices = split_invoices_based_on_payment_terms(prepare_invoices_to_split(invoices_to_bill), bt.company)
 	adjust_and_allocate_invoices(bt, invoices, payment_entry, action=_attach_invoice)
 
+	company_currency = frappe.get_value("Company", bt.company, "default_currency")
+
 	# Payment Entry automatically does the exchange rate conversion
 	if payment_entry.payment_type == "Pay":
 		payment_entry.received_amount = abs(
 			sum(row.allocated_amount for row in payment_entry.references)
 		)  # should not be negative
+		frappe.msgprint(str(bt.__dict__))
+		payment_entry.paid_amount = bt.allocated_amount
+		payment_entry.source_exchange_rate = get_exchange_rate(bt.currency, company_currency, bt.date)
 	else:
 		payment_entry.paid_amount = abs(
 			sum(row.allocated_amount for row in payment_entry.references)
 		)  # should not be negative
+		frappe.msgprint(str(bt.__dict__))
+		payment_entry.received_amount = bt.allocated_amount
+		payment_entry.target_exchange_rate = get_exchange_rate(bt.currency, company_currency, bt.date)
+	#frappe.msgprint(payment_entry.__dict__)
+	#frappe.throw(str(payment_entry.as_dict()))
 	payment_entry.submit()
 	return payment_entry
 
@@ -215,12 +230,16 @@ def get_positive_and_negative_sums(bt_deposit: float, bt_unallocated: float, inv
 	Calculate a permissible positive and negative upper limit sum for the allocation.
 	This will ensure that the allocated positive and negative amounts add up to the unallocated amount.
 	"""
-	sum_positive = (
-		sum(invoice.outstanding_amount for invoice in invoices if invoice.outstanding_amount > 0) or 0.0
-	)
-	sum_negative = (
-		abs(sum(invoice.outstanding_amount for invoice in invoices if invoice.outstanding_amount < 0)) or 0.0
-	)
+	
+	sum_positive = 0.0
+	sum_negative = 0.0
+	for invoice in invoices:
+		conversion_rate = frappe.get_value(invoice.voucher_type, invoice.voucher_no, "conversion_rate") or 1.0
+		if invoice.outstanding_amount > 0:
+			sum_positive = sum_positive + (invoice.outstanding_amount / conversion_rate)
+		else:
+			sum_negative = sum_negative + abs(invoice.outstanding_amount / conversion_rate)
+
 	validate_sums(bt_deposit, sum_positive, sum_negative, invoices)
 
 	# Adjust the positive sum (trim it) if overallocated
@@ -241,22 +260,30 @@ def adjust_and_allocate_invoices(
 	Adjust and allocate the invoicees to the payment voucher based on
 	the unallocated amount.
 	The `payment_voucher` object is mutated by param:action.
+	Only same currency allocations are supported: BT Currency == Invoice Currency
 	"""
-	sum_postive, sum_negative = get_positive_and_negative_sums(bt.deposit, bt.unallocated_amount, invoices)
+
+	sum_positive, sum_negative = get_positive_and_negative_sums(bt.deposit, bt.unallocated_amount, invoices)
+	currency_precision = get_currency_precision() or 2
+
 	for row in invoices:
+		conversion_rate = frappe.get_value(row.voucher_type, row.voucher_no, "conversion_rate") or 1.0
 		if row.outstanding_amount > 0:
-			if sum_postive <= 0:
+			if sum_positive <= 0:
 				continue
-			row_allocated_amount = min(row.outstanding_amount, sum_postive)
-			sum_postive -= row_allocated_amount
+			row_allocated_amount = min(row.outstanding_amount / conversion_rate, sum_positive)
+			bt.allocated_amount += row_allocated_amount
+			sum_positive -= row_allocated_amount
 		else:
 			if sum_negative <= 0:
 				continue
-			can_allocate = min(abs(row.outstanding_amount), sum_negative)
+			can_allocate = min(abs(row.outstanding_amount / (conversion_rate or 1.0)), sum_negative)
+			bt.allocated_amount += can_allocate
 			row_allocated_amount = -1 * can_allocate
 			sum_negative -= can_allocate
 
-		row.allocated_amount = row_allocated_amount
+		row.allocated_amount = flt(row_allocated_amount * conversion_rate, currency_precision)
+
 		# Attach the invoice to/Mutate the payment voucher
 		action(row, payment_voucher)
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -164,9 +164,15 @@ def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list
 	invoices = split_invoices_based_on_payment_terms(prepare_invoices_to_split(invoices_to_bill), bt.company)
 	adjust_and_allocate_invoices(bt, invoices, payment_entry, action=_attach_invoice)
 
-	payment_entry.paid_amount = abs(
-		sum(row.allocated_amount for row in payment_entry.references)
-	)  # should not be negative
+	# Payment Entry automatically does the exchange rate conversion
+	if payment_entry.payment_type == "Pay":
+		payment_entry.received_amount = abs(
+			sum(row.allocated_amount for row in payment_entry.references)
+		)  # should not be negative
+	else:
+		payment_entry.paid_amount = abs(
+			sum(row.allocated_amount for row in payment_entry.references)
+		)  # should not be negative
 	payment_entry.submit()
 	return payment_entry
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -276,6 +276,7 @@ def adjust_and_allocate_invoices(
 		bt_company_currency_match = True
 	else:
 		bt_company_currency_match = False
+	bt.allocated_amount = 0
 
 	sum_positive, sum_negative = get_positive_and_negative_sums(
 		bt.deposit, bt.unallocated_amount, invoices, bt_company_currency_match
@@ -296,7 +297,7 @@ def adjust_and_allocate_invoices(
 		else:
 			if sum_negative <= 0:
 				continue
-			can_allocate = min(abs(row.outstanding_amount / (conversion_rate or 1.0)), sum_negative)
+			can_allocate = min(abs(row.outstanding_amount / conversion_rate), sum_negative)
 			bt.allocated_amount += can_allocate
 			row_allocated_amount = -1 * can_allocate
 			sum_negative -= can_allocate

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -225,7 +225,7 @@ def prepare_invoices_to_split(invoices):
 	return invoices_to_split
 
 
-def get_positive_and_negative_sums(bt_deposit: float, bt_unallocated: float, invoices: list):
+def get_positive_and_negative_sums(bt_deposit: float, bt_unallocated: float, invoices: list, bt_company_currency_match):
 	"""
 	Calculate a permissible positive and negative upper limit sum for the allocation.
 	This will ensure that the allocated positive and negative amounts add up to the unallocated amount.
@@ -234,7 +234,11 @@ def get_positive_and_negative_sums(bt_deposit: float, bt_unallocated: float, inv
 	sum_positive = 0.0
 	sum_negative = 0.0
 	for invoice in invoices:
-		conversion_rate = frappe.get_value(invoice.voucher_type, invoice.voucher_no, "conversion_rate") or 1.0
+		if bt_company_currency_match:
+			conversion_rate = 1.0
+		else:
+			conversion_rate = frappe.get_value(invoice.voucher_type, invoice.voucher_no, "conversion_rate") or 1.0
+
 		if invoice.outstanding_amount > 0:
 			sum_positive = sum_positive + (invoice.outstanding_amount / conversion_rate)
 		else:
@@ -262,12 +266,21 @@ def adjust_and_allocate_invoices(
 	The `payment_voucher` object is mutated by param:action.
 	Only same currency allocations are supported: BT Currency == Invoice Currency
 	"""
+	
+	company_currency = frappe.get_value("Company", bt.company, "default_currency")
+	if bt.currency == company_currency:
+		bt_company_currency_match = True
+	else:
+		bt_company_currency_match = False
 
-	sum_positive, sum_negative = get_positive_and_negative_sums(bt.deposit, bt.unallocated_amount, invoices)
+	sum_positive, sum_negative = get_positive_and_negative_sums(bt.deposit, bt.unallocated_amount, invoices, bt_company_currency_match)
 	currency_precision = get_currency_precision() or 2
 
 	for row in invoices:
-		conversion_rate = frappe.get_value(row.voucher_type, row.voucher_no, "conversion_rate") or 1.0
+		if bt_company_currency_match:
+			conversion_rate = 1.0
+		else:
+			conversion_rate = frappe.get_value(row.voucher_type, row.voucher_no, "conversion_rate") or 1.0
 		if row.outstanding_amount > 0:
 			if sum_positive <= 0:
 				continue

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -416,6 +416,15 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				fieldtype: "Column Break",
 			},
 			{
+				label: __("Multi-Currency"),
+				fieldname: "multi_currency",
+				fieldtype: "Check",
+				default: filters_state.multi_currency,
+				onchange: (e) => {
+					this.populate_matching_vouchers(e);
+				},
+			},
+			{
 				fieldtype: "Section Break",
 			},
 			{

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -213,7 +213,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		let unallocated =
 			flt(this.transaction.unallocated_amount) - flt(max_allocated);
 		let actual_unallocated =
-			flt(this.transaction.unallocated_amount) - flt(total_allocated);
+			flt(this.transaction.unallocated_amount) - Math.abs(flt(total_allocated));
 
 		this.render_transaction_amount_summary(
 			flt(transaction_amount),
@@ -414,15 +414,6 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			},
 			{
 				fieldtype: "Column Break",
-			},
-			{
-				label: __("Multi-Currency"),
-				fieldname: "multi_currency",
-				fieldtype: "Check",
-				default: filters_state.multi_currency,
-				onchange: (e) => {
-					this.populate_matching_vouchers(e);
-				},
 			},
 			{
 				fieldtype: "Section Break",

--- a/banking/public/js/bank_reconciliation_beta/panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/panel_manager.js
@@ -75,6 +75,7 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 		this.actions_filters.exact_match = 0;
 		this.actions_filters.exact_party_match = 0;
 		this.actions_filters.unpaid_invoices = 1;
+		this.actions_filters.multi_currency = 0;
 	}
 
 	render_no_transactions() {

--- a/banking/public/js/bank_reconciliation_beta/panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/panel_manager.js
@@ -75,7 +75,6 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 		this.actions_filters.exact_match = 0;
 		this.actions_filters.exact_party_match = 0;
 		this.actions_filters.unpaid_invoices = 1;
-		this.actions_filters.multi_currency = 0;
 	}
 
 	render_no_transactions() {

--- a/banking/utils.py
+++ b/banking/utils.py
@@ -33,6 +33,10 @@ def before_tests():
 			}
 		)
 
+		frappe.db.set_single_value(
+			"Accounts Settings", "allow_multi_currency_invoices_against_single_party_account", 1
+		)
+
 	frappe.db.commit()  # nosemgrep
 
 


### PR DESCRIPTION
This PR fixes existing multi-currency support. Multi-currency reconciliation only works with invoices where the invoice currency is in the bank transaction currency or with bank transactions in company currency.

Sales Invoices and Purchase Invoices (only fully unpaid are supported) can be reconciled against their issuing curreny or company currency.

The invoice value in company currency is used as a basis. This value was calculated at the moment of booking the invoice. As soon as the invoice is paid, the currency of the day (or whatever is in the Currency Exchange DocType) is used for an evaluation of the current payment situation. In case the currency exchange rate changed, a gain or loss is automatically created. These accounts need to be defined in the company settings.

Addtitionally the invoices are set to their "payment" status percentage according to the currency exchange rate set in the invoice. This ensures, that a 100 USD invoice requires 100 USD or the equivilent in company currency at the time of booking to be fully paid.

Multi invoices are supported, each with their own conversion rate.

Features and fixes:
 #102, #189, #271 