### PR TITLE
feat: re-import ebics request

### DIFF
--- a/banking/ebics/doctype/ebics_request/ebics_request.js
+++ b/banking/ebics/doctype/ebics_request/ebics_request.js
@@ -7,6 +7,10 @@ frappe.ui.form.on("EBICS Request", {
 			frm.add_custom_button(__("Download response files"), () => {
 				frm.trigger("download_files");
 			});
+
+			frm.add_custom_button(__("Re-Import"), () => {
+				frm.trigger("re_import");
+			});
 		}
 	},
 	download_files: function (frm) {
@@ -15,5 +19,26 @@ frappe.ui.form.on("EBICS Request", {
 				frm.doc.name
 			)}`
 		);
+	},
+	re_import: function (frm) {
+		frm
+			.call({
+				doc: frm.doc,
+				method: "re_import",
+				freeze: true,
+				freeze_message: __("Re-importing EBICS transactions ..."),
+			})
+			.then(() => {
+				frappe.show_alert({
+					message: __("EBICS transactions re-imported successfully."),
+					indicator: "green",
+				});
+			})
+			.catch(() => {
+				frappe.show_alert({
+					message: __("Failed to re-import EBICS transactions."),
+					indicator: "red",
+				});
+			});
 	},
 });

--- a/banking/ebics/doctype/ebics_request/ebics_request.js
+++ b/banking/ebics/doctype/ebics_request/ebics_request.js
@@ -20,7 +20,17 @@ frappe.ui.form.on("EBICS Request", {
 			)}`
 		);
 	},
