### PR TITLE
feat(Bank Transaction): normalize negative imported values

### DIFF
--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -108,7 +108,6 @@ override_doctype_class = {"Bank Transaction": "banking.overrides.bank_transactio
 doc_events = {
 	"Bank Transaction": {
 		"on_update_after_submit": "banking.overrides.bank_transaction.on_update_after_submit",
-		"before_validate": "banking.overrides.bank_transaction.before_validate",
 	},
 	"Bank Account": {
 		"before_validate": "banking.overrides.bank_account.before_validate",

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -108,6 +108,7 @@ override_doctype_class = {"Bank Transaction": "banking.overrides.bank_transactio
 doc_events = {
 	"Bank Transaction": {
 		"on_update_after_submit": "banking.overrides.bank_transaction.on_update_after_submit",
+		"before_validate": "banking.overrides.bank_transaction.before_validate",
 	},
 	"Bank Account": {
 		"before_validate": "banking.overrides.bank_account.before_validate",

--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -6,6 +6,24 @@ from frappe.utils import flt, getdate
 
 
 class CustomBankTransaction(BankTransaction):
+	def before_validate(self):
+		"""Normalize imported signs before ERPNext computes fees and balances.
+
+		Order matters here:
+		- ERPNext's `BankTransaction.before_validate` applies `handle_excluded_fee()`
+		  and then recalculates `unallocated_amount`.
+		- Imported statements can contain negative deposit/withdrawal/fee values.
+		- If we normalize after the core method, fees may be applied in the wrong
+		  direction and `unallocated_amount` can be computed from pre-normalized
+		  values (stale until a later validation cycle).
+
+		By normalizing first and calling `super().before_validate()` second, core
+		fee handling and amount calculations run once on a consistent, positive-value
+		representation in the same validation pass.
+		"""
+		self.enforce_positive_values()
+		super().before_validate()
+
 	def add_payment_entries(self, vouchers: list, reconcile_multi_party: bool = False):
 		"Add the vouchers with zero allocation. Save() will perform the allocations and clearance"
 		if self.unallocated_amount <= 0.0:
@@ -72,13 +90,6 @@ class CustomBankTransaction(BankTransaction):
 		"""
 		for fieldname in ["deposit", "withdrawal", "included_fee", "excluded_fee"]:
 			self.convert_to_positive_value(fieldname)
-
-		# Re-call this function as the original function runs before this one and values are not converted
-		self.handle_excluded_fee()
-
-
-def before_validate(doc: "CustomBankTransaction", method):
-	doc.enforce_positive_values()
 
 
 def on_update_after_submit(doc, event):

--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -58,6 +58,15 @@ class CustomBankTransaction(BankTransaction):
 			lambda x: x.payment_document == voucher_type and x.payment_entry == voucher_name,
 		)
 
+	def convert_to_positive_value(self, fieldname: str):
+		cur_value = self.get(fieldname)
+		if cur_value is not None and flt(cur_value) < 0:
+			self.set(fieldname, abs(flt(cur_value)))
+
+
+def before_validate(doc: "CustomBankTransaction", method):
+	enforce_positive_values(doc)
+
 
 def on_update_after_submit(doc, event):
 	"""Validate if the Bank Transaction is over-allocated."""
@@ -72,3 +81,17 @@ def on_update_after_submit(doc, event):
 				),
 				title=_("Over Allocation"),
 			)
+
+
+def enforce_positive_values(doc: "CustomBankTransaction"):
+	"""Convert any negative values to positive values.
+
+	Bank Statements often contain negative values (mostly for withdrawals and
+	fees) while ERPNext expects positive values only. To avoid errors during
+	Data Import, we accept negative values but convert them to positive values.
+	"""
+	for fieldname in ["deposit", "withdrawal", "included_fee", "excluded_fee"]:
+		doc.convert_to_positive_value(fieldname)
+
+	# Re-call this function as the original function runs before this one and values are not converted
+	doc.handle_excluded_fee()

--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -63,9 +63,22 @@ class CustomBankTransaction(BankTransaction):
 		if cur_value is not None and flt(cur_value) < 0:
 			self.set(fieldname, abs(flt(cur_value)))
 
+	def enforce_positive_values(self):
+		"""Convert any negative values to positive values.
+
+		Bank Statements often contain negative values (mostly for withdrawals and
+		fees) while ERPNext expects positive values only. To avoid errors during
+		Data Import, we accept negative values but convert them to positive values.
+		"""
+		for fieldname in ["deposit", "withdrawal", "included_fee", "excluded_fee"]:
+			self.convert_to_positive_value(fieldname)
+
+		# Re-call this function as the original function runs before this one and values are not converted
+		self.handle_excluded_fee()
+
 
 def before_validate(doc: "CustomBankTransaction", method):
-	enforce_positive_values(doc)
+	doc.enforce_positive_values()
 
 
 def on_update_after_submit(doc, event):
@@ -81,17 +94,3 @@ def on_update_after_submit(doc, event):
 				),
 				title=_("Over Allocation"),
 			)
-
-
-def enforce_positive_values(doc: "CustomBankTransaction"):
-	"""Convert any negative values to positive values.
-
-	Bank Statements often contain negative values (mostly for withdrawals and
-	fees) while ERPNext expects positive values only. To avoid errors during
-	Data Import, we accept negative values but convert them to positive values.
-	"""
-	for fieldname in ["deposit", "withdrawal", "included_fee", "excluded_fee"]:
-		doc.convert_to_positive_value(fieldname)
-
-	# Re-call this function as the original function runs before this one and values are not converted
-	doc.handle_excluded_fee()

--- a/banking/overrides/test_bank_transaction_positive_values.py
+++ b/banking/overrides/test_bank_transaction_positive_values.py
@@ -4,8 +4,6 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from banking.overrides.bank_transaction import enforce_positive_values
-
 
 class TestEnforcePositiveValues(FrappeTestCase):
 	def test_deposit_values_are_normalized(self):
@@ -16,7 +14,7 @@ class TestEnforcePositiveValues(FrappeTestCase):
 		doc.included_fee = -1.0
 		doc.excluded_fee = -1.0
 
-		enforce_positive_values(doc)
+		doc.enforce_positive_values()
 
 		self.assertEqual(doc.deposit, 1.0)
 		self.assertEqual(doc.withdrawal, 0.0)
@@ -31,7 +29,7 @@ class TestEnforcePositiveValues(FrappeTestCase):
 		doc.included_fee = -1.0
 		doc.excluded_fee = -1.0
 
-		enforce_positive_values(doc)
+		doc.enforce_positive_values()
 
 		self.assertEqual(doc.deposit, 0.0)
 		self.assertEqual(doc.withdrawal, 2.0)
@@ -46,7 +44,7 @@ class TestEnforcePositiveValues(FrappeTestCase):
 		doc.included_fee = None
 		doc.excluded_fee = None
 
-		enforce_positive_values(doc)
+		doc.enforce_positive_values()
 
 		self.assertIsNone(doc.deposit)
 		self.assertIsNone(doc.withdrawal)

--- a/banking/overrides/test_bank_transaction_positive_values.py
+++ b/banking/overrides/test_bank_transaction_positive_values.py
@@ -6,47 +6,78 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestEnforcePositiveValues(FrappeTestCase):
-	def test_deposit_values_are_normalized(self):
+	def make_doc_and_run_before_validate(self, **kwargs):
 		doc = frappe.new_doc("Bank Transaction")
+		doc.update(kwargs)
+		doc.run_method("before_validate")
+		return doc
 
-		doc.deposit = -2.0
-		doc.withdrawal = 0.0
-		doc.included_fee = -1.0
-		doc.excluded_fee = -1.0
-
-		doc.enforce_positive_values()
+	def test_deposit_values_are_normalized(self):
+		doc = self.make_doc_and_run_before_validate(
+			deposit=-2.0,
+			withdrawal=0.0,
+			included_fee=-1.0,
+			excluded_fee=-1.0,
+		)
 
 		self.assertEqual(doc.deposit, 1.0)
 		self.assertEqual(doc.withdrawal, 0.0)
 		self.assertEqual(doc.included_fee, 2.0)
 		self.assertEqual(doc.excluded_fee, 0.0)
+		self.assertEqual(doc.unallocated_amount, 1.0)
 
 	def test_withdrawal_values_are_normalized(self):
-		doc = frappe.new_doc("Bank Transaction")
-
-		doc.deposit = 0.0
-		doc.withdrawal = -1.0
-		doc.included_fee = -1.0
-		doc.excluded_fee = -1.0
-
-		doc.enforce_positive_values()
+		doc = self.make_doc_and_run_before_validate(
+			deposit=0.0,
+			withdrawal=-1.0,
+			included_fee=-1.0,
+			excluded_fee=-1.0,
+		)
 
 		self.assertEqual(doc.deposit, 0.0)
 		self.assertEqual(doc.withdrawal, 2.0)
 		self.assertEqual(doc.included_fee, 2.0)
 		self.assertEqual(doc.excluded_fee, 0.0)
+		self.assertEqual(doc.unallocated_amount, 2.0)
+
+	def test_negative_withdrawal_with_positive_excluded_fee(self):
+		doc = self.make_doc_and_run_before_validate(
+			deposit=0.0,
+			withdrawal=-10.0,
+			included_fee=0.0,
+			excluded_fee=1.0,
+		)
+
+		self.assertEqual(doc.deposit, 0.0)
+		self.assertEqual(doc.withdrawal, 11.0)
+		self.assertEqual(doc.included_fee, 1.0)
+		self.assertEqual(doc.excluded_fee, 0.0)
+		self.assertEqual(doc.unallocated_amount, 11.0)
+
+	def test_negative_deposit_with_positive_excluded_fee(self):
+		doc = self.make_doc_and_run_before_validate(
+			deposit=-10.0,
+			withdrawal=0.0,
+			included_fee=0.0,
+			excluded_fee=1.0,
+		)
+
+		self.assertEqual(doc.deposit, 9.0)
+		self.assertEqual(doc.withdrawal, 0.0)
+		self.assertEqual(doc.included_fee, 1.0)
+		self.assertEqual(doc.excluded_fee, 0.0)
+		self.assertEqual(doc.unallocated_amount, 9.0)
 
 	def test_none_values_are_left_untouched(self):
-		doc = frappe.new_doc("Bank Transaction")
-
-		doc.deposit = None
-		doc.withdrawal = None
-		doc.included_fee = None
-		doc.excluded_fee = None
-
-		doc.enforce_positive_values()
+		doc = self.make_doc_and_run_before_validate(
+			deposit=None,
+			withdrawal=None,
+			included_fee=None,
+			excluded_fee=None,
+		)
 
 		self.assertIsNone(doc.deposit)
 		self.assertIsNone(doc.withdrawal)
 		self.assertIsNone(doc.included_fee)
 		self.assertIsNone(doc.excluded_fee)
+		self.assertEqual(doc.unallocated_amount, 0.0)

--- a/banking/overrides/test_bank_transaction_positive_values.py
+++ b/banking/overrides/test_bank_transaction_positive_values.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025, ALYF GmbH and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from banking.overrides.bank_transaction import enforce_positive_values
+
+
+class TestEnforcePositiveValues(FrappeTestCase):
+	def test_deposit_values_are_normalized(self):
+		doc = frappe.new_doc("Bank Transaction")
+
+		doc.deposit = -2.0
+		doc.withdrawal = 0.0
+		doc.included_fee = -1.0
+		doc.excluded_fee = -1.0
+
+		enforce_positive_values(doc)
+
+		self.assertEqual(doc.deposit, 1.0)
+		self.assertEqual(doc.withdrawal, 0.0)
+		self.assertEqual(doc.included_fee, 2.0)
+		self.assertEqual(doc.excluded_fee, 0.0)
+
+	def test_withdrawal_values_are_normalized(self):
+		doc = frappe.new_doc("Bank Transaction")
+
+		doc.deposit = 0.0
+		doc.withdrawal = -1.0
+		doc.included_fee = -1.0
+		doc.excluded_fee = -1.0
+
+		enforce_positive_values(doc)
+
+		self.assertEqual(doc.deposit, 0.0)
+		self.assertEqual(doc.withdrawal, 2.0)
+		self.assertEqual(doc.included_fee, 2.0)
+		self.assertEqual(doc.excluded_fee, 0.0)
+
+	def test_none_values_are_left_untouched(self):
+		doc = frappe.new_doc("Bank Transaction")
+
+		doc.deposit = None
+		doc.withdrawal = None
+		doc.included_fee = None
+		doc.excluded_fee = None
+
+		enforce_positive_values(doc)
+
+		self.assertIsNone(doc.deposit)
+		self.assertIsNone(doc.withdrawal)
+		self.assertIsNone(doc.included_fee)
+		self.assertIsNone(doc.excluded_fee)


### PR DESCRIPTION
## Summary
- Normalize negative imported `Bank Transaction` amount fields before validation so statement imports align with ERPNext expectations.
- Keep reconciliation math stable by re-running excluded-fee handling after normalization.
- Add focused tests covering deposit, withdrawal, and `None` value scenarios.

Co-authored with @0xD0M1M0