### PR TITLE
fix(Bank Reconciliation): handle multi-currency invoices in matching and reconciliation

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1105,10 +1105,31 @@ def get_unpaid_si_matching_query(
 	sales_invoice = frappe.qb.DocType("Sales Invoice")
 	description = common_filters.description
 
+	# When the invoice currency matches the bank currency but the party account
+	# currency differs, outstanding_amount (stored in party_account_currency) must
+	# be converted back to the invoice/bank currency for display and matching.
+	# In all other cases (e.g. party_account_currency matches bank currency),
+	# return the unchanged outstanding_amount and party_account_currency.
+	is_converted = (sales_invoice.currency == currency) & (
+		sales_invoice.party_account_currency != sales_invoice.currency
+	)
+
+	invoice_outstanding = (
+		frappe.qb.terms.Case()
+		.when(is_converted, sales_invoice.outstanding_amount / sales_invoice.conversion_rate)
+		.else_(sales_invoice.outstanding_amount)
+	)
+
+	display_currency = (
+		frappe.qb.terms.Case()
+		.when(is_converted, sales_invoice.currency)
+		.else_(sales_invoice.party_account_currency)
+	)
+
 	party_filter = sales_invoice.customer == common_filters.party
 	party_rank = frappe.qb.terms.Case().when(party_filter, 1).else_(0)
 
-	amount_rank = amount_rank_condition(sales_invoice.outstanding_amount, common_filters.amount)
+	amount_rank = amount_rank_condition(invoice_outstanding, common_filters.amount)
 
 	# Check reference field equality with common_filters.reference_no
 	reference_field_is_set = reference_field and reference_field != "name"
@@ -1141,14 +1162,14 @@ def get_unpaid_si_matching_query(
 			rank_expression.as_("rank"),
 			ConstantColumn("Sales Invoice").as_("doctype"),
 			sales_invoice.name.as_("name"),
-			sales_invoice.outstanding_amount.as_("paid_amount"),
+			invoice_outstanding.as_("paid_amount"),
 			sales_invoice[reference_field or "name"].as_("reference_no"),
 			sales_invoice.posting_date.as_("reference_date"),
 			sales_invoice.customer.as_("party"),
 			ConstantColumn("Customer").as_("party_type"),
 			sales_invoice.customer_name.as_("party_name"),
 			sales_invoice.posting_date,
-			sales_invoice.currency,
+			display_currency.as_("currency"),
 			party_rank.as_("party_match"),
 			amount_rank.as_("amount_match"),
 			date_rank.as_("date_match"),
@@ -1159,7 +1180,7 @@ def get_unpaid_si_matching_query(
 		.where(sales_invoice.docstatus == 1)
 		.where(sales_invoice.company == company)  # because we do not have bank account check
 		.where(sales_invoice.outstanding_amount != 0.0)
-		.where(sales_invoice.currency == currency)
+		.where((sales_invoice.currency == currency) | (sales_invoice.party_account_currency == currency))
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1167,7 +1188,7 @@ def get_unpaid_si_matching_query(
 	if include_only_returns:
 		query = query.where(sales_invoice.is_return == 1)
 	if exact_match:
-		query = query.where(sales_invoice.outstanding_amount == common_filters.amount)
+		query = query.where(invoice_outstanding == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
 
@@ -1280,10 +1301,31 @@ def get_unpaid_pi_matching_query(
 	purchase_invoice = frappe.qb.DocType("Purchase Invoice")
 	description = common_filters.description
 
+	# When the invoice currency matches the bank currency but the party account
+	# currency differs, outstanding_amount (stored in party_account_currency) must
+	# be converted back to the invoice/bank currency for display and matching.
+	# In all other cases (e.g. party_account_currency matches bank currency),
+	# return the unchanged outstanding_amount and party_account_currency.
+	is_converted = (purchase_invoice.currency == currency) & (
+		purchase_invoice.party_account_currency != purchase_invoice.currency
+	)
+
+	invoice_outstanding = (
+		frappe.qb.terms.Case()
+		.when(is_converted, purchase_invoice.outstanding_amount / purchase_invoice.conversion_rate)
+		.else_(purchase_invoice.outstanding_amount)
+	)
+
+	display_currency = (
+		frappe.qb.terms.Case()
+		.when(is_converted, purchase_invoice.currency)
+		.else_(purchase_invoice.party_account_currency)
+	)
+
 	party_filter = purchase_invoice.supplier == common_filters.party
 	party_match = frappe.qb.terms.Case().when(party_filter, 1).else_(0)
 
-	amount_rank = amount_rank_condition(purchase_invoice.outstanding_amount, common_filters.amount)
+	amount_rank = amount_rank_condition(invoice_outstanding, common_filters.amount)
 
 	# Check reference field equality with common_filters.reference_no
 	reference_field_is_set = reference_field and reference_field != "name"
@@ -1318,14 +1360,14 @@ def get_unpaid_pi_matching_query(
 			rank_expression.as_("rank"),
 			ConstantColumn("Purchase Invoice").as_("doctype"),
 			purchase_invoice.name.as_("name"),
-			purchase_invoice.outstanding_amount.as_("paid_amount"),
+			invoice_outstanding.as_("paid_amount"),
 			purchase_invoice[reference_field].as_("reference_no"),
 			purchase_invoice.bill_date.as_("reference_date"),
 			purchase_invoice.supplier.as_("party"),
 			ConstantColumn("Supplier").as_("party_type"),
 			purchase_invoice.supplier_name.as_("party_name"),
 			purchase_invoice.posting_date,
-			purchase_invoice.currency,
+			display_currency.as_("currency"),
 			party_match.as_("party_match"),
 			amount_rank.as_("amount_match"),
 			date_rank.as_("date_match"),
@@ -1337,7 +1379,9 @@ def get_unpaid_pi_matching_query(
 		.where(purchase_invoice.company == company)
 		.where(purchase_invoice.outstanding_amount != 0.0)
 		.where(purchase_invoice.is_paid == 0)
-		.where(purchase_invoice.currency == currency)
+		.where(
+			(purchase_invoice.currency == currency) | (purchase_invoice.party_account_currency == currency)
+		)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1345,7 +1389,7 @@ def get_unpaid_pi_matching_query(
 	if include_only_returns:
 		query = query.where(purchase_invoice.is_return == 1)
 	if exact_match:
-		query = query.where(purchase_invoice.outstanding_amount == common_filters.amount)
+		query = query.where(invoice_outstanding == common_filters.amount)
 	if common_filters.exact_party_match:
 		query = query.where(party_filter)
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -6,6 +6,9 @@ import frappe
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
 	create_payment_entry,
 )
+from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import (
+	make_purchase_invoice,
+)
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
 	create_sales_invoice,
 )
@@ -22,6 +25,8 @@ from banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank
 	create_payment_entry_bts,
 	get_linked_payments,
 )
+
+test_dependencies = ["Warehouse", "Item", "Account", "Cost Center", "UOM", "Company"]
 
 
 class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
@@ -678,6 +683,222 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(first_match["name"], journal_entry.name)
 		self.assertEqual(first_match["paid_amount"], 200.0)
 
+	def test_usd_purchase_invoice_paid_in_usd(self):
+		"""Reconcile a USD Purchase Invoice via a USD bank account.
+
+		Invoice: 100 USD, payable account in company currency (INR).
+		Bank Transaction: 100 USD withdrawal.
+		Expected: invoice fetched with 100 USD outstanding (converted from 8000 INR),
+		multi-currency PE with paid_amount=100 USD, full reconciliation.
+		"""
+		_gl_account, usd_bank_account = setup_usd_bank()
+		supplier = create_supplier("USD Supplier Inc.", "USD")
+		create_currency_exchange("USD", "INR", 80)
+
+		pi = make_purchase_invoice(
+			supplier=supplier,
+			currency="USD",
+			conversion_rate=80,
+			rate=100,
+			qty=1,
+			cost_center="_Test Cost Center - _TC",
+		)
+
+		bt = create_bank_transaction(
+			withdrawal=100,
+			bank_account=usd_bank_account,
+			currency="USD",
+		)
+
+		# Verify the invoice is fetched with the correct outstanding and currency
+		matched = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["purchase_invoice", "unpaid_invoices"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		pi_match = next(m for m in matched if m["name"] == pi.name)
+		self.assertEqual(pi_match["paid_amount"], 100)  # converted from 8000 INR
+		self.assertEqual(pi_match["currency"], "USD")
+
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps([{"payment_doctype": "Purchase Invoice", "payment_name": pi.name}]),
+		)
+
+		bt.reload()
+		pi.reload()
+
+		self.assertEqual(bt.status, "Reconciled")
+		self.assertEqual(bt.unallocated_amount, 0)
+		self.assertEqual(pi.outstanding_amount, 0)
+
+		pe = frappe.get_doc("Payment Entry", bt.payment_entries[0].payment_entry)
+		self.assertEqual(pe.paid_amount, 100)
+		self.assertEqual(pe.paid_from_account_currency, "USD")
+		self.assertEqual(pe.paid_to_account_currency, "INR")
+
+	def test_usd_purchase_invoice_paid_in_company_currency(self):
+		"""Reconcile a USD Purchase Invoice via an INR bank account.
+
+		Invoice: 100 USD (= 8000 INR outstanding), payable account in INR.
+		Bank Transaction: 8000 INR withdrawal.
+		Expected: invoice fetched with 8000 INR outstanding (unchanged),
+		same-currency PE with paid_amount=8000 INR, full reconciliation.
+		"""
+		supplier = create_supplier("USD Supplier Inc.", "USD")
+
+		pi = make_purchase_invoice(
+			supplier=supplier,
+			currency="USD",
+			conversion_rate=80,
+			rate=100,
+			qty=1,
+			cost_center="_Test Cost Center - _TC",
+		)
+
+		bt = create_bank_transaction(
+			withdrawal=8000,
+			bank_account=self.bank_account,
+		)
+
+		# Verify the invoice is fetched with unchanged INR outstanding
+		matched = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["purchase_invoice", "unpaid_invoices"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		pi_match = next(m for m in matched if m["name"] == pi.name)
+		self.assertEqual(pi_match["paid_amount"], 8000)  # INR, unchanged
+		self.assertEqual(pi_match["currency"], "INR")
+
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps([{"payment_doctype": "Purchase Invoice", "payment_name": pi.name}]),
+		)
+
+		bt.reload()
+		pi.reload()
+
+		self.assertEqual(bt.status, "Reconciled")
+		self.assertEqual(bt.unallocated_amount, 0)
+		self.assertEqual(pi.outstanding_amount, 0)
+
+		pe = frappe.get_doc("Payment Entry", bt.payment_entries[0].payment_entry)
+		self.assertEqual(pe.paid_amount, 8000)
+		self.assertEqual(pe.paid_from_account_currency, "INR")
+		self.assertEqual(pe.paid_to_account_currency, "INR")
+
+	def test_usd_sales_invoice_paid_in_usd(self):
+		"""Reconcile a USD Sales Invoice via a USD bank account.
+
+		Invoice: 100 USD, receivable account in company currency (INR).
+		Bank Transaction: 100 USD deposit.
+		Expected: invoice fetched with 100 USD outstanding (converted from 8000 INR),
+		multi-currency PE with received_amount=100 USD, full reconciliation.
+		"""
+		_gl_account, usd_bank_account = setup_usd_bank()
+		customer = create_customer("USD Client Inc.", "USD")
+		create_currency_exchange("USD", "INR", 80)
+
+		si = create_sales_invoice(
+			customer=customer,
+			currency="USD",
+			conversion_rate=80,
+			rate=100,
+			warehouse="Finished Goods - _TC",
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+
+		bt = create_bank_transaction(
+			deposit=100,
+			bank_account=usd_bank_account,
+			currency="USD",
+		)
+
+		# Verify the invoice is fetched with the correct outstanding and currency
+		matched = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["sales_invoice", "unpaid_invoices"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		si_match = next(m for m in matched if m["name"] == si.name)
+		self.assertEqual(si_match["paid_amount"], 100)  # converted from 8000 INR
+		self.assertEqual(si_match["currency"], "USD")
+
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps([{"payment_doctype": "Sales Invoice", "payment_name": si.name}]),
+		)
+
+		bt.reload()
+		si.reload()
+
+		self.assertEqual(bt.status, "Reconciled")
+		self.assertEqual(bt.unallocated_amount, 0)
+		self.assertEqual(si.outstanding_amount, 0)
+
+		pe = frappe.get_doc("Payment Entry", bt.payment_entries[0].payment_entry)
+		self.assertEqual(pe.received_amount, 100)
+		self.assertEqual(pe.paid_from_account_currency, "INR")
+		self.assertEqual(pe.paid_to_account_currency, "USD")
+
+	def test_usd_sales_invoice_paid_in_company_currency(self):
+		"""Reconcile a USD Sales Invoice via an INR bank account.
+
+		Invoice: 100 USD (= 8000 INR outstanding), receivable account in INR.
+		Bank Transaction: 8000 INR deposit.
+		Expected: invoice fetched with 8000 INR outstanding (unchanged),
+		same-currency PE with paid_amount=8000 INR, full reconciliation.
+		"""
+		customer = create_customer("USD Client Inc.", "USD")
+
+		si = create_sales_invoice(
+			customer=customer,
+			currency="USD",
+			conversion_rate=80,
+			rate=100,
+			warehouse="Finished Goods - _TC",
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+
+		bt = create_bank_transaction(
+			deposit=8000,
+			bank_account=self.bank_account,
+		)
+
+		# Verify the invoice is fetched with unchanged INR outstanding
+		matched = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["sales_invoice", "unpaid_invoices"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		si_match = next(m for m in matched if m["name"] == si.name)
+		self.assertEqual(si_match["paid_amount"], 8000)  # INR, unchanged
+		self.assertEqual(si_match["currency"], "INR")
+
+		bulk_reconcile_vouchers(
+			bt.name,
+			json.dumps([{"payment_doctype": "Sales Invoice", "payment_name": si.name}]),
+		)
+
+		bt.reload()
+		si.reload()
+
+		self.assertEqual(bt.status, "Reconciled")
+		self.assertEqual(bt.unallocated_amount, 0)
+		self.assertEqual(si.outstanding_amount, 0)
+
+		pe = frappe.get_doc("Payment Entry", bt.payment_entries[0].payment_entry)
+		self.assertEqual(pe.paid_amount, 8000)
+		self.assertEqual(pe.paid_from_account_currency, "INR")
+		self.assertEqual(pe.paid_to_account_currency, "INR")
+
 	def test_usd_jv_against_eur_company(self):
 		"""Test if the tool can create a USD Journal Entry against a EUR company."""
 		bank = create_bank("Citi Bank USD", swift_number="CITIUS34")
@@ -835,3 +1056,37 @@ def create_bank_gl_account(account_name: str = "_Test Bank - _TC", currency: str
 		}
 	).insert()
 	return gl_account.name
+
+
+def create_supplier(supplier_name="_Test Supplier", currency=None):
+	if not frappe.db.exists("Supplier", supplier_name):
+		supplier = frappe.new_doc("Supplier")
+		supplier.supplier_name = supplier_name
+		supplier.supplier_group = "All Supplier Groups"
+		supplier.supplier_type = "Individual"
+		if currency:
+			supplier.default_currency = currency
+		supplier.save()
+	return supplier_name
+
+
+def setup_usd_bank():
+	"""Create a USD bank account for multi-currency tests."""
+	bank = create_bank("Citi Bank USD", swift_number="CITIUS34")
+	gl_account = create_bank_gl_account("_Test USD Bank Reco Beta", "USD")
+	bank_account = create_bank_account(bank.name, gl_account, "USD Reco Account")
+	return gl_account, bank_account
+
+
+def create_currency_exchange(from_currency, to_currency, rate, date=None):
+	frappe.get_doc(
+		{
+			"doctype": "Currency Exchange",
+			"from_currency": from_currency,
+			"to_currency": to_currency,
+			"exchange_rate": rate,
+			"date": date or frappe.utils.nowdate(),
+			"for_buying": 1,
+			"for_selling": 1,
+		}
+	).insert()

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -11,7 +11,7 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import (
 )
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt
+from frappe.utils import cint, flt
 
 if TYPE_CHECKING:
 	from banking.overrides.bank_transaction import CustomBankTransaction
@@ -142,6 +142,28 @@ def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list
 
 	bank_account = frappe.db.get_value("Bank Account", bt.bank_account, "account")
 	first_invoice = invoices_to_bill[0]
+
+	# Detect multi-currency: the bank account currency differs from the
+	# party (payable/receivable) account currency.  A USD invoice with a EUR
+	# payable paid from a EUR bank is same-currency from the PE's perspective.
+	is_multi_currency = False
+	if first_invoice[DOCTYPE] != "Expense Claim":
+		invoice_details = frappe.db.get_value(
+			first_invoice[DOCTYPE],
+			first_invoice[DOCNAME],
+			["party_account_currency", "currency", "conversion_rate"],
+			as_dict=True,
+		)
+		bank_account_currency = frappe.db.get_value("Account", bank_account, "account_currency")
+		is_multi_currency = invoice_details.party_account_currency != bank_account_currency
+
+	if is_multi_currency and len(invoices_to_bill) > 1:
+		frappe.throw(
+			_(
+				"Reconciling multiple multi-currency invoices at once is not supported. Please reconcile one invoice at a time."
+			)
+		)
+
 	if first_invoice[DOCTYPE] == "Expense Claim":
 		from hrms.overrides.employee_payment_entry import get_payment_entry_for_employee
 
@@ -151,6 +173,8 @@ def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list
 			party_amount=first_invoice[AMOUNT],
 			bank_account=bank_account,
 		)
+	elif is_multi_currency:
+		payment_entry = _create_multi_currency_pe(bt, first_invoice, invoice_details, bank_account)
 	else:
 		payment_entry = get_payment_entry(
 			first_invoice[DOCTYPE],
@@ -162,20 +186,68 @@ def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list
 			# return SI against a withdrawal should be considered as "Pay" (refund)
 			payment_type="Receive" if bt.deposit > 0 else "Pay",
 		)
+
 	payment_entry.posting_date = bt.date
 	payment_entry.reference_no = bt.reference_number or first_invoice[DOCNAME]
 	payment_entry.reference_date = bt.date
 
-	# clear references to allocate invoices correctly with splits
-	payment_entry.references = []
-	invoices = split_invoices_based_on_payment_terms(prepare_invoices_to_split(invoices_to_bill), bt.company)
-	adjust_and_allocate_invoices(bt, invoices, payment_entry, action=_attach_invoice)
+	if is_multi_currency:
+		# Refresh exchange rate for the bank transaction date (not the invoice date)
+		# and recalculate amounts (exchange gain/loss deductions, etc.)
+		payment_entry.source_exchange_rate = 0
+		payment_entry.target_exchange_rate = 0
+		payment_entry.set_exchange_rate()
+		payment_entry.set_amounts()
+	else:
+		# clear references to allocate invoices correctly with splits
+		payment_entry.references = []
+		invoices = split_invoices_based_on_payment_terms(
+			prepare_invoices_to_split(invoices_to_bill), bt.company
+		)
+		adjust_and_allocate_invoices(bt, invoices, payment_entry, action=_attach_invoice)
 
-	payment_entry.paid_amount = abs(
-		sum(row.allocated_amount for row in payment_entry.references)
-	)  # should not be negative
+		payment_entry.paid_amount = abs(
+			sum(row.allocated_amount for row in payment_entry.references)
+		)  # should not be negative
+
 	payment_entry.submit()
 	return payment_entry
+
+
+def _create_multi_currency_pe(
+	bt: "CustomBankTransaction",
+	invoice: tuple,
+	invoice_details: frappe._dict,
+	bank_account: str,
+) -> "Document":
+	"""Create a Payment Entry for a multi-currency invoice.
+
+	When the party account currency (e.g. EUR) differs from the invoice/bank
+	currency (e.g. USD), we pass bank_amount (from the Bank Transaction) to
+	get_payment_entry. This bypasses the get_exchange_rate lookup inside
+	get_payment_entry (which may return a different rate than the invoice's
+	original conversion_rate) and ensures paid_amount is set correctly in the
+	bank currency.
+	"""
+	bank_amount = bt.unallocated_amount
+	party_amount = invoice[AMOUNT]  # outstanding in party_account_currency
+
+	# For partial payments: cap party_amount to what the bank amount covers,
+	# converted to party_account_currency using the invoice's conversion_rate.
+	# Round to currency precision to avoid false partial payments from floating
+	# point drift (e.g. stored outstanding 1140.07 vs computed 1140.0654...).
+	currency_precision = cint(frappe.db.get_default("currency_precision")) or 2
+	max_party_amount = flt(bank_amount * invoice_details.conversion_rate, currency_precision)
+	party_amount = min(party_amount, max_party_amount)
+
+	return get_payment_entry(
+		invoice[DOCTYPE],
+		invoice[DOCNAME],
+		party_amount=party_amount,
+		bank_account=bank_account,
+		bank_amount=bank_amount,
+		payment_type="Receive" if bt.deposit > 0 else "Pay",
+	)
 
 
 def prepare_invoices_to_split(invoices):

--- a/banking/utils.py
+++ b/banking/utils.py
@@ -33,6 +33,10 @@ def before_tests():
 			}
 		)
 
+	frappe.db.set_single_value(
+		"Accounts Settings", "allow_multi_currency_invoices_against_single_party_account", 1
+	)
+
 	frappe.db.commit()  # nosemgrep
 
 


### PR DESCRIPTION
**The core problem in one sentence:** `outstanding_amount` is stored in the payable/receivable account's currency, not the invoice currency -- the BRT assumed they're the same.

| Case | Invoice | Bank Account | Payable/Receivable | Displayed as | PE type |
|---|---|---|---|---|---|
| 1 | USD | USD | USD | USD (as-is) | same-currency |
| 2 | USD | USD | EUR | USD (converted) | multi-currency |
| 3 | USD | EUR | EUR | EUR (as-is) | same-currency |

Cases 2 and 3 were both broken:

- Case 2: showed EUR amount with $ sign, created incorrect PE
- Case 3: invoice was hidden entirely (filtered out by `WHERE currency = 'EUR'` since invoice currency is USD)

New behavior for case 2:

- Purchase Invoice: 100 USD, `conversion_rate` 0.8 → outstanding 80 EUR
- Bank Transaction: 100 USD
- Query now returns: `80 / 0.8 = 100 USD` (was: `80` with $ symbol)
- PE created: `paid_amount=100 USD`, `allocated_amount=80 EUR`, exchange gain/loss deduction bridges the rate difference

New behavior for case 3:

- Purchase Invoice: 100 USD, `conversion_rate` 0.8 → outstanding 80 EUR
- Bank Transaction: 80 EUR
- Query now returns: `80 €` (was: `80` with $ symbol)
- PE created: `paid_amount=80 EUR`, `allocated_amount=80 EUR`

---

Query changes (SI + PI):

- Convert `outstanding_amount` to invoice currency via `conversion_rate` when `invoice.currency` matches bank currency but differs from `party_account_currency`
- Return `party_account_currency` as display currency when no conversion is applied
- Relax `WHERE` clause to also match invoices whose `party_account_currency` equals the bank currency

Reconciliation changes:

- Detect multi-currency by comparing bank account currency with party account currency (not invoice currency)
- Create PE via `get_payment_entry` with explicit `bank_amount` from the **Bank Transaction**
- Refresh exchange rate for the bank transaction date and recalculate exchange gain/loss deductions via `set_amounts()`
- Round partial-payment cap to currency precision to avoid floating point drift
- Disallow reconciling multiple multi-currency invoices at once