-	re_import: function (frm) {
+	re_import: async function (frm) {
+		try {
+			await confirm_re_import(frm.doc.ebics_user);
+		} catch {
+			frappe.show_alert({
+				message: __("Re-import cancelled."),
+				indicator: "red",
+			});
+			return;
+		}
+
 		frm
 			.call({
 				doc: frm.doc,
@@ -42,3 +52,27 @@ frappe.ui.form.on("EBICS Request", {
 			});
 	},
 });
+
+function confirm_re_import(ebics_user) {
+	return new Promise((resolve, reject) => {
+		frappe.db
+			.get_value("EBICS User", ebics_user, "download_batch_transactions")
+			.then((r) => {
+				if (r?.message?.download_batch_transactions) {
+					frappe.confirm(
+						__(
+							"<b>EBICS User</b> '{0}' has <i>Download Batch Transactions</i> enabled. Batch details are stored in separate <b>EBICS Requests</b>, so this re-import might be incomplete. Do you want to continue?",
+							[ebics_user]
+						),
+						() => resolve(),
+						() => reject()
+					);
+				} else {
+					resolve();
+				}
+			})
+			.catch(() => {
+				reject();
+			});
+	});
+}

--- a/banking/ebics/doctype/ebics_request/ebics_request.py
+++ b/banking/ebics/doctype/ebics_request/ebics_request.py
@@ -1,12 +1,30 @@
 # Copyright (c) 2025, ALYF GmbH and contributors
 # For license information, please see license.txt
 
+import json
+
 import frappe
+from frappe import _
 from frappe.model.document import Document
+
+from banking.ebics.utils import import_ebics_json, register_fintech
 
 
 class EBICSRequest(Document):
-	pass
+	@frappe.whitelist()
+	def re_import(self):
+		"""Re-import the EBICS transactions from the response."""
+		ebics_user = frappe.get_doc("EBICS User", self.ebics_user)
+		try:
+			data = json.loads(self.response)
+		except (json.JSONDecodeError, TypeError):
+			frappe.throw(_("Invalid data for re-import."))
+
+		if not isinstance(data, dict):
+			frappe.throw(_("Invalid data for re-import."))
+
+		register_fintech(needs_license_key=True)
+		import_ebics_json(ebics_user, data)
 
 
 def sanitize_filename(filename: str) -> str:

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -156,10 +156,6 @@ def sync_ebics_transactions(
 	user = frappe.get_doc("EBICS User", ebics_user)
 	manager = get_ebics_manager(ebics_user=user, passphrase=passphrase)
 
-	from fintech.sepa import (
-		CAMTDocument,
-	)  # import possible only after manager is initialized
-
 	request_map = get_request_map(manager.country_code, start_date, end_date)
 	main_request = request_map["intraday"] if intraday else request_map["statement"]
 
@@ -184,25 +180,7 @@ def sync_ebics_transactions(
 	# We want to process either all documents or none. If we fail to process one, we
 	# want to rollback the entire transaction and report an error.
 	try:
-		for name in sorted(main_xml):
-			camt_document = CAMTDocument(xml=main_xml[name], camt54=batch_xml)
-			bank_account = get_bank_account(camt_document.iban, user.bank, user.company)
-			if not bank_account:
-				frappe.log_error(
-					title=_("Banking Error"),
-					message=_("Bank Account not found for IBAN {0}").format(camt_document.iban),
-					reference_doctype="EBICS User",
-					reference_name=user.name,
-				)
-				continue
-
-			process_camt_document(
-				camt_document,
-				bank_account,
-				user.company,
-				user.start_date,
-				user.split_batch_transactions,
-			)
+		import_ebics_json(user, main_xml, batch_xml)
 	except Exception:
 		frappe.db.rollback()
 		frappe.log_error(
@@ -214,6 +192,34 @@ def sync_ebics_transactions(
 		return
 
 	manager.confirm_download(success=True)
+
+
+def import_ebics_json(user: "EBICSUser", main_data: dict, batch_data: dict | None = None):
+	"""Import EBICS transactions from the given JSON data, considering user settings.
+
+	NOTE: fintech needs to be registered before calling this function.
+	"""
+	from fintech.sepa import CAMTDocument
+
+	for name in sorted(main_data):
+		camt_document = CAMTDocument(xml=main_data[name], camt54=batch_data)
+		bank_account = get_bank_account(camt_document.iban, user.bank, user.company)
+		if not bank_account:
+			frappe.log_error(
+				title=_("Banking Error"),
+				message=_("Bank Account not found for IBAN {0}").format(camt_document.iban),
+				reference_doctype="EBICS User",
+				reference_name=user.name,
+			)
+			continue
+
+		process_camt_document(
+			camt_document,
+			bank_account,
+			user.company,
+			user.start_date,
+			user.split_batch_transactions,
+		)
 
 
 def validated_perms(ebics_user, permitted_types, required_type):

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -198,6 +198,11 @@ def import_ebics_json(user: "EBICSUser", main_data: dict, batch_data: dict | Non
 	"""Import EBICS transactions from the given JSON data, considering user settings.
 
 	NOTE: fintech needs to be registered before calling this function.
+
+	Args:
+		user: An EBICS User record
+		main_data: Dictionary of XML files by name, e.g. {"camt053.xml": "<xml>...</xml>"}
+		batch_data: Dictionary of XML files by name, or None if batch transactions are not enabled
 	"""
 	from fintech.sepa import CAMTDocument
 

--- a/banking/locale/de.po
+++ b/banking/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-10-29 00:05+0053\n"
+"POT-Creation-Date: 2025-11-07 14:18+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -15,6 +15,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.13.1\n"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:63
+msgid "<b>EBICS User</b> '{0}' has <i>Download Batch Transactions</i> enabled. Batch details are stored in separate <b>EBICS Requests</b>, so this re-import might be incomplete. Do you want to continue?"
+msgstr "<b>EBICS-Benutzer</b> '{0}' hat <i>Sammelüberweisungen herunterladen</i> aktiviert. Batch-Details werden in separaten <b>EBICS-Anfragen</b> gespeichert, daher kann dieser erneute Import möglicherweise unvollständig sein. Möchten Sie fortfahren?"
 
 #. Header text in the ALYF Banking Workspace
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
@@ -27,7 +31,7 @@ msgstr "<span class=\"h4\">Banking</span>"
 msgid "<ul><li>It stores DocType-wise mapping of fields that should be considered as 'reference number' fields in Bank Reconciliation Tool Beta</li><li>Link and Data fields are supported</li><li>The field must have a singular reference number for matching with Bank Transactions</li></ul>"
 msgstr "<ul><li>DocType-weise Zuordnung von Feldern, die im Bankabgleich Beta als zusätzliche Referenznummer verwendet werden sollen</li><li>Es werden Link- und Datenfelder unterstützt</li><li>Das Feld sollte genau eine Referenznummer enthalten, die auch in der Banktransaktionen vorkommen kann</li></ul>"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:176
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:214
 msgid "A new version of the Banking app is available ({0}). Please update your instance."
 msgstr "Eine neue Version der Banking-App ist verfügbar ({0}). Bitte aktualisieren Sie Ihre Instanz."
 
@@ -88,15 +92,15 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:87
 msgid "Amount updated to {0} in row {1}."
 msgstr "Betrag in Zeile {1} auf {0} aktualisiert."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:169
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
 msgid "Amounts not updated."
 msgstr "Beträge nicht aktualisiert."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:162
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
 msgid "Amounts updated."
 msgstr "Beträge aktualisiert."
 
@@ -152,7 +156,7 @@ msgstr "Bank"
 msgid "Bank Account"
 msgstr "Bankkonto"
 
-#: banking/ebics/utils.py:193
+#: banking/ebics/utils.py:215
 msgid "Bank Account not found for IBAN {0}"
 msgstr "Bankkonto nicht gefunden für IBAN {0}"
 
@@ -237,8 +241,8 @@ msgstr "Banking-Aktion ist aufgrund der folgenden Fehler fehlgeschlagen:"
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
 #: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:140
-#: banking/ebics/utils.py:192 banking/ebics/utils.py:209
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/ebics/utils.py:187 banking/ebics/utils.py:214
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
 #: banking/klarna_kosma_integration/exception_handler.py:41
@@ -266,7 +270,7 @@ msgstr "Bank-Referenz-Zuordnung"
 msgid "Banking Settings"
 msgstr "Bankeneinstellungen"
 
-#: banking/ebics/utils.py:224
+#: banking/ebics/utils.py:235
 msgid "Banking Warning"
 msgstr "Banking-Warnung"
 
@@ -401,8 +405,8 @@ msgstr "Beschreibung"
 msgid "Details"
 msgstr "Details"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:86
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:114
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:87
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:152
 msgid "Developer mode is enabled. Please disable it to continue auto-syncing bank transactions."
 msgstr "Entwicklermodus ist aktiviert. Bitte deaktivieren Sie ihn, um die automatische Synchronisierung von Banktransaktionen fortzusetzen."
 
@@ -490,7 +494,7 @@ msgstr "EBICS-URL"
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:78
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
 msgid "EBICS User"
 msgstr "EBICS-Benutzer"
 
@@ -502,6 +506,10 @@ msgstr "EBICS-Benutzerlimit überschritten."
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
 msgid "EBICS Users"
 msgstr "EBICS-Benutzer"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:43
+msgid "EBICS transactions re-imported successfully."
+msgstr "EBICS-Transaktionen erfolgreich reimportiert."
 
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
@@ -566,7 +574,7 @@ msgstr "Passwort eingeben"
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr "Nur eingeben, wenn eine terminierte Ausführung bei der Bank gewünscht ist."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:126
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
 msgid "Enter your passphrase"
 msgstr "Passwort eingeben"
 
@@ -575,11 +583,11 @@ msgstr "Passwort eingeben"
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr "Geben Sie Ihr Passwort ein, um die automatisierte, regelmäßige Synchronisierung zu aktivieren. Lassen Sie das Feld leer, wenn Sie die Synchronisierung manuell durchführen möchten."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:119
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
 msgid "Enter your signature passphrase"
 msgstr "Geben Sie Ihr Signaturpasswort ein"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 msgid "Error while fetching releases"
 msgstr "Fehler beim Abrufen von Releases"
 
@@ -602,6 +610,10 @@ msgstr "Fehlgeschlagen"
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:91
 msgid "Failed to create {0} against {1}"
 msgstr "Fehler beim Erstellen von {0} gegen {1}"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:49
+msgid "Failed to re-import EBICS transactions."
+msgstr "Fehler beim erneuten Importieren von EBICS-Transaktionen."
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:122
 msgid "Failed to reconcile new {0} against {1}"
@@ -713,7 +725,7 @@ msgstr "IBAN-Warnung: Nicht in SEPA-Zahlungsaufträgen verwendet"
 msgid "IBAN on Employee is not used in SEPA Payment Orders. Please use Bank Account instead for payment processing."
 msgstr "IBAN auf Mitarbeiter wird nicht in SEPA-Zahlungsaufträgen verwendet. Bitte verwenden Sie stattdessen Bankkonto für die Zahlungsabwicklung."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:105
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
 msgid "IBAN {0} is invalid."
 msgstr "IBAN {0} ist ungültig."
 
@@ -769,11 +781,16 @@ msgstr "Untertägige Synchronisation"
 msgid "Invalid Field"
 msgstr "Unzulässiges Feld"
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:57
+#: banking/ebics/doctype/ebics_request/ebics_request.py:75
 msgid "Invalid data available for download."
 msgstr "Die Daten, die heruntergeladen werden sollen, sind ungültig."
 
-#: banking/ebics/utils.py:225
+#: banking/ebics/doctype/ebics_request/ebics_request.py:21
+#: banking/ebics/doctype/ebics_request/ebics_request.py:24
+msgid "Invalid data for re-import."
+msgstr "Ungültige Daten für den erneuten Import."
+
+#: banking/ebics/utils.py:236
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr "Es scheint, dass der EBICS-Benutzer keine Berechtigungen für die Auftragsart '{0}' hat. Die zulässigen Typen sind: {1}."
 
@@ -794,7 +811,7 @@ msgstr ""
 msgid "Last Renewed On"
 msgstr "Zuletzt erneuert am"
 
-#: banking/ebics/utils.py:544
+#: banking/ebics/utils.py:555
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr "Lizenzschlüssel nicht gefunden. Bitte aktivieren Sie das Kontrollkästchen 'EBICS aktivieren' in den {0} und stellen Sie sicher, dass Ihr Abonnement aktiv ist."
 
@@ -832,7 +849,7 @@ msgstr "Keine Transaktionen gefunden für die aktuellen Filter."
 msgid "No changes to update"
 msgstr "Keine Änderungen zum Aktualisieren"
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:54
+#: banking/ebics/doctype/ebics_request/ebics_request.py:72
 msgid "No data available for download."
 msgstr "Keine Daten für das Herunterladen verfügbar."
 
@@ -908,19 +925,19 @@ msgstr "Partei-Typ und Partei sind erforderlich für das Empfängerkonto {0}"
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
 msgid "Passphrase"
 msgstr "Passwort"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:143
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
 msgid "Payment Order has been sent to bank."
 msgstr "Überweisung wurde an die Bank gesendet."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:149
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
 msgid "Payment Order has not been sent to bank."
 msgstr "Überweisung wurde nicht an die Bank gesendet."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:52
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr "Die Zahlungsbeträge haben sich geändert. Sind Sie sicher, dass Sie ohne diese erst zu aktualisieren buchen möchten?"
 
@@ -1014,6 +1031,18 @@ msgstr ""
 msgid "Purpose"
 msgstr "Zweck"
 
+#: banking/ebics/doctype/ebics_request/ebics_request.js:11
+msgid "Re-Import"
+msgstr "Erneut importieren"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:28
+msgid "Re-import cancelled."
+msgstr ""
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:39
+msgid "Re-importing EBICS transactions ..."
+msgstr "EBICS-Transaktionen werden erneut importiert ..."
+
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
 msgid "Recipient"
@@ -1078,11 +1107,11 @@ msgstr "Angefragt von"
 msgid "Response"
 msgstr "Antwort"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:118
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
 msgid "Row {0}: Currency {1} does not match bank account currency {2}."
 msgstr "Zeile {0}: Währung {1} stimmt nicht mit der Währung des Bankkontos {2} überein."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:100
 msgid "Row {0}: IBAN {1} is invalid."
 msgstr "Zeile {0}: IBAN {1} ist ungültig."
 
@@ -1153,11 +1182,6 @@ msgstr "Legen Sie ein neues Passwort fest, um Transaktionen an Ihre Bank hochzul
 msgid "Setup"
 msgstr "Einrichtung"
 
-#. Label of a Check field in DocType 'SEPA Payment Order'
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
-msgid "Should Update Amounts"
-msgstr "Beträge sollten aktualisiert werden"
-
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:396
 msgid "Show Exact Amount"
 msgstr "Betrag muss übereinstimmen"
@@ -1171,7 +1195,7 @@ msgid "Show Protocol Versions"
 msgstr "Protokollversionen anzeigen"
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:117
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
 msgid "Signature Passphrase"
 msgstr "Signatur-Passwort"
 
@@ -1279,7 +1303,7 @@ msgstr "Die Währung des zweiten Kontos ({0} : {1}) muss mit der des Bankkontos 
 msgid "The currency of the second account ({0}) must be the same as of the bank account ({1})"
 msgstr "Die Währung des zweiten Kontos ({0}) muss mit der des Bankkontos ({1}) übereinstimmen."
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:181
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:219
 msgid "The scheduler is inactive. Please activate it to continue auto-syncing bank transactions."
 msgstr "Der Scheduler ist inaktiv. Bitte aktivieren Sie ihn, um den automatischen Abruf von Banktransaktionen fortzusetzen."
 
@@ -1346,7 +1370,7 @@ msgstr "Unbezahlte Belege"
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:39
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
 msgid "Update Amounts"
 msgstr "Beträge aktualisieren"
 

--- a/banking/locale/es.po
+++ b/banking/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-10-29 00:05+0053\n"
+"POT-Creation-Date: 2025-11-07 14:18+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -15,6 +15,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.13.1\n"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:63
+msgid "<b>EBICS User</b> '{0}' has <i>Download Batch Transactions</i> enabled. Batch details are stored in separate <b>EBICS Requests</b>, so this re-import might be incomplete. Do you want to continue?"
+msgstr "<b>Usuario de EBICS</b> '{0}' tiene <i>Descargar transacciones por lotes</i> habilitado. Los detalles del lote se almacenan en <b>Solicitudes de EBICS</b> separadas, por lo que este reimportar podría ser incompleto. ¿Desea continuar?"
 
 #. Header text in the ALYF Banking Workspace
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
@@ -27,7 +31,7 @@ msgstr "<span class=\"h4\">Bancario</span>"
 msgid "<ul><li>It stores DocType-wise mapping of fields that should be considered as 'reference number' fields in Bank Reconciliation Tool Beta</li><li>Link and Data fields are supported</li><li>The field must have a singular reference number for matching with Bank Transactions</li></ul>"
 msgstr "<ul><li>Almacena el mapeo por DocType de campos que deben considerarse como campos de 'número de referencia' en la Herramienta de Conciliación Bancaria Beta</li><li>Se admiten campos de enlace y datos</li><li>El campo debe tener un número de referencia singular para coincidir con las transacciones bancarias</li></ul>"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:176
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:214
 msgid "A new version of the Banking app is available ({0}). Please update your instance."
 msgstr "Es está disponible una nueva versión de la aplicación Banking ({0}). Por favor, actualice su instancia."
 
@@ -88,15 +92,15 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:87
 msgid "Amount updated to {0} in row {1}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:169
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
 msgid "Amounts not updated."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:162
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
 msgid "Amounts updated."
 msgstr ""
 
@@ -152,7 +156,7 @@ msgstr ""
 msgid "Bank Account"
 msgstr ""
 
-#: banking/ebics/utils.py:193
+#: banking/ebics/utils.py:215
 msgid "Bank Account not found for IBAN {0}"
 msgstr "No se encontró la cuenta bancaria para el IBAN {0}"
 
@@ -237,8 +241,8 @@ msgstr "La acción de Banking ha fallado debido a los siguientes errores:"
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
 #: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:140
-#: banking/ebics/utils.py:192 banking/ebics/utils.py:209
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/ebics/utils.py:187 banking/ebics/utils.py:214
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
 #: banking/klarna_kosma_integration/exception_handler.py:41
@@ -266,7 +270,7 @@ msgstr "Asignación de referencia de Banking"
 msgid "Banking Settings"
 msgstr "Configuración de Banking"
 
-#: banking/ebics/utils.py:224
+#: banking/ebics/utils.py:235
 msgid "Banking Warning"
 msgstr "Advertencia de Banking"
 
@@ -401,8 +405,8 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:86
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:114
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:87
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:152
 msgid "Developer mode is enabled. Please disable it to continue auto-syncing bank transactions."
 msgstr "El modo desarrollador está activado. Por favor, desactívelo para continuar sincronizando transacciones bancarias automáticamente."
 
@@ -490,7 +494,7 @@ msgstr "URL EBICS"
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:78
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
 msgid "EBICS User"
 msgstr "Usuario de EBICS"
 
@@ -502,6 +506,10 @@ msgstr "Se ha excedido el límite de usuarios de EBICS"
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
 msgid "EBICS Users"
 msgstr "Usuarios de EBICS"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:43
+msgid "EBICS transactions re-imported successfully."
+msgstr "Transacciones EBICS reimportadas correctamente."
 
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
@@ -566,7 +574,7 @@ msgstr "Ingrese la frase de contraseña"
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr "Ingrese solo si se desea ejecución programada en el banco."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:126
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
 msgid "Enter your passphrase"
 msgstr "Ingrese su frase de contraseña"
 
@@ -575,11 +583,11 @@ msgstr "Ingrese su frase de contraseña"
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr "Ingrese su contraseña para habilitar la sincronización automática, regular, o deje en blanco si prefiere sincronizar manualmente."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:119
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
 msgid "Enter your signature passphrase"
 msgstr "Ingrese su frase de contraseña de firma"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 msgid "Error while fetching releases"
 msgstr "Error al obtener las versiones"
 
@@ -602,6 +610,10 @@ msgstr "Fallido"
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:91
 msgid "Failed to create {0} against {1}"
 msgstr "No se pudo crear {0} contra {1}"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:49
+msgid "Failed to re-import EBICS transactions."
+msgstr "No se pudo reimportar las transacciones EBICS."
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:122
 msgid "Failed to reconcile new {0} against {1}"
@@ -713,7 +725,7 @@ msgstr "Advertencia de IBAN: No se usa en órdenes de pago SEPA"
 msgid "IBAN on Employee is not used in SEPA Payment Orders. Please use Bank Account instead for payment processing."
 msgstr "El IBAN del empleado no se usa en las órdenes de pago SEPA. Por favor, use la cuenta bancaria en su lugar para procesar el pago."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:105
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
 msgid "IBAN {0} is invalid."
 msgstr "El IBAN {0} es inválido."
 
@@ -769,11 +781,16 @@ msgstr "Sincronización intradía"
 msgid "Invalid Field"
 msgstr "Campo inválido"
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:57
+#: banking/ebics/doctype/ebics_request/ebics_request.py:75
 msgid "Invalid data available for download."
 msgstr "No hay datos disponibles para descargar."
 
-#: banking/ebics/utils.py:225
+#: banking/ebics/doctype/ebics_request/ebics_request.py:21
+#: banking/ebics/doctype/ebics_request/ebics_request.py:24
+msgid "Invalid data for re-import."
+msgstr "Datos inválidos para el reimport."
+
+#: banking/ebics/utils.py:236
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr "Parece que el usuario de EBICS no tiene permisos para el tipo de pedido '{0}'. Los tipos permitidos son: {1}."
 
@@ -794,7 +811,7 @@ msgstr "Integración de Klarna Kosma"
 msgid "Last Renewed On"
 msgstr "Última renovación en"
 
-#: banking/ebics/utils.py:544
+#: banking/ebics/utils.py:555
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr "No se encontró la clave de licencia. Por favor, active el campo 'Habilitar EBICS' en {0} y asegúrese de que su suscripción esté activa."
 
@@ -832,7 +849,7 @@ msgstr "No se encontraron transacciones para los filtros actuales."
 msgid "No changes to update"
 msgstr "No hay cambios para actualizar"
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:54
+#: banking/ebics/doctype/ebics_request/ebics_request.py:72
 msgid "No data available for download."
 msgstr ""
 
@@ -908,19 +925,19 @@ msgstr "Se requiere tipo de parte y parte para la cuenta por cobrar/pagar {0}"
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
 msgid "Passphrase"
 msgstr "Frase de contraseña"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:143
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
 msgid "Payment Order has been sent to bank."
 msgstr "La orden de pago ha sido enviada al banco."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:149
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
 msgid "Payment Order has not been sent to bank."
 msgstr "La orden de pago no ha sido enviada al banco."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:52
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr ""
 
@@ -1014,6 +1031,18 @@ msgstr ""
 msgid "Purpose"
 msgstr "Propósito"
 
+#: banking/ebics/doctype/ebics_request/ebics_request.js:11
+msgid "Re-Import"
+msgstr "Reimportar"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:28
+msgid "Re-import cancelled."
+msgstr "Reimportación cancelada."
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:39
+msgid "Re-importing EBICS transactions ..."
+msgstr "Reimportando transacciones EBICS ..."
+
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
 msgid "Recipient"
@@ -1078,11 +1107,11 @@ msgstr "Solicitado por"
 msgid "Response"
 msgstr "Respuesta"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:118
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
 msgid "Row {0}: Currency {1} does not match bank account currency {2}."
 msgstr "Fila {0}: La moneda {1} no coincide con la moneda de la cuenta bancaria {2}."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:100
 msgid "Row {0}: IBAN {1} is invalid."
 msgstr "Fila {0}: El IBAN {1} es inválido."
 
@@ -1153,11 +1182,6 @@ msgstr "Establezca una nueva contraseña para cargar transacciones a su banco."
 msgid "Setup"
 msgstr "Configuración"
 
-#. Label of a Check field in DocType 'SEPA Payment Order'
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
-msgid "Should Update Amounts"
-msgstr ""
-
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:396
 msgid "Show Exact Amount"
 msgstr "Mostrar cantidad exacta"
@@ -1171,7 +1195,7 @@ msgid "Show Protocol Versions"
 msgstr "Mostrar versiones de protocolo"
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:117
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
 msgid "Signature Passphrase"
 msgstr "Contraseña de firma"
 
@@ -1279,7 +1303,7 @@ msgstr "El tipo de cambio de la cuenta bancaria ({0} : {1}) debe ser el mismo qu
 msgid "The currency of the second account ({0}) must be the same as of the bank account ({1})"
 msgstr "El tipo de cambio de la cuenta bancaria ({0}) debe ser el mismo que el de la cuenta bancaria ({1})"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:181
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:219
 msgid "The scheduler is inactive. Please activate it to continue auto-syncing bank transactions."
 msgstr "El programador está inactivo. Por favor, actívelo para continuar sincronizando transacciones bancarias automáticamente."
 
@@ -1346,7 +1370,7 @@ msgstr "Comprobantes sin pagar"
 msgid "Update"
 msgstr "Actualizar"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:39
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
 msgid "Update Amounts"
 msgstr ""
 

--- a/banking/locale/fr.po
+++ b/banking/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-10-29 00:05+0053\n"
+"POT-Creation-Date: 2025-11-07 14:18+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -15,6 +15,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.13.1\n"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:63
+msgid "<b>EBICS User</b> '{0}' has <i>Download Batch Transactions</i> enabled. Batch details are stored in separate <b>EBICS Requests</b>, so this re-import might be incomplete. Do you want to continue?"
+msgstr "<b>Utilisateur EBICS</b> '{0}' a <i>Télécharger les transactions par lot</i> activé. Les détails du lot sont stockés dans des <b>Demandes EBICS</b> séparées, donc cette reimportation pourrait être incomplète. Voulez-vous continuer?"
 
 #. Header text in the ALYF Banking Workspace
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
@@ -27,7 +31,7 @@ msgstr "<span class=\"h4\">Banque</span>"
 msgid "<ul><li>It stores DocType-wise mapping of fields that should be considered as 'reference number' fields in Bank Reconciliation Tool Beta</li><li>Link and Data fields are supported</li><li>The field must have a singular reference number for matching with Bank Transactions</li></ul>"
 msgstr "<ul><li>Il stocke le mapping des champs à considérer comme champs 'numéro de référence' dans le Reconciliation Bancaire Beta</li><li>Les champs Link et Data sont supportés</li><li>Le champ doit avoir un numéro de référence unique pour correspondre avec les transactions bancaires</li></ul>"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:176
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:214
 msgid "A new version of the Banking app is available ({0}). Please update your instance."
 msgstr "Une nouvelle version de l'application Banking est disponible ({0}). Veuillez mettre à jour votre instance."
 
@@ -88,15 +92,15 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:87
 msgid "Amount updated to {0} in row {1}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:169
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
 msgid "Amounts not updated."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:162
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
 msgid "Amounts updated."
 msgstr ""
 
@@ -152,7 +156,7 @@ msgstr ""
 msgid "Bank Account"
 msgstr "Compte bancaire"
 
-#: banking/ebics/utils.py:193
+#: banking/ebics/utils.py:215
 msgid "Bank Account not found for IBAN {0}"
 msgstr "Compte bancaire introuvable pour IBAN {0}"
 
@@ -237,8 +241,8 @@ msgstr "L'action Banking a échoué en raison des erreurs suivantes :"
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
 #: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:140
-#: banking/ebics/utils.py:192 banking/ebics/utils.py:209
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/ebics/utils.py:187 banking/ebics/utils.py:214
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
 #: banking/klarna_kosma_integration/exception_handler.py:41
@@ -266,7 +270,7 @@ msgstr "Mappage de référence bancaire"
 msgid "Banking Settings"
 msgstr "Paramètres Banking"
 
-#: banking/ebics/utils.py:224
+#: banking/ebics/utils.py:235
 msgid "Banking Warning"
 msgstr "Avertissement Banking"
 
@@ -401,8 +405,8 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:86
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:114
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:87
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:152
 msgid "Developer mode is enabled. Please disable it to continue auto-syncing bank transactions."
 msgstr "Le mode développeur est activé. Veuillez le désactiver pour continuer à synchroniser les transactions bancaires automatiquement."
 
@@ -490,7 +494,7 @@ msgstr "URL EBICS"
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:78
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
 msgid "EBICS User"
 msgstr "Utilisateur EBICS"
 
@@ -502,6 +506,10 @@ msgstr "Limite d'utilisateurs EBICS dépassée."
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
 msgid "EBICS Users"
 msgstr "Utilisateurs EBICS"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:43
+msgid "EBICS transactions re-imported successfully."
+msgstr "Transactions EBICS reimportées avec succès."
 
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
@@ -566,7 +574,7 @@ msgstr "Entrez le mot de passe"
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr "Saisissez uniquement si une exécution programmée à la banque est souhaitée."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:126
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
 msgid "Enter your passphrase"
 msgstr "Entrez votre phrase secrète"
 
@@ -575,11 +583,11 @@ msgstr "Entrez votre phrase secrète"
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr "Entrez votre mot de passe pour activer la synchronisation automatique et régulière. Laissez vide si vous préférez une synchronisation manuelle."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:119
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
 msgid "Enter your signature passphrase"
 msgstr "Entrez votre phrase secrète de signature"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 msgid "Error while fetching releases"
 msgstr "Erreur lors de la récupération des versions"
 
@@ -602,6 +610,10 @@ msgstr "Échec"
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:91
 msgid "Failed to create {0} against {1}"
 msgstr "Échec de la création de {0} contre {1}"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:49
+msgid "Failed to re-import EBICS transactions."
+msgstr "Échec du reimport des transactions EBICS."
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:122
 msgid "Failed to reconcile new {0} against {1}"
@@ -713,7 +725,7 @@ msgstr "Avertissement IBAN : N'est pas utilisé dans les ordres de paiement SEPA
 msgid "IBAN on Employee is not used in SEPA Payment Orders. Please use Bank Account instead for payment processing."
 msgstr "L'IBAN de l'employé n'est pas utilisé dans les ordres de paiement SEPA. Veuillez utiliser le compte bancaire à la place pour le traitement des paiements."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:105
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
 msgid "IBAN {0} is invalid."
 msgstr "L'IBAN {0} est invalide."
 
@@ -769,11 +781,16 @@ msgstr "Synchronisation intraday"
 msgid "Invalid Field"
 msgstr "Champ invalide"
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:57
+#: banking/ebics/doctype/ebics_request/ebics_request.py:75
 msgid "Invalid data available for download."
 msgstr "Les données disponibles pour le téléchargement sont invalides."
 
-#: banking/ebics/utils.py:225
+#: banking/ebics/doctype/ebics_request/ebics_request.py:21
+#: banking/ebics/doctype/ebics_request/ebics_request.py:24
+msgid "Invalid data for re-import."
+msgstr "Données invalides pour le reimport."
+
+#: banking/ebics/utils.py:236
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr "Il semble que l'utilisateur EBICS n'ait pas les permissions pour le type de commande '{0}'. Les types autorisés sont: {1}."
 
@@ -794,7 +811,7 @@ msgstr ""
 msgid "Last Renewed On"
 msgstr "Dernier renouvellement le"
 
-#: banking/ebics/utils.py:544
+#: banking/ebics/utils.py:555
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr "Clé de licence non trouvée. Veuillez activer la case à cocher 'Activer EBICS' dans le {0} et vérifier que votre abonnement est actif."
 
@@ -832,7 +849,7 @@ msgstr "Aucune transaction trouvée pour les filtres actuels."
 msgid "No changes to update"
 msgstr "Aucun changement à mettre à jour"
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:54
+#: banking/ebics/doctype/ebics_request/ebics_request.py:72
 msgid "No data available for download."
 msgstr ""
 
@@ -908,19 +925,19 @@ msgstr "Le type de partenaire et le partenaire sont requis pour le compte Receiv
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
 msgid "Passphrase"
 msgstr "Phrase secrète"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:143
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
 msgid "Payment Order has been sent to bank."
 msgstr "L'ordre de paiement a été envoyé à la banque."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:149
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
 msgid "Payment Order has not been sent to bank."
 msgstr "L'ordre de paiement n'a pas été envoyé à la banque."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:52
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr ""
 
@@ -1014,6 +1031,18 @@ msgstr ""
 msgid "Purpose"
 msgstr "Objet"
 
+#: banking/ebics/doctype/ebics_request/ebics_request.js:11
+msgid "Re-Import"
+msgstr "Reimport"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:28
+msgid "Re-import cancelled."
+msgstr "Reimportation annulée."
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:39
+msgid "Re-importing EBICS transactions ..."
+msgstr "Reimportation des transactions EBICS ..."
+
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
 msgid "Recipient"
@@ -1078,11 +1107,11 @@ msgstr "Demandé par"
 msgid "Response"
 msgstr "Réponse"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:118
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
 msgid "Row {0}: Currency {1} does not match bank account currency {2}."
 msgstr "Ligne {0} : La devise {1} ne correspond pas à la devise du compte bancaire {2}."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:100
 msgid "Row {0}: IBAN {1} is invalid."
 msgstr "Ligne {0} : L'IBAN {1} est invalide."
 
@@ -1153,11 +1182,6 @@ msgstr "Définissez un nouveau mot de passe pour télécharger les transactions 
 msgid "Setup"
 msgstr ""
 
-#. Label of a Check field in DocType 'SEPA Payment Order'
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
-msgid "Should Update Amounts"
-msgstr ""
-
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:396
 msgid "Show Exact Amount"
 msgstr "Afficher le montant exact"
@@ -1171,7 +1195,7 @@ msgid "Show Protocol Versions"
 msgstr "Afficher les versions de protocole"
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:117
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
 msgid "Signature Passphrase"
 msgstr "Phrase secrète de signature"
 
@@ -1279,7 +1303,7 @@ msgstr "La devise du second compte ({0} : {1}) doit être la même que celle du 
 msgid "The currency of the second account ({0}) must be the same as of the bank account ({1})"
 msgstr "La devise du second compte ({0}) doit être la même que celle du compte bancaire ({1})"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:181
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:219
 msgid "The scheduler is inactive. Please activate it to continue auto-syncing bank transactions."
 msgstr "Le planificateur est inactif. Veuillez l'activer pour continuer à synchroniser les transactions bancaires automatiquement."
 
@@ -1346,7 +1370,7 @@ msgstr "Chèques impayés"
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:39
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
 msgid "Update Amounts"
 msgstr ""
 

--- a/banking/locale/it.po
+++ b/banking/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-10-29 00:05+0053\n"
+"POT-Creation-Date: 2025-11-07 14:18+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -15,6 +15,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.13.1\n"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:63
+msgid "<b>EBICS User</b> '{0}' has <i>Download Batch Transactions</i> enabled. Batch details are stored in separate <b>EBICS Requests</b>, so this re-import might be incomplete. Do you want to continue?"
+msgstr "<b>Utente EBICS</b> '{0}' ha <i>Scaricare transazioni per lotti</i> abilitato. I dettagli del lotto sono memorizzati in <b>Richieste EBICS</b> separate, quindi questo riimport potrebbe essere incompleto. Vuoi continuare?"
 
 #. Header text in the ALYF Banking Workspace
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
@@ -27,7 +31,7 @@ msgstr "<span class=\"h4\">Bancario</span>"
 msgid "<ul><li>It stores DocType-wise mapping of fields that should be considered as 'reference number' fields in Bank Reconciliation Tool Beta</li><li>Link and Data fields are supported</li><li>The field must have a singular reference number for matching with Bank Transactions</li></ul>"
 msgstr "<ul><li>Memorizza la mappatura dei campi DocType che dovrebbero essere considerati come 'numero di riferimento' nel Tool di Conciliazione Bancaria</li><li>Sono supportati i campi Link e Data</li><li>Il campo deve avere un singolo numero di riferimento per il matching con le transazioni bancarie</li></ul>"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:176
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:214
 msgid "A new version of the Banking app is available ({0}). Please update your instance."
 msgstr "Una nuova versione dell'app Banking è disponibile ({0}). Per favore, aggiorna la tua istanza."
 
@@ -88,15 +92,15 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:87
 msgid "Amount updated to {0} in row {1}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:169
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
 msgid "Amounts not updated."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:162
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
 msgid "Amounts updated."
 msgstr ""
 
@@ -152,7 +156,7 @@ msgstr ""
 msgid "Bank Account"
 msgstr ""
 
-#: banking/ebics/utils.py:193
+#: banking/ebics/utils.py:215
 msgid "Bank Account not found for IBAN {0}"
 msgstr "Conto bancario non trovato per l'IBAN {0}"
 
@@ -237,8 +241,8 @@ msgstr "L'azione di Banking ha fallito a causa dei seguenti errori:"
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
 #: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:140
-#: banking/ebics/utils.py:192 banking/ebics/utils.py:209
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/ebics/utils.py:187 banking/ebics/utils.py:214
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
 #: banking/klarna_kosma_integration/exception_handler.py:41
@@ -266,7 +270,7 @@ msgstr "Mapping dei riferimenti bancari"
 msgid "Banking Settings"
 msgstr "Impostazioni di Banking"
 
-#: banking/ebics/utils.py:224
+#: banking/ebics/utils.py:235
 msgid "Banking Warning"
 msgstr "Avviso di Banking"
 
@@ -401,8 +405,8 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:86
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:114
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:87
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:152
 msgid "Developer mode is enabled. Please disable it to continue auto-syncing bank transactions."
 msgstr "Il modo sviluppatore è attivo. Per continuare a sincronizzare le transazioni bancarie, per favore disabilitane il modo sviluppatore."
 
@@ -490,7 +494,7 @@ msgstr "URL EBICS"
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:78
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
 msgid "EBICS User"
 msgstr "Utente EBICS"
 
@@ -502,6 +506,10 @@ msgstr "Limite di utenti EBICS superato."
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
 msgid "EBICS Users"
 msgstr "Utenti EBICS"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:43
+msgid "EBICS transactions re-imported successfully."
+msgstr "Transazioni EBICS riimportate con successo."
 
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
@@ -566,7 +574,7 @@ msgstr "Inserisci la passphrase"
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr "Inserire solo se si desidera l'esecuzione programmata presso la banca."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:126
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
 msgid "Enter your passphrase"
 msgstr "Inserisci la tua passphrase"
 
@@ -575,11 +583,11 @@ msgstr "Inserisci la tua passphrase"
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr "Inserisci la tua password per abilitare il sincronizzazione automatica, regolare. Lascia vuoto se preferisci sincronizzare manualmente."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:119
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
 msgid "Enter your signature passphrase"
 msgstr "Inserisci la tua passphrase di firma"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 msgid "Error while fetching releases"
 msgstr "Errore durante il recupero delle release"
 
@@ -602,6 +610,10 @@ msgstr ""
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:91
 msgid "Failed to create {0} against {1}"
 msgstr "Impossibile creare {0} contro {1}"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:49
+msgid "Failed to re-import EBICS transactions."
+msgstr "Impossibile riimportare le transazioni EBICS."
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:122
 msgid "Failed to reconcile new {0} against {1}"
@@ -713,7 +725,7 @@ msgstr "Avviso IBAN: non usato negli ordini di pagamento SEPA"
 msgid "IBAN on Employee is not used in SEPA Payment Orders. Please use Bank Account instead for payment processing."
 msgstr "L'IBAN del dipendente non è usato negli ordini di pagamento SEPA. Si prega di usare il conto bancario per l'elaborazione dei pagamenti."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:105
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
 msgid "IBAN {0} is invalid."
 msgstr "L'IBAN {0} non è valido."
 
@@ -769,11 +781,16 @@ msgstr "Sincronizzazione intraday"
 msgid "Invalid Field"
 msgstr "Campo non valido"
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:57
+#: banking/ebics/doctype/ebics_request/ebics_request.py:75
 msgid "Invalid data available for download."
 msgstr "I dati disponibili per il download non sono validi."
 
-#: banking/ebics/utils.py:225
+#: banking/ebics/doctype/ebics_request/ebics_request.py:21
+#: banking/ebics/doctype/ebics_request/ebics_request.py:24
+msgid "Invalid data for re-import."
+msgstr "Dati non validi per il riimport."
+
+#: banking/ebics/utils.py:236
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr "Sembra che l'utente EBICS non abbia le autorizzazioni per il tipo di ordine '{0}'. I tipi autorizzati sono: {1}."
 
@@ -794,7 +811,7 @@ msgstr "Integrazione Klarna Kosma"
 msgid "Last Renewed On"
 msgstr "Ultimo rinnovo il"
 
-#: banking/ebics/utils.py:544
+#: banking/ebics/utils.py:555
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr "Chiave di licenza non trovata. Per favore attiva il checkbox 'Abilita EBICS' in {0} e assicurati che la tua sottoscrizione sia attiva."
 
@@ -832,7 +849,7 @@ msgstr "Nessuna transazione trovata per i filtri correnti."
 msgid "No changes to update"
 msgstr "Nessun cambiamento da aggiornare"
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:54
+#: banking/ebics/doctype/ebics_request/ebics_request.py:72
 msgid "No data available for download."
 msgstr ""
 
@@ -908,19 +925,19 @@ msgstr "Tipo di partner e partner sono richiesti per il conto recepibile / pagab
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
 msgid "Passphrase"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:143
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
 msgid "Payment Order has been sent to bank."
 msgstr "L'ordine di pagamento è stato inviato alla banca."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:149
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
 msgid "Payment Order has not been sent to bank."
 msgstr "L'ordine di pagamento non è stato inviato alla banca."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:52
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr ""
 
@@ -1014,6 +1031,18 @@ msgstr ""
 msgid "Purpose"
 msgstr "Scopo"
 
+#: banking/ebics/doctype/ebics_request/ebics_request.js:11
+msgid "Re-Import"
+msgstr "Riimporta"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:28
+msgid "Re-import cancelled."
+msgstr "Riimportazione annullata."
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:39
+msgid "Re-importing EBICS transactions ..."
+msgstr "Riimportazione delle transazioni EBICS ..."
+
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
 msgid "Recipient"
@@ -1078,11 +1107,11 @@ msgstr "Richiesto da"
 msgid "Response"
 msgstr "Risposta"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:118
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
 msgid "Row {0}: Currency {1} does not match bank account currency {2}."
 msgstr "Riga {0}: La valuta {1} non corrisponde alla valuta del conto bancario {2}."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:100
 msgid "Row {0}: IBAN {1} is invalid."
 msgstr "Riga {0}: L'IBAN {1} non è valido."
 
@@ -1153,11 +1182,6 @@ msgstr "Imposta una nuova password per caricare transazioni al tuo banco."
 msgid "Setup"
 msgstr "Configurazione"
 
-#. Label of a Check field in DocType 'SEPA Payment Order'
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
-msgid "Should Update Amounts"
-msgstr ""
-
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:396
 msgid "Show Exact Amount"
 msgstr "Mostra importo esatto"
@@ -1171,7 +1195,7 @@ msgid "Show Protocol Versions"
 msgstr "Mostra versioni protocollo"
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:117
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
 msgid "Signature Passphrase"
 msgstr "Password per la firma"
 
@@ -1279,7 +1303,7 @@ msgstr "La valuta del secondo conto ({0} : {1}) deve essere la stessa del conto 
 msgid "The currency of the second account ({0}) must be the same as of the bank account ({1})"
 msgstr "La valuta del secondo conto ({0}) deve essere la stessa del conto bancario ({1})"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:181
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:219
 msgid "The scheduler is inactive. Please activate it to continue auto-syncing bank transactions."
 msgstr "Il programma di sincronizzazione non è attivo. Per favore attiva il programma per continuare a sincronizzare le transazioni bancarie."
 
@@ -1346,7 +1370,7 @@ msgstr "Ricevute non pagate"
 msgid "Update"
 msgstr "Aggiorna"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:39
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
 msgid "Update Amounts"
 msgstr ""
 

--- a/banking/locale/main.pot
+++ b/banking/locale/main.pot
@@ -7,14 +7,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-10-29 00:05+0053\n"
-"PO-Revision-Date: 2025-10-29 00:05+0053\n"
+"POT-Creation-Date: 2025-11-07 14:18+0053\n"
+"PO-Revision-Date: 2025-11-07 14:18+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.13.1\n"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:63
+msgid "<b>EBICS User</b> '{0}' has <i>Download Batch Transactions</i> enabled. Batch details are stored in separate <b>EBICS Requests</b>, so this re-import might be incomplete. Do you want to continue?"
+msgstr ""
 
 #. Header text in the ALYF Banking Workspace
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
@@ -27,7 +31,7 @@ msgstr ""
 msgid "<ul><li>It stores DocType-wise mapping of fields that should be considered as 'reference number' fields in Bank Reconciliation Tool Beta</li><li>Link and Data fields are supported</li><li>The field must have a singular reference number for matching with Bank Transactions</li></ul>"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:176
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:214
 msgid "A new version of the Banking app is available ({0}). Please update your instance."
 msgstr ""
 
@@ -88,15 +92,15 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:87
 msgid "Amount updated to {0} in row {1}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:169
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
 msgid "Amounts not updated."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:162
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
 msgid "Amounts updated."
 msgstr ""
 
@@ -152,7 +156,7 @@ msgstr ""
 msgid "Bank Account"
 msgstr ""
 
-#: banking/ebics/utils.py:193
+#: banking/ebics/utils.py:215
 msgid "Bank Account not found for IBAN {0}"
 msgstr ""
 
@@ -237,8 +241,8 @@ msgstr ""
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
 #: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:140
-#: banking/ebics/utils.py:192 banking/ebics/utils.py:209
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/ebics/utils.py:187 banking/ebics/utils.py:214
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
 #: banking/klarna_kosma_integration/exception_handler.py:41
@@ -266,7 +270,7 @@ msgstr ""
 msgid "Banking Settings"
 msgstr ""
 
-#: banking/ebics/utils.py:224
+#: banking/ebics/utils.py:235
 msgid "Banking Warning"
 msgstr ""
 
@@ -401,8 +405,8 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:86
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:114
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:87
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:152
 msgid "Developer mode is enabled. Please disable it to continue auto-syncing bank transactions."
 msgstr ""
 
@@ -490,7 +494,7 @@ msgstr ""
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:78
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
 msgid "EBICS User"
 msgstr ""
 
@@ -501,6 +505,10 @@ msgstr ""
 #. Label of a Link in the ALYF Banking Workspace
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
 msgid "EBICS Users"
+msgstr ""
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:43
+msgid "EBICS transactions re-imported successfully."
 msgstr ""
 
 #. Label of a Data field in DocType 'SEPA Payment'
@@ -566,7 +574,7 @@ msgstr ""
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:126
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
 msgid "Enter your passphrase"
 msgstr ""
 
@@ -575,11 +583,11 @@ msgstr ""
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:119
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
 msgid "Enter your signature passphrase"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 msgid "Error while fetching releases"
 msgstr ""
 
@@ -601,6 +609,10 @@ msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:91
 msgid "Failed to create {0} against {1}"
+msgstr ""
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:49
+msgid "Failed to re-import EBICS transactions."
 msgstr ""
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:122
@@ -713,7 +725,7 @@ msgstr ""
 msgid "IBAN on Employee is not used in SEPA Payment Orders. Please use Bank Account instead for payment processing."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:105
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
 msgid "IBAN {0} is invalid."
 msgstr ""
 
@@ -769,11 +781,16 @@ msgstr ""
 msgid "Invalid Field"
 msgstr ""
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:57
+#: banking/ebics/doctype/ebics_request/ebics_request.py:75
 msgid "Invalid data available for download."
 msgstr ""
 
-#: banking/ebics/utils.py:225
+#: banking/ebics/doctype/ebics_request/ebics_request.py:21
+#: banking/ebics/doctype/ebics_request/ebics_request.py:24
+msgid "Invalid data for re-import."
+msgstr ""
+
+#: banking/ebics/utils.py:236
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr ""
 
@@ -794,7 +811,7 @@ msgstr ""
 msgid "Last Renewed On"
 msgstr ""
 
-#: banking/ebics/utils.py:544
+#: banking/ebics/utils.py:555
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr ""
 
@@ -832,7 +849,7 @@ msgstr ""
 msgid "No changes to update"
 msgstr ""
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:54
+#: banking/ebics/doctype/ebics_request/ebics_request.py:72
 msgid "No data available for download."
 msgstr ""
 
@@ -908,19 +925,19 @@ msgstr ""
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
 msgid "Passphrase"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:143
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
 msgid "Payment Order has been sent to bank."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:149
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
 msgid "Payment Order has not been sent to bank."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:52
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr ""
 
@@ -1014,6 +1031,18 @@ msgstr ""
 msgid "Purpose"
 msgstr ""
 
+#: banking/ebics/doctype/ebics_request/ebics_request.js:11
+msgid "Re-Import"
+msgstr ""
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:28
+msgid "Re-import cancelled."
+msgstr ""
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:39
+msgid "Re-importing EBICS transactions ..."
+msgstr ""
+
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
 msgid "Recipient"
@@ -1078,11 +1107,11 @@ msgstr ""
 msgid "Response"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:118
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
 msgid "Row {0}: Currency {1} does not match bank account currency {2}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:100
 msgid "Row {0}: IBAN {1} is invalid."
 msgstr ""
 
@@ -1153,11 +1182,6 @@ msgstr ""
 msgid "Setup"
 msgstr ""
 
-#. Label of a Check field in DocType 'SEPA Payment Order'
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
-msgid "Should Update Amounts"
-msgstr ""
-
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:396
 msgid "Show Exact Amount"
 msgstr ""
@@ -1171,7 +1195,7 @@ msgid "Show Protocol Versions"
 msgstr ""
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:117
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
 msgid "Signature Passphrase"
 msgstr ""
 
@@ -1279,7 +1303,7 @@ msgstr ""
 msgid "The currency of the second account ({0}) must be the same as of the bank account ({1})"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:181
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:219
 msgid "The scheduler is inactive. Please activate it to continue auto-syncing bank transactions."
 msgstr ""
 
@@ -1346,7 +1370,7 @@ msgstr ""
 msgid "Update"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:39
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
 msgid "Update Amounts"
 msgstr ""
 

--- a/banking/locale/nl.po
+++ b/banking/locale/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-10-29 00:05+0053\n"
+"POT-Creation-Date: 2025-11-07 14:18+0053\n"
 "PO-Revision-Date: 2025-09-29 23:38+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: nl\n"
@@ -17,6 +17,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.13.1\n"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:63
+msgid "<b>EBICS User</b> '{0}' has <i>Download Batch Transactions</i> enabled. Batch details are stored in separate <b>EBICS Requests</b>, so this re-import might be incomplete. Do you want to continue?"
+msgstr "<b>EBICS-gebruiker</b> '{0}' heeft <i>Sammeloverboekingen downloaden</i> ingeschakeld. Batchdetails worden in afzonderlijke <b>EBICS-aanvragen</b> opgeslagen, dus deze herimport kan incompleet zijn. Wilt u doorgaan?"
 
 #. Header text in the ALYF Banking Workspace
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
@@ -29,7 +33,7 @@ msgstr ""
 msgid "<ul><li>It stores DocType-wise mapping of fields that should be considered as 'reference number' fields in Bank Reconciliation Tool Beta</li><li>Link and Data fields are supported</li><li>The field must have a singular reference number for matching with Bank Transactions</li></ul>"
 msgstr "<ul><li>Slaat DocType-gewijs de toewijzing op van velden die moeten worden beschouwd als 'referentienummer'-velden in Bankafstemming Beta</li><li>Link- en Datavelden worden ondersteund</li><li>Het veld moet een enkelvoudig referentienummer bevatten dat kan overeenkomen met Banktransacties</li></ul>"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:176
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:214
 msgid "A new version of the Banking app is available ({0}). Please update your instance."
 msgstr "Een nieuwe versie van de Banking-app is beschikbaar ({0}). Update uw instantie."
 
@@ -90,15 +94,15 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:87
 msgid "Amount updated to {0} in row {1}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:169
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
 msgid "Amounts not updated."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:162
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
 msgid "Amounts updated."
 msgstr ""
 
@@ -154,7 +158,7 @@ msgstr ""
 msgid "Bank Account"
 msgstr ""
 
-#: banking/ebics/utils.py:193
+#: banking/ebics/utils.py:215
 msgid "Bank Account not found for IBAN {0}"
 msgstr "Bankrekening niet gevonden voor IBAN {0}"
 
@@ -239,8 +243,8 @@ msgstr "Banking-actie is mislukt door de volgende fout(en):"
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
 #: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:140
-#: banking/ebics/utils.py:192 banking/ebics/utils.py:209
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/ebics/utils.py:187 banking/ebics/utils.py:214
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
 #: banking/klarna_kosma_integration/exception_handler.py:41
@@ -268,7 +272,7 @@ msgstr "Banking Referentietoewijzing"
 msgid "Banking Settings"
 msgstr "Banking-instellingen"
 
-#: banking/ebics/utils.py:224
+#: banking/ebics/utils.py:235
 msgid "Banking Warning"
 msgstr "Banking-waarschuwing"
 
@@ -403,8 +407,8 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:86
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:114
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:87
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:152
 msgid "Developer mode is enabled. Please disable it to continue auto-syncing bank transactions."
 msgstr "Ontwikkelaarsmodus is ingeschakeld. Schakel deze uit om automatische synchronisatie van banktransacties voort te zetten."
 
@@ -492,7 +496,7 @@ msgstr ""
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:78
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
 msgid "EBICS User"
 msgstr ""
 
@@ -504,6 +508,10 @@ msgstr "EBICS-gebruikerslimiet overschreden."
 #: banking/klarna_kosma_integration/workspace/alyf_banking/alyf_banking.json
 msgid "EBICS Users"
 msgstr "EBICS-gebruikers"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:43
+msgid "EBICS transactions re-imported successfully."
+msgstr "EBICS-transacties succesvol reimporteerd."
 
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
@@ -568,7 +576,7 @@ msgstr "Wachtwoord invoeren"
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr "Vul alleen in als geplande uitvoering bij de bank gewenst is."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:126
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
 msgid "Enter your passphrase"
 msgstr "Voer uw wachtwoord in"
 
@@ -577,11 +585,11 @@ msgstr "Voer uw wachtwoord in"
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr "Voer uw wachtwoord in om geautomatiseerde, regelmatige synchronisatie in te schakelen. Laat leeg als u handmatig wilt synchroniseren."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:119
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
 msgid "Enter your signature passphrase"
 msgstr "Voer uw handtekeningwachtwoord in"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:204
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 msgid "Error while fetching releases"
 msgstr "Fout bij ophalen van releases"
 
@@ -604,6 +612,10 @@ msgstr ""
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:91
 msgid "Failed to create {0} against {1}"
 msgstr "Aanmaken van {0} tegen {1} mislukt"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:49
+msgid "Failed to re-import EBICS transactions."
+msgstr "Reimporteren van EBICS-transacties mislukt."
 
 #: banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js:122
 msgid "Failed to reconcile new {0} against {1}"
@@ -715,7 +727,7 @@ msgstr "IBAN-waarschuwing: Niet gebruikt in SEPA-betalingsopdrachten"
 msgid "IBAN on Employee is not used in SEPA Payment Orders. Please use Bank Account instead for payment processing."
 msgstr "IBAN op werknemer wordt niet gebruikt in SEPA-betalingsopdrachten. Gebruik in plaats daarvan Bankrekening voor betalingsverwerking."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:105
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:96
 msgid "IBAN {0} is invalid."
 msgstr "IBAN {0} is ongeldig."
 
@@ -771,11 +783,16 @@ msgstr "Intradagsynchronisatie"
 msgid "Invalid Field"
 msgstr "Ongeldig veld"
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:57
+#: banking/ebics/doctype/ebics_request/ebics_request.py:75
 msgid "Invalid data available for download."
 msgstr "Ongeldige gegevens beschikbaar voor downloaden."
 
-#: banking/ebics/utils.py:225
+#: banking/ebics/doctype/ebics_request/ebics_request.py:21
+#: banking/ebics/doctype/ebics_request/ebics_request.py:24
+msgid "Invalid data for re-import."
+msgstr "Ongeldige gegevens voor reimporteren."
+
+#: banking/ebics/utils.py:236
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr "Het lijkt erop dat de EBICS-gebruiker geen toestemmingen heeft voor ordertype '{0}'. De toegestane typen zijn: {1}."
 
@@ -796,7 +813,7 @@ msgstr "Klarna Kosma-integratie"
 msgid "Last Renewed On"
 msgstr "Laatst vernieuwd op"
 
-#: banking/ebics/utils.py:544
+#: banking/ebics/utils.py:555
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr "Licentiesleutel niet gevonden. Activeer het selectievakje 'EBICS inschakelen' in de {0} en zorg ervoor dat uw abonnement actief is."
 
@@ -834,7 +851,7 @@ msgstr "Geen transacties gevonden voor de huidige filters."
 msgid "No changes to update"
 msgstr "Geen wijzigingen om bij te werken"
 
-#: banking/ebics/doctype/ebics_request/ebics_request.py:54
+#: banking/ebics/doctype/ebics_request/ebics_request.py:72
 msgid "No data available for download."
 msgstr "Geen gegevens beschikbaar voor downloaden."
 
@@ -910,19 +927,19 @@ msgstr "Partijtype en partij zijn vereist voor debiteuren-/crediteuren rekening 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
 msgid "Passphrase"
 msgstr "Wachtwoord"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:143
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
 msgid "Payment Order has been sent to bank."
 msgstr "Betalingsopdracht is naar de bank verzonden."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:149
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
 msgid "Payment Order has not been sent to bank."
 msgstr "Betalingsopdracht is niet naar de bank verzonden."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:52
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr ""
 
@@ -1016,6 +1033,18 @@ msgstr ""
 msgid "Purpose"
 msgstr "Doel"
 
+#: banking/ebics/doctype/ebics_request/ebics_request.js:11
+msgid "Re-Import"
+msgstr "Reimporteren"
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:28
+msgid "Re-import cancelled."
+msgstr ""
+
+#: banking/ebics/doctype/ebics_request/ebics_request.js:39
+msgid "Re-importing EBICS transactions ..."
+msgstr "Reimporteren van EBICS-transacties ..."
+
 #. Label of a Data field in DocType 'SEPA Payment'
 #: banking/ebics/doctype/sepa_payment/sepa_payment.json
 msgid "Recipient"
@@ -1080,11 +1109,11 @@ msgstr "Gevraagd door"
 msgid "Response"
 msgstr "Antwoord"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:118
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
 msgid "Row {0}: Currency {1} does not match bank account currency {2}."
 msgstr "Rij {0}: Valuta {1} komt niet overeen met bankrekeningvaluta {2}."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:109
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:100
 msgid "Row {0}: IBAN {1} is invalid."
 msgstr "Rij {0}: IBAN {1} is ongeldig."
 
@@ -1155,11 +1184,6 @@ msgstr "Stel een nieuw wachtwoord in voor het uploaden van transacties naar uw b
 msgid "Setup"
 msgstr "Instellen"
 
-#. Label of a Check field in DocType 'SEPA Payment Order'
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
-msgid "Should Update Amounts"
-msgstr ""
-
 #: banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js:396
 msgid "Show Exact Amount"
 msgstr "Toon exact bedrag"
@@ -1173,7 +1197,7 @@ msgid "Show Protocol Versions"
 msgstr "Toon protocolversies"
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:117
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
 msgid "Signature Passphrase"
 msgstr "Handtekeningwachtwoord"
 
@@ -1281,7 +1305,7 @@ msgstr "De valuta van de tweede rekening ({0} : {1}) moet hetzelfde zijn als die
 msgid "The currency of the second account ({0}) must be the same as of the bank account ({1})"
 msgstr "De valuta van de tweede rekening ({0}) moet hetzelfde zijn als die van de bankrekening ({1})"
 
-#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:181
+#: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:219
 msgid "The scheduler is inactive. Please activate it to continue auto-syncing bank transactions."
 msgstr "De scheduler is inactief. Activeer deze om automatische synchronisatie van banktransacties voort te zetten."
 
@@ -1348,7 +1372,7 @@ msgstr "Onbetaalde documenten"
 msgid "Update"
 msgstr "Bijwerken"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:39
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
 msgid "Update Amounts"
 msgstr ""
 


### PR DESCRIPTION
This pull request adds a new "Re-Import" feature to the EBICS Request workflow, allowing users to re-import EBICS transactions from the stored response data. The implementation includes UI changes, backend logic for re-importing, and a refactoring of the EBICS transaction import logic to enable reuse. The most important changes are grouped below.

**New Feature: Re-Import EBICS Transactions**

* Added a "Re-Import" custom button to the EBICS Request form UI, which triggers the new re-import functionality.
* Implemented a new `re_import` method in the `EBICSRequest` Python class, which validates and re-imports transactions from the response field, using the refactored import logic.

**Refactoring and Backend Improvements**

* Extracted the EBICS transaction import logic into a new `import_ebics_json` function in `utils.py`, allowing both the original sync process and the new re-import feature to use the same code path.
* Updated the original `sync_ebics_transactions` function to use the new `import_ebics_json` helper, improving code reuse and maintainability.
* Cleaned up an unnecessary import in `utils.py` for better code organization.

Resolves #319