### PR TITLE
fix: Fixes the bank list display and sorts them

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1456,7 +1456,7 @@ def bank_query(doctype: str, txt: str, searchfield: str, start: int, page_len: i
 		limit_start=start,
 		limit_page_length=page_len,
 		group_by="bank",
-		order_by="bank"
+		order_by="bank",
 	)
 
 	return [(result,) for result in results]

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1458,5 +1458,5 @@ def bank_query(doctype: str, txt: str, searchfield: str, start: int, page_len: i
 	)
 	results = list(dict.fromkeys(results))
 	results.sort()
-	
+
 	return [(result,) for result in results]

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1455,8 +1455,8 @@ def bank_query(doctype: str, txt: str, searchfield: str, start: int, page_len: i
 		pluck="bank",
 		limit_start=start,
 		limit_page_length=page_len,
+		group_by="bank",
+		order_by="bank"
 	)
-	results = list(dict.fromkeys(results))
-	results.sort()
 
 	return [(result,) for result in results]

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1456,4 +1456,7 @@ def bank_query(doctype: str, txt: str, searchfield: str, start: int, page_len: i
 		limit_start=start,
 		limit_page_length=page_len,
 	)
+	results = list(dict.fromkeys(results))
+	results.sort()
+	
 	return [(result,) for result in results]


### PR DESCRIPTION
The bank filter in the reconciliation tool contained the same key twice, separated by ", " and not all banks where shown. This PR deduplicates the results and sorts the banks.