### PR TITLE
fix!: unique ID for sub-transactions

### DIFF
--- a/banking/custom_fields.py
+++ b/banking/custom_fields.py
@@ -79,4 +79,12 @@ def get_custom_fields():
 				allow_on_submit=1,
 			),
 		],
+		"Bank Transaction": [
+			dict(
+				fieldname="subtransaction_id",
+				label=_("Subtransaction ID"),
+				fieldtype="Data",
+				insert_after="transaction_id",
+			),
+		],
 	}

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -258,6 +258,8 @@ def process_camt_document(
 			# Skip PDNG and INFO transactions
 			continue
 
+		transaction_id = get_transaction_id(transaction)
+
 		if (
 			transaction.batch
 			and (split_batch_transactions or len(transaction) == 1)
@@ -267,20 +269,22 @@ def process_camt_document(
 			# from camt.054 that is sometimes available.
 			# If that's not possible, create a single transaction
 			for sub_transaction_index, sub_transaction in enumerate(transaction):
+				sub_transaction_id = get_transaction_id(sub_transaction, sub_transaction_index)
 				create_sepa_bank_transaction(
 					bank_account,
 					company,
 					sub_transaction,
-					earliest_date,
-					is_sub_transaction=True,
-					subtransaction_index=sub_transaction_index,
+					transaction_id=transaction_id,
+					subtransaction_id=sub_transaction_id,
+					start_date=earliest_date,
 				)
 		else:
 			create_sepa_bank_transaction(
 				bank_account,
 				company,
 				transaction,
-				earliest_date,
+				transaction_id=transaction_id,
+				start_date=earliest_date,
 			)
 
 
@@ -288,8 +292,9 @@ def create_sepa_bank_transaction(
 	bank_account: str,
 	company: str,
 	sepa_transaction: "SEPATransaction",
-	start_date: "date | None" = None,
-	subtransaction_index: int | None = None,
+	transaction_id: str,
+	subtransaction_id: str | None = None,
+	start_date: date | None = None,
 ):
 	"""Create an ERPNext Bank Transaction from a given fintech.sepa.SEPATransaction.
 
@@ -301,7 +306,8 @@ def create_sepa_bank_transaction(
 	amount = float(sepa_transaction.amount.value)
 	create_bank_transaction(
 		bank_account=bank_account,
-		transaction_id=get_transaction_id(sepa_transaction, subtransaction_index),
+		transaction_id=transaction_id,
+		subtransaction_id=subtransaction_id,
 		company=company,
 		currency=sepa_transaction.amount.currency,
 		description="\n".join(sepa_transaction.purpose) or sepa_transaction.info,
@@ -475,19 +481,49 @@ def create_mt940_bank_transaction(
 def create_bank_transaction(
 	bank_account: str,
 	transaction_id: str,
+	subtransaction_id: str | None = None,
 	**kwargs,
 ):
-	"""Create a bank transaction from the given kwargs."""
-	# NOTE: This does not work for old data, this ID is different from Kosma's.
-	if frappe.db.exists(
+	"""Create a bank transaction from the given kwargs.
+
+	NOTE: This does not prevent duplicate transactions for old data, this ID is
+	different from Kosma's.
+	"""
+	if subtransaction_id:
+		# Check if we have already created a single batch transaction.
+		# Then this subtransaction would be a duplicate resulting from changed batch-splitting settings.
+		if frappe.db.exists(
+			"Bank Transaction",
+			{
+				"transaction_id": transaction_id,
+				"bank_account": bank_account,
+				"subtransaction_id": ("is", "not set"),
+			},
+		):
+			return
+
+		# Check if this subtransaction has already been created.
+		if frappe.db.exists(
+			"Bank Transaction",
+			{
+				"transaction_id": transaction_id,
+				"bank_account": bank_account,
+				"subtransaction_id": subtransaction_id,
+			},
+		):
+			return
+	elif frappe.db.exists(
 		"Bank Transaction",
 		{"transaction_id": transaction_id, "bank_account": bank_account},
 	):
+		# This is not a subtransaction and we have already created a transaction with this ID.
+		# We should only allow additional subtransactions.
 		return
 
 	bt: CustomBankTransaction = frappe.new_doc("Bank Transaction")
 	bt.bank_account = bank_account
 	bt.transaction_id = transaction_id
+	bt.subtransaction_id = subtransaction_id
 	bt.update(kwargs)
 
 	with contextlib.suppress(frappe.exceptions.UniqueValidationError):

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -266,12 +266,14 @@ def process_camt_document(
 			# Split batch transactions into sub-transactions, based on info
 			# from camt.054 that is sometimes available.
 			# If that's not possible, create a single transaction
-			for sub_transaction in transaction:
+			for sub_transaction_index, sub_transaction in enumerate(transaction):
 				create_sepa_bank_transaction(
 					bank_account,
 					company,
 					sub_transaction,
 					earliest_date,
+					is_sub_transaction=True,
+					sub_transaction_index=sub_transaction_index,
 				)
 		else:
 			create_sepa_bank_transaction(
@@ -287,6 +289,8 @@ def create_sepa_bank_transaction(
 	company: str,
 	sepa_transaction: "SEPATransaction",
 	start_date: "date | None" = None,
+	is_sub_transaction: bool = False,
+	sub_transaction_index: int = 0,
 ):
 	"""Create an ERPNext Bank Transaction from a given fintech.sepa.SEPATransaction.
 
@@ -306,16 +310,26 @@ def create_sepa_bank_transaction(
 		*sepa_transaction.purpose,
 	]
 
-	amount = float(sepa_transaction.amount.value)
-	create_bank_transaction(
-		bank_account=bank_account,
-		transaction_id=(
+	if is_sub_transaction:
+		if sepa_transaction._xmlobj.Refs.TxId.text:
+			transaction_id = sepa_transaction._xmlobj.Refs.TxId.text
+		elif sepa_transaction.bank_reference:
+			transaction_id = f"{sepa_transaction.bank_reference}-{sub_transaction_index}"
+		else:
+			transaction_id = get_transaction_hash(values_to_hash)
+	else:
+		transaction_id = (
 			# sepa_transaction.bank_reference can be None, but we can still find an ID in the XML
 			# For our test bank, the latter is a timestamp with nanosecond accuracy.
 			sepa_transaction.bank_reference
 			or sepa_transaction._xmlobj.Refs.TxId.text
 			or get_transaction_hash(values_to_hash)
-		),
+		)
+
+	amount = float(sepa_transaction.amount.value)
+	create_bank_transaction(
+		bank_account=bank_account,
+		transaction_id=transaction_id,
 		company=company,
 		currency=sepa_transaction.amount.currency,
 		description="\n".join(sepa_transaction.purpose) or sepa_transaction.info,

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -294,7 +294,7 @@ def create_sepa_bank_transaction(
 	sepa_transaction: "SEPATransaction",
 	transaction_id: str,
 	subtransaction_id: str | None = None,
-	start_date: date | None = None,
+	start_date: "date | None" = None,
 ):
 	"""Create an ERPNext Bank Transaction from a given fintech.sepa.SEPATransaction.
 

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -273,7 +273,7 @@ def process_camt_document(
 					sub_transaction,
 					earliest_date,
 					is_sub_transaction=True,
-					sub_transaction_index=sub_transaction_index,
+					subtransaction_index=sub_transaction_index,
 				)
 		else:
 			create_sepa_bank_transaction(
@@ -289,8 +289,7 @@ def create_sepa_bank_transaction(
 	company: str,
 	sepa_transaction: "SEPATransaction",
 	start_date: "date | None" = None,
-	is_sub_transaction: bool = False,
-	sub_transaction_index: int = 0,
+	subtransaction_index: int | None = None,
 ):
 	"""Create an ERPNext Bank Transaction from a given fintech.sepa.SEPATransaction.
 
@@ -299,37 +298,10 @@ def create_sepa_bank_transaction(
 	if start_date and sepa_transaction.date < start_date:
 		return
 
-	values_to_hash = [
-		sepa_transaction.date,
-		sepa_transaction.iban,
-		sepa_transaction.name,
-		sepa_transaction.eref,
-		sepa_transaction.amount.value,
-		sepa_transaction.amount.currency,
-		sepa_transaction.info,
-		*sepa_transaction.purpose,
-	]
-
-	if is_sub_transaction:
-		if sepa_transaction._xmlobj.Refs.TxId.text:
-			transaction_id = sepa_transaction._xmlobj.Refs.TxId.text
-		elif sepa_transaction.bank_reference:
-			transaction_id = f"{sepa_transaction.bank_reference}-{sub_transaction_index}"
-		else:
-			transaction_id = get_transaction_hash(values_to_hash)
-	else:
-		transaction_id = (
-			# sepa_transaction.bank_reference can be None, but we can still find an ID in the XML
-			# For our test bank, the latter is a timestamp with nanosecond accuracy.
-			sepa_transaction.bank_reference
-			or sepa_transaction._xmlobj.Refs.TxId.text
-			or get_transaction_hash(values_to_hash)
-		)
-
 	amount = float(sepa_transaction.amount.value)
 	create_bank_transaction(
 		bank_account=bank_account,
-		transaction_id=transaction_id,
+		transaction_id=get_transaction_id(sepa_transaction, subtransaction_index),
 		company=company,
 		currency=sepa_transaction.amount.currency,
 		description="\n".join(sepa_transaction.purpose) or sepa_transaction.info,
@@ -349,6 +321,39 @@ def get_transaction_hash(transaction: list):
 			sha.update(frappe.safe_encode(str(value)))
 
 	return sha.hexdigest()
+
+
+def get_transaction_id(sepa_transaction: "SEPATransaction", subtransaction_index: int | None = None):
+	"""Return a transaction ID for the given SEPA transaction.
+
+	If a subtransaction index is provided, the transaction is treated as a sub-transaction.
+	"""
+	values_to_hash = [
+		sepa_transaction.date,
+		sepa_transaction.iban,
+		sepa_transaction.name,
+		sepa_transaction.eref,
+		sepa_transaction.amount.value,
+		sepa_transaction.amount.currency,
+		sepa_transaction.info,
+		*sepa_transaction.purpose,
+	]
+
+	if subtransaction_index is not None:
+		if sepa_transaction._xmlobj.Refs.TxId.text:
+			return sepa_transaction._xmlobj.Refs.TxId.text
+		elif sepa_transaction.bank_reference:
+			return f"{sepa_transaction.bank_reference}-{subtransaction_index}"
+		else:
+			return get_transaction_hash(values_to_hash)
+	else:
+		return (
+			# sepa_transaction.bank_reference can be None, but we can still find an ID in the XML
+			# For our test bank, the latter is a timestamp with nanosecond accuracy.
+			sepa_transaction.bank_reference
+			or sepa_transaction._xmlobj.Refs.TxId.text
+			or get_transaction_hash(values_to_hash)
+		)
 
 
 def log_request(

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -208,7 +208,15 @@ alyf_banking_property_setters = {
 			value="",
 			property_type="Small Text",
 		),
-	]
+	],
+	"Bank Transaction": [
+		dict(
+			fieldname="transaction_id",
+			property="unique",
+			value=0,
+			property_type="Check",
+		),
+	],
 }
 
 # Bank Reconciliation Doctypes are defined in the respective apps.

--- a/banking/patches.txt
+++ b/banking/patches.txt
@@ -1,5 +1,5 @@
 [pre_model_sync]
-banking.patches.recreate_custom_fields # 2025-09-29
+banking.patches.recreate_custom_fields # 2025-10-23
 banking.patches.remove_spaces_from_iban
 
 [post_model_sync]

--- a/banking/patches.txt
+++ b/banking/patches.txt
@@ -11,3 +11,4 @@ execute:frappe.delete_doc_if_exists("Custom Field", "Bank Transaction-kosma_part
 execute:from banking.install import insert_custom_records; insert_custom_records()
 banking.patches.set_voucher_matching_defaults
 banking.patches.download_batch_transactions
+execute:from banking.install import make_property_setters; make_property_setters()


### PR DESCRIPTION
This pull request updates the logic for processing and creating SEPA bank transactions, particularly improving how sub-transactions are handled when parsing CAMT documents. The main focus is on generating more accurate and unique transaction IDs for sub-transactions, reducing the risk of duplicate or ambiguous IDs.

Improvements to sub-transaction handling:

* The `create_sepa_bank_transaction` function now accepts two new parameters: `is_sub_transaction` and `sub_transaction_index`, allowing it to distinguish between main transactions and sub-transactions and to track the index of each sub-transaction.
* When processing a batch of sub-transactions, the loop in `process_camt_document` now passes `is_sub_transaction=True` and the current `sub_transaction_index` to `create_sepa_bank_transaction`, ensuring each sub-transaction is properly identified.

Improvements to transaction ID generation:

* For sub-transactions, the transaction ID is now determined by first checking for an explicit XML transaction ID, then falling back to a combination of the bank reference and sub-transaction index, or finally hashing relevant values. This provides more robust and unique IDs for sub-transactions.
* The logic for main transactions remains unchanged, but is now clearly separated from the sub-transaction logic, improving code clarity and maintainability.

### Original Issue

So far, we preferred `bank_reference` as the transaction ID, if it was available. However, in case of batch transactions, `bank_reference` can be the same for all sub-transactions (the value is only available on the top-level transaction, but copied down to the sub-transactions by fintech). This meant that only the first sub-transaction was being imported and other sub-transactions were silently dropped as duplicates.

We need to be careful with changing the transaction ID logic to prevent duplicates for existing users.

Ref: DRC-158

Resolves #307

<details>
<summary>User docs</summary>

# Fixing Partial Batch Transaction Imports

## Problem Description

Due to a previous issue with transaction ID generation, batch transactions (transactions containing multiple sub-transactions) may have been only partially imported. Specifically, only the first sub-transaction was imported while subsequent sub-transactions were silently dropped as duplicates.

## How to Identify Affected Transactions

### 1. Check for Batch Transactions
Look for transactions where the bank grouped multiple payments together. Common indicators:
- Transaction descriptions mentioning "batch", "collective", or "bulk"
- Transactions with amounts that seem to represent multiple payments
- Business scenarios where batch processing is common (e.g., salary payments, bulk supplier payments)

### 2. Compare with Bank Statements
- Download your original bank statement (PDF or CSV) for the affected period
- Compare the number of individual transactions shown in the statement with what's imported in ERPNext
- Look for discrepancies where the bank statement shows multiple sub-transactions but ERPNext only shows one

## Manual Cleanup Process

### Step 1: Document Affected Transactions
Before making any changes, create a list of potentially affected transactions:
- Transaction ID
- Date
- Amount
- Bank Account

### Step 2: Delete the Partial Import
1. Navigate to the Bank Transaction list
2. Filter by the affected date range and bank account
3. Open each identified batch transaction
4. Click on **Menu > Cancel** to cancel the transaction
5. Click on **Menu > Delete** to remove it completely

**Important**: Only delete transactions you've confirmed are partial batch imports.

### Step 3: Re-import the Transactions
1. Go to the EBICS User or your bank import method
2. Set the date range to cover only the period with deleted transactions
3. Run the import process again
4. The system will now properly import all sub-transactions with unique IDs

### Step 4: Verify the Import
After re-importing:
- Check that the number of imported transactions matches your bank statement
- Verify that each sub-transaction has a unique transaction ID
- Confirm the total amounts match your bank statement

## Prevention

This issue has been fixed in the latest version. New batch transaction imports will automatically receive unique IDs for each sub-transaction, preventing this problem from occurring again.

If you're unsure about any step or have a large number of affected transactions, consider:
- Creating a backup before making changes
- Testing the process with one transaction first
- Contacting support for assistance with bulk corrections

</details>