### PR TITLE
fix: include clearance_date in journal entry

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -167,6 +167,7 @@ def create_journal_entry_bts(
 			"cheque_no": reference_number,
 			"mode_of_payment": mode_of_payment,
 			"user_remark": bank_transaction.description,
+			"clearance_date": posting_date,
 		}
 	)
 	journal_entry.set(


### PR DESCRIPTION
This commit adds the clearance_date to the journal entry that is reconciling the bank transaction.

This way, the journal entry is not presented in any case for any other reconciliation.