### PR TITLE
fix(Match Tab): set options for IBAN field

### DIFF
--- a/banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js
@@ -147,6 +147,7 @@ erpnext.accounts.bank_reconciliation.DetailsTab = class DetailsTab {
 				label: __("Party IBAN"),
 				fieldname: "iban",
 				fieldtype: "Data",
+				options: "IBAN",
 				default: this.transaction.bank_party_iban,
 				read_only: 1,
 				hidden: this.transaction.bank_party_iban ? 0 : 1,


### PR DESCRIPTION
This way, IBAN is formatted in blocks of 4
