### PR TITLE
feat: move currency check after insert

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -150,13 +150,6 @@ def create_journal_entry_bts(
 			_("Party Type and Party is required for Receivable / Payable account {0}").format(second_account)
 		)
 
-	if second_account_currency != bank_account_currency:
-		frappe.throw(
-			_(
-				"The currency of the second account ({0} : {1}) must be the same as of the bank account ({2} : {3})"
-			).format(second_account, second_account_currency, bank_gl_account, bank_account_currency)
-		)
-
 	journal_entry = frappe.new_doc("Journal Entry")
 	journal_entry.update(
 		{
@@ -200,6 +193,13 @@ def create_journal_entry_bts(
 	if allow_edit:
 		return journal_entry  # Return saved document
 
+	if second_account_currency != bank_account_currency:
+		frappe.throw(
+			_(
+				"The currency of the second account ({0} : {1}) must be the same as of the bank account ({2} : {3})"
+			).format(second_account, second_account_currency, bank_gl_account, bank_account_currency)
+		)
+	
 	journal_entry.submit()
 
 	return reconcile_voucher(

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -193,6 +193,8 @@ def create_journal_entry_bts(
 	if allow_edit:
 		return journal_entry  # Return saved document
 
+	# This check happens here because the user should be able to make
+	# multicurrency entries when they edit the Journal Entry manually (`allow_edit` is True).
 	if second_account_currency != bank_account_currency:
 		frappe.throw(
 			_(

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -199,7 +199,7 @@ def create_journal_entry_bts(
 				"The currency of the second account ({0} : {1}) must be the same as of the bank account ({2} : {3})"
 			).format(second_account, second_account_currency, bank_gl_account, bank_account_currency)
 		)
-	
+
 	journal_entry.submit()
 
 	return reconcile_voucher(


### PR DESCRIPTION
Allow the user not to submit directly with an account that has a different currency than the bank transaction, but "Edit in Full Page" to fine tune his settings.

Resolves #322