### PR TITLE
fix: avoid hardcoded zero cutoff

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -45,7 +45,7 @@ def get_bank_transactions(
 	filters = [
 		["bank_account", "=", bank_account],
 		["docstatus", "=", 1],
-		["unallocated_amount", ">", 0.001],
+		["status", "not in", ["Reconciled", "Cancelled"]],
 	]
 
 	if to_date:


### PR DESCRIPTION
Some currencies hold significant worth in smaller decimals.
