### PR TITLE
fix: retry daily sync until successful

### DIFF
--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -131,8 +131,8 @@ scheduler_events = {
 			# on every day-of-week from Monday through Friday.
 			"banking.klarna_kosma_integration.doctype.banking_settings.banking_settings.intraday_sync_ebics",
 		],
-		"14 */3 * * *": [
-			# At minute 14 past every 3rd hour.
+		"14 6-22/4 * * *": [
+			# At minute 14 past every 4th hour from 6 through 22.
 			"banking.klarna_kosma_integration.doctype.banking_settings.banking_settings.sync_all_accounts_and_transactions",
 		],
 	},

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -131,8 +131,8 @@ scheduler_events = {
 			# on every day-of-week from Monday through Friday.
 			"banking.klarna_kosma_integration.doctype.banking_settings.banking_settings.intraday_sync_ebics",
 		],
-		"42 4 * * *": [
-			# Daily at 4:42 am
+		"14 */3 * * *": [
+			# At minute 14 past every 3rd hour.
 			"banking.klarna_kosma_integration.doctype.banking_settings.banking_settings.sync_all_accounts_and_transactions",
 		],
 	},

--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2022, ALYF GmbH and contributors
 # For license information, please see license.txt
 
-from datetime import timedelta
+import json
+from datetime import date, timedelta
 
 import frappe
 from frappe import _
@@ -86,7 +87,7 @@ def daily_sync_ebics():
 			_("Developer mode is enabled. Please disable it to continue auto-syncing bank transactions.")
 		)
 
-	yesterday = (now_datetime() - timedelta(days=1)).date().isoformat()
+	yesterday = (now_datetime() - timedelta(days=1)).date()
 	for ebics_user, country in frappe.get_all(
 		"EBICS User",
 		filters={
@@ -98,24 +99,49 @@ def daily_sync_ebics():
 		fields=["name", "country"],
 		as_list=True,
 	):
-		if frappe.db.exists(
-			"EBICS Request",
-			{
-				"ebics_user": ebics_user,
-				"order_type": "Z53" if country == "Switzerland" else "C53",
-				"status": "Successful",
-				"parameters": ("like", f"%{yesterday}%"),
-			},
+		if successful_request_exists(
+			ebics_user, order_type="Z53" if country == "Switzerland" else "C53", request_date=yesterday
 		):
 			continue
 
 		frappe.enqueue(
 			sync_ebics_transactions,
 			requested_by="System",
-			start_date=yesterday,
-			end_date=yesterday,
+			start_date=yesterday.isoformat(),
+			end_date=yesterday.isoformat(),
 			ebics_user=ebics_user,
 		)
+
+
+def successful_request_exists(ebics_user: str | None, order_type: str, request_date: date) -> bool:
+	existing_request = frappe.db.get_value(
+		"EBICS Request",
+		{
+			"ebics_user": ebics_user,
+			"order_type": order_type,
+			"status": "Successful",
+		},
+		["name", "parameters"],
+		as_dict=True,
+	)
+
+	if not existing_request:
+		return False
+
+	try:
+		params = json.loads(existing_request.parameters)
+		start_date = params.get("start_date")
+		end_date = params.get("end_date")
+		if (
+			start_date
+			and end_date
+			and date.fromisoformat(start_date) <= request_date <= date.fromisoformat(end_date)
+		):
+			return True
+	except json.JSONDecodeError:
+		pass  # If we can't parse, let the sync attempt
+
+	return False
 
 
 def intraday_sync_ebics():

--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
@@ -87,7 +87,7 @@ def daily_sync_ebics():
 		)
 
 	yesterday = (now_datetime() - timedelta(days=1)).date().isoformat()
-	for ebics_user in frappe.get_all(
+	for ebics_user, country in frappe.get_all(
 		"EBICS User",
 		filters={
 			"initialized": 1,
@@ -95,8 +95,20 @@ def daily_sync_ebics():
 			"passphrase": ("is", "set"),
 			"keyring": ("is", "set"),
 		},
-		pluck="name",
+		fields=["name", "country"],
+		as_list=True,
 	):
+		if frappe.db.exists(
+			"EBICS Request",
+			{
+				"ebics_user": ebics_user,
+				"order_type": "Z53" if country == "Switzerland" else "C53",
+				"status": "Successful",
+				"parameters": ("like", f"%{yesterday}%"),
+			},
+		):
+			continue
+
 		frappe.enqueue(
 			sync_ebics_transactions,
 			requested_by="System",

--- a/banking/klarna_kosma_integration/doctype/banking_settings/test_banking_settings.py
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/test_banking_settings.py
@@ -1,9 +1,33 @@
 # Copyright (c) 2022, ALYF GmbH and Contributors
 # See license.txt
 
-# import frappe
+import json
+from contextlib import contextmanager
+from datetime import date
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from banking.klarna_kosma_integration.doctype.banking_settings.banking_settings import (
+	successful_request_exists,
+)
 
 
 class TestBankingSettings(FrappeTestCase):
-	pass
+	def test_successful_request_exists(self):
+		with create_successful_request("C53", date(2025, 1, 1), date(2025, 1, 1)) as request:
+			self.assertTrue(successful_request_exists(None, request.order_type, date(2025, 1, 1)))
+			self.assertFalse(successful_request_exists(None, request.order_type, date(2025, 1, 2)))
+
+
+@contextmanager
+def create_successful_request(order_type: str, start_date: date, end_date: date):
+	doc = frappe.new_doc("EBICS Request")
+	doc.order_type = order_type
+	doc.status = "Successful"
+	doc.parameters = json.dumps({"start_date": start_date.isoformat(), "end_date": end_date.isoformat()})
+	doc.save()
+
+	yield doc
+
+	doc.delete()


### PR DESCRIPTION
This pull request updates the scheduling and logic for EBICS daily sync operations to improve efficiency and avoid redundant processing. The key changes involve modifying the sync schedule and enhancing the filtering of EBICS users to prevent duplicate transaction syncs.

**Scheduling updates:**

* Changed the cron schedule for `sync_all_accounts_and_transactions` from daily at 4:42 am to run at minute 14 past every 3rd hour, increasing sync frequency.

**EBICS sync logic improvements:**

* Updated the EBICS user query in `daily_sync_ebics` to retrieve both `name` and `country` fields instead of just `name`, enabling country-specific logic.
* Added a check to skip processing for EBICS users who already have a successful `EBICS Request` for the previous day, using country-specific order types (`Z53` for Switzerland, `C53` otherwise). This prevents duplicate transaction syncs.

Resolves #315