### PR TITLE
feat: Add reference filter to Journal Entry matching query

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ def get_payment_entries(
 	]
 ```
 
+In case you automatically create **Journal Entries** for **Bank Transactions** (e.g. to Cash In Transit), you can prevent them from showing up in **Bank Reconciliation Tool Beta** by using the **Bank Transaction**'s _ID_ (`name`) as the **Journal Entry**'s _Reference Number_ (`cheque_no`).
+
 ### SEPA Payment Order
 
 DocTypes that map to **SEPA Payment Order** can provide a method `get_sepa_payment_amount` via controller or `doc_events` hook. This is called when the execution date is changed. The parameters are the reference row name and execution date. It should return the amount of the payment. The main use case for this is early payment discounts.

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -645,7 +645,6 @@ def get_matching_queries(
 	if "journal_entry" in document_types:
 		frappe.has_permission("Journal Entry", throw=True)
 		query = get_je_matching_query(
-			transaction,
 			exact_match,
 			common_filters,
 			from_date,
@@ -653,6 +652,7 @@ def get_matching_queries(
 			filter_by_reference_date,
 			from_reference_date,
 			to_reference_date,
+			transaction.name,
 		)
 		queries.append(query)
 
@@ -931,7 +931,6 @@ def get_pe_matching_query(
 
 
 def get_je_matching_query(
-	transaction: "CustomBankTransaction",
 	exact_match: bool,
 	common_filters: frappe._dict,
 	from_date: str | datetime.date | None = None,
@@ -939,6 +938,7 @@ def get_je_matching_query(
 	filter_by_reference_date: bool = False,
 	from_reference_date: str | datetime.date | None = None,
 	to_reference_date: str | datetime.date | None = None,
+	bank_transaction_name: str | None = None,
 ):
 	# get matching journal entry query
 	# We have mapping at the bank level
@@ -971,13 +971,15 @@ def get_je_matching_query(
 		)
 		.where(je.docstatus == 1)
 		.where(je.voucher_type != "Opening Entry")
-		.where(je.cheque_no != transaction.name)
 		.where(je.clearance_date.isnull())
 		.where(jea.account == common_filters.bank_account)
 		.where(filter_by_date)
 		.groupby(je.name)
 		.orderby(je.cheque_date if cint(filter_by_reference_date) else je.posting_date)
 	)
+
+	if bank_transaction_name:
+		subquery = subquery.where(je.cheque_no != bank_transaction_name)
 
 	if frappe.flags.auto_reconcile_vouchers:
 		subquery = subquery.where(je.cheque_no == common_filters.reference_no)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -645,6 +645,7 @@ def get_matching_queries(
 	if "journal_entry" in document_types:
 		frappe.has_permission("Journal Entry", throw=True)
 		query = get_je_matching_query(
+			transaction,
 			exact_match,
 			common_filters,
 			from_date,
@@ -930,6 +931,7 @@ def get_pe_matching_query(
 
 
 def get_je_matching_query(
+	transaction: "CustomBankTransaction",
 	exact_match: bool,
 	common_filters: frappe._dict,
 	from_date: str | datetime.date | None = None,
@@ -969,6 +971,7 @@ def get_je_matching_query(
 		)
 		.where(je.docstatus == 1)
 		.where(je.voucher_type != "Opening Entry")
+		.where(je.cheque_no != transaction.name)
 		.where(je.clearance_date.isnull())
 		.where(jea.account == common_filters.bank_account)
 		.where(filter_by_date)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -979,6 +979,9 @@ def get_je_matching_query(
 	)
 
 	if bank_transaction_name:
+		# This filter ensures that Journal Entries that have been created
+		# automatically for the Bank Transaction (e.g. to Cash In Transit) via
+		# other apps are not offered as matches.
 		subquery = subquery.where(je.cheque_no != bank_transaction_name)
 
 	if frappe.flags.auto_reconcile_vouchers:


### PR DESCRIPTION
This added filter in the Journal Entry matching allows custom integrations, that create journal entries with a reference to the bank transaction itself to hide the journal entry by filtering the bank transaction name from the journal entries reference.