### PR TITLE
fix: multi-currency matching

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -12,6 +12,7 @@ from erpnext.accounts.doctype.bank_transaction.bank_transaction import (
 from erpnext.accounts.utils import get_account_currency
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder import Case
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import Cast, Coalesce, Sum
 from frappe.utils import cint, flt, sbool
@@ -1086,19 +1087,64 @@ def get_si_matching_query(
 
 def get_unpaid_si_matching_query(
 	exact_match: bool,
-	currency: str,
+	currency: str,  # This is B (bank account currency)
 	common_filters: frappe._dict,
 	company: str,
 	include_only_returns: bool = False,
 	reference_field: str = "name",
 ):
+	"""
+	Get matching unpaid sales invoices for bank reconciliation.
+
+	Multi-Currency Handling:
+	- B = Bank account currency (parameter 'currency')
+	- I = Invoice currency (invoice.currency field)
+	- P = Party account currency (invoice.party_account_currency field)
+
+	Amount Selection:
+	- When B = I AND invoice is fully unpaid: Returns grand_total in invoice currency
+	  (User is paying in the same currency as the invoice)
+	- When B ≠ I OR invoice is partially paid: Returns outstanding_amount in party account currency
+	  (ERPNext tracks outstanding in party account currency)
+
+	Note: outstanding_amount is stored in P when P ≠ I, not in I.
+	This is standard ERPNext behavior from taxes_and_totals.py.
+	"""
 	sales_invoice = frappe.qb.DocType("Sales Invoice")
 	description = common_filters.description
+
+	is_fully_unpaid = (
+		Case()
+		.when(
+			sales_invoice.party_account_currency == sales_invoice.currency,
+			sales_invoice.outstanding_amount == sales_invoice.grand_total,
+		)
+		.else_(sales_invoice.outstanding_amount == sales_invoice.base_grand_total)
+	)
+
+	paid_amount_field = (
+		Case()
+		.when(
+			(sales_invoice.currency == currency) & is_fully_unpaid,
+			sales_invoice.grand_total,
+		)
+		.else_(sales_invoice.outstanding_amount)
+	)
+
+	company_currency = frappe.get_value("Company", company, "default_currency")
+	currency_field = (
+		Case()
+		.when(
+			(sales_invoice.currency == currency) & is_fully_unpaid,
+			sales_invoice.currency,
+		)
+		.else_(Coalesce(sales_invoice.party_account_currency, company_currency))
+	)
 
 	party_filter = sales_invoice.customer == common_filters.party
 	party_rank = frappe.qb.terms.Case().when(party_filter, 1).else_(0)
 
-	amount_rank = amount_rank_condition(sales_invoice.outstanding_amount, common_filters.amount)
+	amount_rank = amount_rank_condition(paid_amount_field, common_filters.amount)
 
 	# Check reference field equality with common_filters.reference_no
 	reference_field_is_set = reference_field and reference_field != "name"
@@ -1131,14 +1177,14 @@ def get_unpaid_si_matching_query(
 			rank_expression.as_("rank"),
 			ConstantColumn("Sales Invoice").as_("doctype"),
 			sales_invoice.name.as_("name"),
-			sales_invoice.outstanding_amount.as_("paid_amount"),
+			paid_amount_field.as_("paid_amount"),
 			sales_invoice[reference_field or "name"].as_("reference_no"),
 			sales_invoice.posting_date.as_("reference_date"),
 			sales_invoice.customer.as_("party"),
 			ConstantColumn("Customer").as_("party_type"),
 			sales_invoice.customer_name.as_("party_name"),
 			sales_invoice.posting_date,
-			sales_invoice.currency,
+			currency_field.as_("currency"),
 			party_rank.as_("party_match"),
 			amount_rank.as_("amount_match"),
 			date_rank.as_("date_match"),
@@ -1147,9 +1193,8 @@ def get_unpaid_si_matching_query(
 			(ref_rank).as_("reference_number_match"),
 		)
 		.where(sales_invoice.docstatus == 1)
-		.where(sales_invoice.company == company)  # because we do not have bank account check
+		.where(sales_invoice.company == company)
 		.where(sales_invoice.outstanding_amount != 0.0)
-		.where(sales_invoice.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1157,7 +1202,7 @@ def get_unpaid_si_matching_query(
 	if include_only_returns:
 		query = query.where(sales_invoice.is_return == 1)
 	if exact_match:
-		query = query.where(sales_invoice.outstanding_amount == common_filters.amount)
+		query = query.where(paid_amount_field == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
 
@@ -1256,12 +1301,29 @@ def get_pi_matching_query(
 
 def get_unpaid_pi_matching_query(
 	exact_match: bool,
-	currency: str,
+	currency: str,  # This is B (bank account currency)
 	common_filters: frappe._dict,
 	company: str,
 	include_only_returns: bool = False,
 	reference_field: str = "name",
 ):
+	"""
+	Get matching unpaid purchase invoices for bank reconciliation.
+
+	Multi-Currency Handling:
+	- B = Bank account currency (parameter 'currency')
+	- I = Invoice currency (invoice.currency field)
+	- P = Party account currency (invoice.party_account_currency field)
+
+	Amount Selection:
+	- When B = I AND invoice is fully unpaid: Returns grand_total in invoice currency
+	  (User is paying in the same currency as the invoice)
+	- When B ≠ I OR invoice is partially paid: Returns outstanding_amount in party account currency
+	  (ERPNext tracks outstanding in party account currency)
+
+	Note: outstanding_amount is stored in P when P ≠ I, not in I.
+	This is standard ERPNext behavior from taxes_and_totals.py.
+	"""
 	# Default to bill_no instead of name.
 	# "name" is passed when it is unset. Handle specific default here.
 	if reference_field == "name" or not reference_field:
@@ -1270,10 +1332,38 @@ def get_unpaid_pi_matching_query(
 	purchase_invoice = frappe.qb.DocType("Purchase Invoice")
 	description = common_filters.description
 
+	is_fully_unpaid = (
+		Case()
+		.when(
+			purchase_invoice.party_account_currency == purchase_invoice.currency,
+			purchase_invoice.outstanding_amount == purchase_invoice.grand_total,
+		)
+		.else_(purchase_invoice.outstanding_amount == purchase_invoice.base_grand_total)
+	)
+
+	paid_amount_field = (
+		Case()
+		.when(
+			(purchase_invoice.currency == currency) & is_fully_unpaid,
+			purchase_invoice.grand_total,
+		)
+		.else_(purchase_invoice.outstanding_amount)
+	)
+
+	company_currency = frappe.get_value("Company", company, "default_currency")
+	currency_field = (
+		Case()
+		.when(
+			(purchase_invoice.currency == currency) & is_fully_unpaid,
+			purchase_invoice.currency,
+		)
+		.else_(Coalesce(purchase_invoice.party_account_currency, company_currency))
+	)
+
 	party_filter = purchase_invoice.supplier == common_filters.party
 	party_match = frappe.qb.terms.Case().when(party_filter, 1).else_(0)
 
-	amount_rank = amount_rank_condition(purchase_invoice.outstanding_amount, common_filters.amount)
+	amount_rank = amount_rank_condition(paid_amount_field, common_filters.amount)
 
 	# Check reference field equality with common_filters.reference_no
 	reference_field_is_set = reference_field and reference_field != "name"
@@ -1308,14 +1398,14 @@ def get_unpaid_pi_matching_query(
 			rank_expression.as_("rank"),
 			ConstantColumn("Purchase Invoice").as_("doctype"),
 			purchase_invoice.name.as_("name"),
-			purchase_invoice.outstanding_amount.as_("paid_amount"),
+			paid_amount_field.as_("paid_amount"),
 			purchase_invoice[reference_field].as_("reference_no"),
 			purchase_invoice.bill_date.as_("reference_date"),
 			purchase_invoice.supplier.as_("party"),
 			ConstantColumn("Supplier").as_("party_type"),
 			purchase_invoice.supplier_name.as_("party_name"),
 			purchase_invoice.posting_date,
-			purchase_invoice.currency,
+			currency_field.as_("currency"),
 			party_match.as_("party_match"),
 			amount_rank.as_("amount_match"),
 			date_rank.as_("date_match"),
@@ -1327,7 +1417,6 @@ def get_unpaid_pi_matching_query(
 		.where(purchase_invoice.company == company)
 		.where(purchase_invoice.outstanding_amount != 0.0)
 		.where(purchase_invoice.is_paid == 0)
-		.where(purchase_invoice.currency == currency)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1335,7 +1424,7 @@ def get_unpaid_pi_matching_query(
 	if include_only_returns:
 		query = query.where(purchase_invoice.is_return == 1)
 	if exact_match:
-		query = query.where(purchase_invoice.outstanding_amount == common_filters.amount)
+		query = query.where(paid_amount_field == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -141,22 +141,42 @@ def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list
 	validate_invoices_to_bill(invoices_to_bill)
 
 	bank_account = frappe.db.get_value("Bank Account", bt.bank_account, "account")
+	bank_account_currency = frappe.db.get_value("Account", bank_account, "account_currency")
 	first_invoice = invoices_to_bill[0]
+
+	# Multi-currency handling:
+	# - Don't pass party_amount when bank currency = invoice currency (let ERPNext calculate it)
+	# - Pass bank_amount so ERPNext knows the actual bank transaction amount
+	party_amount = None
+	bank_amount = bt.unallocated_amount
+
+	if first_invoice[DOCTYPE] not in ("Sales Invoice", "Purchase Invoice"):
+		# For Expense Claims and other doctypes, use the outstanding amount
+		party_amount = first_invoice[AMOUNT]
+	else:
+		# Check if bank currency matches invoice currency
+		invoice_currency = frappe.db.get_value(first_invoice[DOCTYPE], first_invoice[DOCNAME], "currency")
+		if bank_account_currency != invoice_currency:
+			# Currencies don't match - pass party_amount (outstanding in party currency)
+			party_amount = first_invoice[AMOUNT]
+		# If currencies match, leave party_amount as None so ERPNext uses grand_total
+
 	if first_invoice[DOCTYPE] == "Expense Claim":
 		from hrms.overrides.employee_payment_entry import get_payment_entry_for_employee
 
 		payment_entry = get_payment_entry_for_employee(
 			first_invoice[DOCTYPE],
 			first_invoice[DOCNAME],
-			party_amount=first_invoice[AMOUNT],
+			party_amount=party_amount,
 			bank_account=bank_account,
 		)
 	else:
 		payment_entry = get_payment_entry(
 			first_invoice[DOCTYPE],
 			first_invoice[DOCNAME],
-			party_amount=first_invoice[AMOUNT],
+			party_amount=party_amount,
 			bank_account=bank_account,
+			bank_amount=bank_amount,
 			# make sure return invoice does not cause wrong payment type
 			# return SI against a deposit should be considered as "Receive" (discount)
 			# return SI against a withdrawal should be considered as "Pay" (refund)
@@ -171,9 +191,19 @@ def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list
 	invoices = split_invoices_based_on_payment_terms(prepare_invoices_to_split(invoices_to_bill), bt.company)
 	adjust_and_allocate_invoices(bt, invoices, payment_entry, action=_attach_invoice)
 
-	payment_entry.paid_amount = abs(
-		sum(row.allocated_amount for row in payment_entry.references)
-	)  # should not be negative
+	# Multi-currency fix: When bank currency = invoice currency but party currency differs,
+	# we need to adjust paid_amount to use the bank transaction amount instead of party amount
+	if party_amount is None and bank_account_currency != payment_entry.paid_to_account_currency:
+		# This means: bank and invoice currencies match, but party currency differs
+		# Use the bank transaction amount for paid_amount
+		payment_entry.paid_amount = bank_amount
+		# received_amount stays as-is (in party currency)
+		# ERPNext will calculate the exchange gain/loss automatically
+	else:
+		payment_entry.paid_amount = abs(
+			sum(row.allocated_amount for row in payment_entry.references)
+		)  # should not be negative
+
 	payment_entry.submit()
 	return payment_entry
 
@@ -307,6 +337,12 @@ def get_debtor_creditor_account(invoice: dict) -> str | None:
 
 
 def get_outstanding_amount(payment_doctype, payment_name) -> float:
+	"""
+	Get the outstanding amount for a voucher.
+
+	Note: Always returns outstanding_amount as stored in the database.
+	Multi-currency conversion is handled by ERPNext's get_payment_entry() function.
+	"""
 	if payment_doctype == "Expense Claim":
 		ec = frappe.get_doc(payment_doctype, payment_name)
 		return flt(


### PR DESCRIPTION
## Fix Multi-Currency Invoice Reconciliation

Resolves #102

### Problem

When reconciling bank transactions with invoices in multi-currency scenarios, the Bank Reconciliation Tool Beta had two critical issues:

1. **Display Issue**: Invoices showed amounts in party account currency (P) but labeled them with invoice currency (I)
   - Example: USD invoice (100 USD) with EUR party account (80 EUR outstanding) displayed as "$ 80" instead of "$ 100"

2. **Payment Entry Issue**: Created Payment Entries used incorrect amounts
   - Example: Payment Entry showed `paid_amount: 35.87` (EUR amount) in a USD bank account

### Root Cause

**Display Issue**: The query functions (`get_unpaid_pi_matching_query`, `get_unpaid_si_matching_query`) always returned `outstanding_amount` (stored in party currency) with `invoice.currency`, causing a currency mismatch.

**Payment Entry Issue**: The `get_payment_entry()` function from ERPNext uses `outstanding_amount` (party currency) for calculations, even when bank and invoice currencies match. This required manual adjustment after creation.

### Solution

#### 1. Query Functions (Display Fix)

Updated `get_unpaid_pi_matching_query()` and `get_unpaid_si_matching_query()` to conditionally select amounts:

- **When B = I AND invoice is fully unpaid**: Return `grand_total` in invoice currency
- **Otherwise**: Return `outstanding_amount` in party account currency

The logic detects fully unpaid invoices by comparing:
- When P = I: `outstanding_amount == grand_total`
- When P ≠ I: `outstanding_amount == base_grand_total`

Removed the currency filter that prevented cross-currency matching.

#### 2. Payment Entry Creation Fix

Updated `make_pe_against_invoices()` to:
1. Pass `party_amount=None` when bank currency = invoice currency (lets ERPNext use `grand_total`)
2. Pass `bank_amount=bt.unallocated_amount` for proper exchange rate handling
3. Manually adjust `paid_amount` after creation when B = I but B ≠ P

### Currency Notation

- **B** = Bank account currency
- **I** = Invoice currency (`invoice.currency`)
- **P** = Party account currency (`invoice.party_account_currency`)

### Changes

**Modified Files**:
- `bank_reconciliation_tool_beta.py`: Query logic for displaying invoices
- `unpaid_vouchers.py`: Payment Entry creation logic

**Key Changes**:
- Added `Case()` conditionals for amount and currency selection
- Added comprehensive docstrings explaining multi-currency logic
- Removed hard currency filters allowing cross-currency matching
- Manual `paid_amount` adjustment after Payment Entry creation

### Testing

Manually tested all scenarios:

✅ **B = I, B ≠ P**: USD invoice, EUR party account, USD bank
- Display: Shows "$ 100" (correct invoice amount)
- Payment Entry: `paid_amount: 41.72 USD`, `received_amount: 35.87 EUR`

✅ **B = P, B ≠ I**: Invoice in different currency, bank matches party account
- Works correctly with existing logic

✅ **B = P = I**: All currencies match
- Works correctly with existing logic

✅ Exchange gain/loss calculated automatically by ERPNext

### Known Limitations

1. **Partially paid invoices with B = I, P ≠ I**: Falls back to showing `outstanding_amount` in party currency (best available option)
2. **Complex FX (B ≠ I ≠ P)**: Shows `outstanding_amount` in P, may require manual reconciliation
3. No automatic FX conversion performed - uses existing ERPNext amounts

### Breaking Changes

None. The changes maintain backward compatibility for existing single-currency scenarios.
