### PR TITLE
feat(SEPA Payment Order): add recipient selection 

### DIFF
--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
@@ -32,10 +32,69 @@ frappe.ui.form.on("SEPA Payment Order", {
 		}
 
 		if (frm.doc.docstatus === 0 && frm.has_perm("write")) {
+			frm.add_custom_button(__("Add Recipient"), () => {
+				frm.trigger("add_recipient");
+			});
 			frm.add_custom_button(__("Update Amounts"), () => {
 				frm.trigger("update_amounts");
 			});
 		}
+	},
+
+	add_recipient(frm) {
+		const d = new frappe.ui.Dialog({
+			title: __("Add Recipient"),
+			fields: [
+				{
+					fieldname: "recipient_doctype",
+					label: __("DocType"),
+					fieldtype: "Link",
+					options: "DocType",
+					reqd: 1,
+					get_query: () => ({
+						filters: { name: ["in", ["Supplier", "Employee"]] },
+					}),
+				},
+				{
+					fieldname: "recipient_name",
+					label: __("Name"),
+					fieldtype: "Dynamic Link",
+					options: "recipient_doctype",
+					reqd: 1,
+				},
+			],
+			primary_action_label: __("Add"),
+			primary_action(values) {
+				frappe.call({
+					method:
+						"banking.ebics.doctype.sepa_payment_order.sepa_payment_order.get_recipient_details",
+					args: {
+						doctype: values.recipient_doctype,
+						name: values.recipient_name,
+					},
+					callback(r) {
+						const data = r.message;
+						const row = {
+							recipient: data.recipient,
+							iban: data.iban,
+							amount: 0,
+						};
+						//use first row if empty, otherweise add a new row (first row is already open when creating a new payment order)
+						const first = frm.doc.payments[0];
+						const firstEmpty =
+							frm.doc.payments.length === 1 && !first.recipient && !first.iban;
+						if (firstEmpty) {
+							Object.assign(first, row);
+						} else {
+							frm.doc.payments.push(row);
+						}
+						frm.refresh_field("payments");
+						d.hide();
+					},
+				});
+			},
+		});
+		d.show();
 	},
 
 	async before_submit(frm) {

--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
@@ -61,6 +61,25 @@ frappe.ui.form.on("SEPA Payment Order", {
 					fieldtype: "Dynamic Link",
 					options: "recipient_doctype",
 					reqd: 1,
+					get_query: () => {
+						const recipient_doctype = d.get_value("recipient_doctype");
+						if (!recipient_doctype) {
+							return;
+						}
+						if (recipient_doctype === "Supplier") {
+							return {
+								filters: {
+									disabled: 0,
+								},
+							};
+						} else if (recipient_doctype === "Employee") {
+							return {
+								filters: {
+									status: ["in", ["Active", "Suspended"]],
+								},
+							};
+						}
+					},
 				},
 			],
 			primary_action_label: __("Add"),

--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
@@ -96,7 +96,7 @@ frappe.ui.form.on("SEPA Payment Order", {
 						doctype: values.recipient_doctype,
 						name: values.recipient_name,
 					},
-					callback({ message }) {
+					async callback({ message }) {
 						const new_row = {
 							recipient: message.recipient,
 							iban: message.iban,
@@ -108,7 +108,8 @@ frappe.ui.form.on("SEPA Payment Order", {
 							!frm.doc.payments.at(-1).recipient &&
 							!frm.doc.payments.at(-1).iban
 						) {
-							Object.assign(frm.doc.payments.at(-1), new_row);
+							const row = frm.doc.payments.at(-1);
+							await frappe.model.set_value(row.doctype, row.name, new_row);
 						} else {
 							frm.add_child("payments", new_row);
 						}

--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
@@ -82,6 +82,11 @@ frappe.ui.form.on("SEPA Payment Order", {
 					},
 				},
 				{
+					fieldname: "purpose",
+					label: __("Purpose"),
+					fieldtype: "Data",
+				},
+				{
 					fieldname: "amount",
 					label: __("Amount"),
 					fieldtype: "Currency",
@@ -100,6 +105,7 @@ frappe.ui.form.on("SEPA Payment Order", {
 						const new_row = {
 							recipient: message.recipient,
 							iban: message.iban,
+							purpose: values.purpose,
 							amount: values.amount,
 						};
 						//use last row if empty, otherwise add a new row

--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
@@ -255,3 +255,9 @@ frappe.ui.form.on("SEPA Payment Order", {
 			});
 	},
 });
+
+frappe.ui.form.on("SEPA Payment", {
+	payments_add(frm) {
+		frm.trigger("add_recipient");
+	},
+});

--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js
@@ -81,6 +81,11 @@ frappe.ui.form.on("SEPA Payment Order", {
 						}
 					},
 				},
+				{
+					fieldname: "amount",
+					label: __("Amount"),
+					fieldtype: "Currency",
+				},
 			],
 			primary_action_label: __("Add"),
 			primary_action(values) {
@@ -91,21 +96,21 @@ frappe.ui.form.on("SEPA Payment Order", {
 						doctype: values.recipient_doctype,
 						name: values.recipient_name,
 					},
-					callback(r) {
-						const data = r.message;
-						const row = {
-							recipient: data.recipient,
-							iban: data.iban,
-							amount: 0,
+					callback({ message }) {
+						const new_row = {
+							recipient: message.recipient,
+							iban: message.iban,
+							amount: values.amount,
 						};
-						//use first row if empty, otherweise add a new row (first row is already open when creating a new payment order)
-						const first = frm.doc.payments[0];
-						const firstEmpty =
-							frm.doc.payments.length === 1 && !first.recipient && !first.iban;
-						if (firstEmpty) {
-							Object.assign(first, row);
+						//use last row if empty, otherwise add a new row
+						if (
+							frm.doc.payments?.length > 0 &&
+							!frm.doc.payments.at(-1).recipient &&
+							!frm.doc.payments.at(-1).iban
+						) {
+							Object.assign(frm.doc.payments.at(-1), new_row);
 						} else {
-							frm.doc.payments.push(row);
+							frm.add_child("payments", new_row);
 						}
 						frm.refresh_field("payments");
 						d.hide();

--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py
@@ -172,21 +172,22 @@ def get_recipient_details(doctype: str, name: str):
 
 	if doctype not in ("Supplier", "Employee"):
 		frappe.throw(_("DocType must be Supplier or Employee."))
-	frappe.has_permission(doctype, "read", doc=name, throw=True)
+	doc = frappe.get_doc(doctype, name)
+	doc.check_permission()
 
+	iban = None
 	if doctype == "Supplier":
-		recipient = frappe.db.get_value("Supplier", name, "supplier_name")
-		bank_acc = frappe.db.get_value(
-			"Bank Account",
-			{"party_type": "Supplier", "party": name, "is_default": 1, "disabled": 0},
-			"name",
-		)
-		if not bank_acc:
-			frappe.throw(_("No default bank account for Supplier {0}.").format(name))
-		iban = frappe.db.get_value("Bank Account", bank_acc, "iban")
+		recipient = doc.supplier_name
 	else:
-		recipient = frappe.db.get_value("Employee", name, "employee_name")
-		iban = frappe.db.get_value("Employee", name, "iban")
+		recipient = doc.employee_name
+		iban = doc.iban
+
+	if not iban:
+		iban = frappe.db.get_value(
+			"Bank Account",
+			{"party_type":  doctype, "party": name, "is_default": 1, "disabled": 0},
+			"iban",
+		)
 
 	if not iban:
 		frappe.throw(_("No IBAN for {0} {1}.").format(doctype, name))

--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py
@@ -185,7 +185,7 @@ def get_recipient_details(doctype: str, name: str):
 	if not iban:
 		iban = frappe.db.get_value(
 			"Bank Account",
-			{"party_type":  doctype, "party": name, "is_default": 1, "disabled": 0},
+			{"party_type": doctype, "party": name, "is_default": 1, "disabled": 0},
 			"iban",
 		)
 

--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py
@@ -167,6 +167,34 @@ class SEPAPaymentOrder(Document):
 
 
 @frappe.whitelist()
+def get_recipient_details(doctype: str, name: str):
+	"""Return recipient and IBAN for Supplier or Employee."""
+
+	if doctype not in ("Supplier", "Employee"):
+		frappe.throw(_("DocType must be Supplier or Employee."))
+	frappe.has_permission(doctype, "read", doc=name, throw=True)
+
+	if doctype == "Supplier":
+		recipient = frappe.db.get_value("Supplier", name, "supplier_name")
+		bank_acc = frappe.db.get_value(
+			"Bank Account",
+			{"party_type": "Supplier", "party": name, "is_default": 1, "disabled": 0},
+			"name",
+		)
+		if not bank_acc:
+			frappe.throw(_("No default bank account for Supplier {0}.").format(name))
+		iban = frappe.db.get_value("Bank Account", bank_acc, "iban")
+	else:
+		recipient = frappe.db.get_value("Employee", name, "employee_name")
+		iban = frappe.db.get_value("Employee", name, "iban")
+
+	if not iban:
+		frappe.throw(_("No IBAN for {0} {1}.").format(doctype, name))
+
+	return {"recipient": recipient, "iban": iban}
+
+
+@frappe.whitelist()
 def have_amounts_changed(sepa_payment_order: str):
 	"""Return True if the payment amounts have changed since the last save.
 

--- a/banking/locale/de.po
+++ b/banking/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-01-27 18:03+0053\n"
+"POT-Creation-Date: 2026-03-04 13:08+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -44,6 +44,11 @@ msgstr "ALYF Banking"
 msgid "Account Holder"
 msgstr "Kontoinhaber"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:46
+msgid "Add Recipient"
+msgstr "Empfänger hinzufügen"
+
 #. Label of a Data field in DocType 'Banking Settings'
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.json
 msgid "Admin URL"
@@ -53,11 +58,11 @@ msgstr "Admin-URL"
 msgid "Amount updated to {0} in row {1}."
 msgstr "Betrag in Zeile {1} auf {0} aktualisiert."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:233
 msgid "Amounts not updated."
 msgstr "Beträge nicht aktualisiert."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:226
 msgid "Amounts updated."
 msgstr "Beträge aktualisiert."
 
@@ -79,7 +84,7 @@ msgstr "Versuchen Sie, Belege verschiedener Parteien abzugleichen? Diese Aktion 
 msgid "Authentication error due to invalid credentials."
 msgstr "Authentifizierungsfehler aufgrund ungültiger Anmeldeinformationen."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:434
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:436
 msgid "Auto Reconciliation Complete"
 msgstr "Automatischer Abgleich abgeschlossen"
 
@@ -91,7 +96,7 @@ msgstr "Automatischer Abgleich ..."
 msgid "Auto reconcile bank transactions based on matching reference numbers?"
 msgstr "Möchten Sie Banktransaktionen automatisch abgleichen, basierend auf übereinstimmenden Referenznummern?"
 
-#: banking/ebics/utils.py:216
+#: banking/ebics/utils.py:245
 msgid "Bank Account not found for IBAN {0}"
 msgstr "Bankkonto nicht gefunden für IBAN {0}"
 
@@ -154,8 +159,8 @@ msgstr "Banking-Aktion ist aufgrund der folgenden Fehler fehlgeschlagen:"
 #: banking/ebics/doctype/ebics_user/ebics_user.py:72
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
-#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:141
-#: banking/ebics/utils.py:188 banking/ebics/utils.py:215
+#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:153
+#: banking/ebics/utils.py:217 banking/ebics/utils.py:244
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
@@ -184,7 +189,7 @@ msgstr "Bank-Referenz-Zuordnung"
 msgid "Banking Settings"
 msgstr "Bankeneinstellungen"
 
-#: banking/ebics/utils.py:236
+#: banking/ebics/utils.py:207 banking/ebics/utils.py:265
 msgid "Banking Warning"
 msgstr "Banking-Warnung"
 
@@ -202,11 +207,11 @@ msgstr ""
 msgid "Cannot create Journal Entry for a Bank Transaction with both Deposit and Withdrawal"
 msgstr "Es kann kein Buchungssatz erstellt werden, wenn eine Banktransaktion sowohl eine Einzahlung als auch eine Auszahlung enthält"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:288
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:360
 msgid "Cannot make Reconciliation Payment Entry against multiple doctypes"
 msgstr "Es kann kein Abgleichs-Zahlungseintrag erstellt werden, wenn mehrere Dokumenttypen abgeglichen werden"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:295
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:367
 msgid "Cannot make Reconciliation Payment Entry against multiple parties"
 msgstr "Es kann kein Abgleichs-Zahlungseintrag erstellt werden, wenn mehrere Parteien abgeglichen werden"
 
@@ -267,6 +272,10 @@ msgstr "Entwicklermodus ist aktiviert. Bitte deaktivieren Sie ihn, um die automa
 msgid "Did you mean {0}?"
 msgstr "Meinten Sie {0}?"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:174
+msgid "DocType must be Supplier or Employee."
+msgstr "DocType muss Lieferant oder Mitarbeiter sein."
+
 #: banking/ebics/doctype/ebics_user/ebics_user.js:105
 #: banking/ebics/doctype/ebics_user/ebics_user.js:296
 msgid "Download Bank Statements"
@@ -289,7 +298,7 @@ msgstr "Antwortdateien herunterladen"
 msgid "Downloaded"
 msgstr "Heruntergeladen"
 
-#: banking/overrides/bank_transaction.py:33
+#: banking/overrides/bank_transaction.py:51
 msgid "Due to Period Closing, you cannot reconcile unpaid vouchers with a Bank Transaction before {0}"
 msgstr "Aufgrund des Periodenschlusses können Sie keine unbezahlten Belege mit einer Banktransaktion vor dem {0} abgleichen"
 
@@ -331,7 +340,7 @@ msgstr "EBICS-URL"
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:142
 msgid "EBICS User"
 msgstr "EBICS-Benutzer"
 
@@ -406,7 +415,7 @@ msgstr "Passwort eingeben"
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr "Nur eingeben, wenn eine terminierte Ausführung bei der Bank gewünscht ist."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:190
 msgid "Enter your passphrase"
 msgstr "Passwort eingeben"
 
@@ -415,7 +424,7 @@ msgstr "Passwort eingeben"
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr "Geben Sie Ihr Passwort ein, um die automatisierte, regelmäßige Synchronisierung zu aktivieren. Lassen Sie das Feld leer, wenn Sie die Synchronisierung manuell durchführen möchten."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:183
 msgid "Enter your signature passphrase"
 msgstr "Geben Sie Ihr Signaturpasswort ein"
 
@@ -475,7 +484,7 @@ msgstr "Fintech-Lizenzschlüssel"
 msgid "Fintech Licensee Name"
 msgstr "Fintech-Lizenznehmername"
 
-#: banking/utils.py:58
+#: banking/utils.py:62
 msgid "For non-German IBANs, a Bank must be provided."
 msgstr "Für Nicht-Deutsche IBANs muss eine Bank angegeben werden."
 
@@ -568,7 +577,7 @@ msgstr "Die Daten, die heruntergeladen werden sollen, sind ungültig."
 msgid "Invalid data for re-import."
 msgstr "Ungültige Daten für den erneuten Import."
 
-#: banking/ebics/utils.py:237
+#: banking/ebics/utils.py:266
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr "Es scheint, dass der EBICS-Benutzer keine Berechtigungen für die Auftragsart '{0}' hat. Die zulässigen Typen sind: {1}."
 
@@ -585,7 +594,7 @@ msgstr ""
 msgid "Last Renewed On"
 msgstr "Zuletzt erneuert am"
 
-#: banking/ebics/utils.py:574
+#: banking/ebics/utils.py:652
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr "Lizenzschlüssel nicht gefunden. Bitte aktivieren Sie das Kontrollkästchen 'EBICS aktivieren' in den {0} und stellen Sie sicher, dass Ihr Abonnement aktiv ist."
 
@@ -603,6 +612,10 @@ msgstr "Benötigt Zertifikat"
 msgid "No Data Available"
 msgstr "Keine Daten verfügbar"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:192
+msgid "No IBAN for {0} {1}."
+msgstr "Keine IBAN für {0} {1}."
+
 #: banking/public/js/bank_reconciliation_beta/panel_manager.js:84
 msgid "No Transactions found for the current filters."
 msgstr "Keine Transaktionen gefunden für die aktuellen Filter."
@@ -611,7 +624,11 @@ msgstr "Keine Transaktionen gefunden für die aktuellen Filter."
 msgid "No data available for download."
 msgstr "Keine Daten für das Herunterladen verfügbar."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:415
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:185
+msgid "No default bank account for Supplier {0}."
+msgstr "Kein Standardbankkonto für Lieferant {0}."
+
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:417
 msgid "No matches occurred via Auto Reconciliation"
 msgstr "Keine Übereinstimmungen bei der automatischen Abgleichung"
 
@@ -641,11 +658,11 @@ msgstr "Nur unbezahlte Belege"
 msgid "Open Billing Portal"
 msgstr "Abrechnungsportal öffnen"
 
-#: banking/overrides/bank_transaction.py:73
+#: banking/overrides/bank_transaction.py:106
 msgid "Over Allocation"
 msgstr "Überbuchung"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:279
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:351
 msgid "Overallocated Returns"
 msgstr "Überbuchte Rückerstattungen"
 
@@ -668,19 +685,19 @@ msgstr "Partei-IBAN"
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:188
 msgid "Passphrase"
 msgstr "Passwort"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:207
 msgid "Payment Order has been sent to bank."
 msgstr "Überweisung wurde an die Bank gesendet."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:213
 msgid "Payment Order has not been sent to bank."
 msgstr "Überweisung wurde nicht an die Bank gesendet."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:115
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr "Die Zahlungsbeträge haben sich geändert. Sind Sie sicher, dass Sie ohne diese erst zu aktualisieren buchen möchten?"
 
@@ -770,6 +787,10 @@ msgstr "EBICS-Transaktionen werden erneut importiert ..."
 msgid "Reconciling ..."
 msgstr "Abgleichen ..."
 
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:162
+msgid "Reconciling multiple multi-currency invoices at once is not supported. Please reconcile one invoice at a time."
+msgstr ""
+
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js:38
 msgid "Redirecting to Customer Portal ..."
 msgstr "Weiterleitung zum Kundenportal ..."
@@ -846,7 +867,7 @@ msgid "Show Protocol Versions"
 msgstr "Protokollversionen anzeigen"
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:181
 msgid "Signature Passphrase"
 msgstr "Signatur-Passwort"
 
@@ -899,15 +920,15 @@ msgstr "Lieferanten-Bankkonto wurde erstellt."
 msgid "Supplier Bank Account was not created."
 msgstr "Lieferanten-Bankkonto wurde nicht erstellt."
 
-#: banking/overrides/bank_transaction.py:70
+#: banking/overrides/bank_transaction.py:103
 msgid "The Bank Transaction is over-allocated by {0} at row {1}."
 msgstr "Die Banktransaktion ist um {0} bei Zeile {1} überbucht."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:280
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:352
 msgid "The allocated amount cannot be negative. Please adjust the selected return vouchers."
 msgstr "Der zugewiesene Betrag kann nicht negativ sein. Bitte passen Sie die ausgewählten Belege an."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:155
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:200
 msgid "The currency of the second account ({0} : {1}) must be the same as of the bank account ({2} : {3})"
 msgstr "Die Währung des zweiten Kontos ({0} : {1}) muss mit der des Bankkontos ({2} : {3}) übereinstimmen."
 
@@ -947,7 +968,11 @@ msgstr "Übertragungszeitpunkt"
 msgid "Transmission Type"
 msgstr "Übertragungstyp"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/utils.py:208
+msgid "Unable to resolve batch transaction: camt.054 not available. Please try again later."
+msgstr ""
+
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:38
 msgid "Update Amounts"
 msgstr "Beträge aktualisieren"
 
@@ -1015,8 +1040,8 @@ msgstr "Sie haben Protokollversion {0} ausgewählt, aber die Bank {1} unterstüt
 msgid "to import bank transactions for {0}."
 msgstr "um Banktransaktionen für {0} zu importieren."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:418
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:427
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:420
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:429
 msgid "{0} {1} {2}"
 msgstr ""
 

--- a/banking/locale/es.po
+++ b/banking/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-01-27 18:03+0053\n"
+"POT-Creation-Date: 2026-03-04 13:08+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -44,6 +44,11 @@ msgstr ""
 msgid "Account Holder"
 msgstr "Titular de la cuenta"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:46
+msgid "Add Recipient"
+msgstr ""
+
 #. Label of a Data field in DocType 'Banking Settings'
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.json
 msgid "Admin URL"
@@ -53,11 +58,11 @@ msgstr "URL de administración"
 msgid "Amount updated to {0} in row {1}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:233
 msgid "Amounts not updated."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:226
 msgid "Amounts updated."
 msgstr ""
 
@@ -79,7 +84,7 @@ msgstr "¿Está intentando conciliar comprobantes de diferentes partes? Esta acc
 msgid "Authentication error due to invalid credentials."
 msgstr "Error de autenticación debido a credenciales inválidas."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:434
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:436
 msgid "Auto Reconciliation Complete"
 msgstr "Conciliación automática completada"
 
@@ -91,7 +96,7 @@ msgstr "Conciliando automáticamente..."
 msgid "Auto reconcile bank transactions based on matching reference numbers?"
 msgstr "¿Desea conciliar automáticamente las transacciones bancarias basándose en los números de referencia coincidentes?"
 
-#: banking/ebics/utils.py:216
+#: banking/ebics/utils.py:245
 msgid "Bank Account not found for IBAN {0}"
 msgstr "No se encontró la cuenta bancaria para el IBAN {0}"
 
@@ -154,8 +159,8 @@ msgstr "La acción de Banking ha fallado debido a los siguientes errores:"
 #: banking/ebics/doctype/ebics_user/ebics_user.py:72
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
-#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:141
-#: banking/ebics/utils.py:188 banking/ebics/utils.py:215
+#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:153
+#: banking/ebics/utils.py:217 banking/ebics/utils.py:244
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
@@ -184,7 +189,7 @@ msgstr "Asignación de referencia de Banking"
 msgid "Banking Settings"
 msgstr "Configuración de Banking"
 
-#: banking/ebics/utils.py:236
+#: banking/ebics/utils.py:207 banking/ebics/utils.py:265
 msgid "Banking Warning"
 msgstr "Advertencia de Banking"
 
@@ -202,11 +207,11 @@ msgstr ""
 msgid "Cannot create Journal Entry for a Bank Transaction with both Deposit and Withdrawal"
 msgstr "No se puede crear un asiento contable para una transacción bancaria con depósito y retiro"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:288
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:360
 msgid "Cannot make Reconciliation Payment Entry against multiple doctypes"
 msgstr "No se puede hacer un pago de conciliación contra múltiples doctypes"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:295
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:367
 msgid "Cannot make Reconciliation Payment Entry against multiple parties"
 msgstr "No se puede hacer un pago de conciliación contra múltiples partes"
 
@@ -267,6 +272,10 @@ msgstr "El modo desarrollador está activado. Por favor, desactívelo para conti
 msgid "Did you mean {0}?"
 msgstr "¿Me refieres a {0}?"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:174
+msgid "DocType must be Supplier or Employee."
+msgstr "El DocType debe ser Proveedor o Empleado."
+
 #: banking/ebics/doctype/ebics_user/ebics_user.js:105
 #: banking/ebics/doctype/ebics_user/ebics_user.js:296
 msgid "Download Bank Statements"
@@ -289,7 +298,7 @@ msgstr "Descargar archivos de respuesta"
 msgid "Downloaded"
 msgstr "Descargado"
 
-#: banking/overrides/bank_transaction.py:33
+#: banking/overrides/bank_transaction.py:51
 msgid "Due to Period Closing, you cannot reconcile unpaid vouchers with a Bank Transaction before {0}"
 msgstr "Debido al cierre del período, no puede conciliar comprobantes sin pagar con una transacción bancaria antes de {0}"
 
@@ -331,7 +340,7 @@ msgstr "URL EBICS"
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:142
 msgid "EBICS User"
 msgstr "Usuario de EBICS"
 
@@ -406,7 +415,7 @@ msgstr "Ingrese la frase de contraseña"
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr "Ingrese solo si se desea ejecución programada en el banco."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:190
 msgid "Enter your passphrase"
 msgstr "Ingrese su frase de contraseña"
 
@@ -415,7 +424,7 @@ msgstr "Ingrese su frase de contraseña"
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr "Ingrese su contraseña para habilitar la sincronización automática, regular, o deje en blanco si prefiere sincronizar manualmente."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:183
 msgid "Enter your signature passphrase"
 msgstr "Ingrese su frase de contraseña de firma"
 
@@ -475,7 +484,7 @@ msgstr "Clave de licencia de Fintech"
 msgid "Fintech Licensee Name"
 msgstr "Nombre de la licenciataria de Fintech"
 
-#: banking/utils.py:58
+#: banking/utils.py:62
 msgid "For non-German IBANs, a Bank must be provided."
 msgstr "Para IBANs no alemanes, se debe proporcionar un banco."
 
@@ -568,7 +577,7 @@ msgstr "No hay datos disponibles para descargar."
 msgid "Invalid data for re-import."
 msgstr "Datos inválidos para el reimport."
 
-#: banking/ebics/utils.py:237
+#: banking/ebics/utils.py:266
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr "Parece que el usuario de EBICS no tiene permisos para el tipo de pedido '{0}'. Los tipos permitidos son: {1}."
 
@@ -585,7 +594,7 @@ msgstr "Integración de Klarna Kosma"
 msgid "Last Renewed On"
 msgstr "Última renovación en"
 
-#: banking/ebics/utils.py:574
+#: banking/ebics/utils.py:652
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr "No se encontró la clave de licencia. Por favor, active el campo 'Habilitar EBICS' en {0} y asegúrese de que su suscripción esté activa."
 
@@ -603,6 +612,10 @@ msgstr "Necesita certificado"
 msgid "No Data Available"
 msgstr "No hay datos disponibles"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:192
+msgid "No IBAN for {0} {1}."
+msgstr "No hay IBAN para {0} {1}."
+
 #: banking/public/js/bank_reconciliation_beta/panel_manager.js:84
 msgid "No Transactions found for the current filters."
 msgstr "No se encontraron transacciones para los filtros actuales."
@@ -611,7 +624,11 @@ msgstr "No se encontraron transacciones para los filtros actuales."
 msgid "No data available for download."
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:415
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:185
+msgid "No default bank account for Supplier {0}."
+msgstr "No hay cuenta bancaria predeterminada para el Proveedor {0}."
+
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:417
 msgid "No matches occurred via Auto Reconciliation"
 msgstr "No se encontraron coincidencias mediante conciliación automática"
 
@@ -641,11 +658,11 @@ msgstr "Solo comprobantes no pagados"
 msgid "Open Billing Portal"
 msgstr "Abrir portal de facturación"
 
-#: banking/overrides/bank_transaction.py:73
+#: banking/overrides/bank_transaction.py:106
 msgid "Over Allocation"
 msgstr "Sobreasignación"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:279
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:351
 msgid "Overallocated Returns"
 msgstr "Devoluciones sobreasignadas"
 
@@ -668,19 +685,19 @@ msgstr "IBAN de la parte"
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:188
 msgid "Passphrase"
 msgstr "Frase de contraseña"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:207
 msgid "Payment Order has been sent to bank."
 msgstr "La orden de pago ha sido enviada al banco."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:213
 msgid "Payment Order has not been sent to bank."
 msgstr "La orden de pago no ha sido enviada al banco."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:115
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr ""
 
@@ -770,6 +787,10 @@ msgstr "Reimportando transacciones EBICS ..."
 msgid "Reconciling ..."
 msgstr "Conciliando..."
 
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:162
+msgid "Reconciling multiple multi-currency invoices at once is not supported. Please reconcile one invoice at a time."
+msgstr ""
+
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js:38
 msgid "Redirecting to Customer Portal ..."
 msgstr "Redirigiendo al portal del cliente ..."
@@ -846,7 +867,7 @@ msgid "Show Protocol Versions"
 msgstr "Mostrar versiones de protocolo"
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:181
 msgid "Signature Passphrase"
 msgstr "Contraseña de firma"
 
@@ -899,15 +920,15 @@ msgstr "Se creó la cuenta bancaria del proveedor."
 msgid "Supplier Bank Account was not created."
 msgstr "No se pudo crear la cuenta bancaria del proveedor."
 
-#: banking/overrides/bank_transaction.py:70
+#: banking/overrides/bank_transaction.py:103
 msgid "The Bank Transaction is over-allocated by {0} at row {1}."
 msgstr "La transacción bancaria está sobreasignada en {0} en la fila {1}."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:280
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:352
 msgid "The allocated amount cannot be negative. Please adjust the selected return vouchers."
 msgstr "La cantidad asignada no puede ser negativa. Por favor, ajuste los comprobantes de devolución seleccionados."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:155
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:200
 msgid "The currency of the second account ({0} : {1}) must be the same as of the bank account ({2} : {3})"
 msgstr "El tipo de cambio de la cuenta bancaria ({0} : {1}) debe ser el mismo que el de la cuenta bancaria ({2} : {3})"
 
@@ -947,7 +968,11 @@ msgstr "Fecha y hora de transmisión"
 msgid "Transmission Type"
 msgstr "Tipo de transmisión"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/utils.py:208
+msgid "Unable to resolve batch transaction: camt.054 not available. Please try again later."
+msgstr ""
+
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:38
 msgid "Update Amounts"
 msgstr ""
 
@@ -1015,8 +1040,8 @@ msgstr "Seleccionó la versión del protocolo {0}, pero el banco {1} solo admite
 msgid "to import bank transactions for {0}."
 msgstr "para importar transacciones bancarias para {0}."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:418
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:427
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:420
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:429
 msgid "{0} {1} {2}"
 msgstr "{0} {1} {2}"
 

--- a/banking/locale/fr.po
+++ b/banking/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-01-27 18:03+0053\n"
+"POT-Creation-Date: 2026-03-04 13:08+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -44,6 +44,11 @@ msgstr "ALYF Banque"
 msgid "Account Holder"
 msgstr "Titulaire du compte"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:46
+msgid "Add Recipient"
+msgstr ""
+
 #. Label of a Data field in DocType 'Banking Settings'
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.json
 msgid "Admin URL"
@@ -53,11 +58,11 @@ msgstr "URL Admin"
 msgid "Amount updated to {0} in row {1}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:233
 msgid "Amounts not updated."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:226
 msgid "Amounts updated."
 msgstr ""
 
@@ -79,7 +84,7 @@ msgstr "Essayez-vous de rapprocher des justificatifs de différentes parties? Ce
 msgid "Authentication error due to invalid credentials."
 msgstr "Erreur d'authentification due à des identifiants invalides."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:434
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:436
 msgid "Auto Reconciliation Complete"
 msgstr "Rapprochement automatique terminé"
 
@@ -91,7 +96,7 @@ msgstr "Rapprochement automatique en cours..."
 msgid "Auto reconcile bank transactions based on matching reference numbers?"
 msgstr "Rapprocher les transactions bancaires en fonction des numéros de référence correspondants?"
 
-#: banking/ebics/utils.py:216
+#: banking/ebics/utils.py:245
 msgid "Bank Account not found for IBAN {0}"
 msgstr "Compte bancaire introuvable pour IBAN {0}"
 
@@ -154,8 +159,8 @@ msgstr "L'action Banking a échoué en raison des erreurs suivantes :"
 #: banking/ebics/doctype/ebics_user/ebics_user.py:72
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
-#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:141
-#: banking/ebics/utils.py:188 banking/ebics/utils.py:215
+#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:153
+#: banking/ebics/utils.py:217 banking/ebics/utils.py:244
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
@@ -184,7 +189,7 @@ msgstr "Mappage de référence bancaire"
 msgid "Banking Settings"
 msgstr "Paramètres Banking"
 
-#: banking/ebics/utils.py:236
+#: banking/ebics/utils.py:207 banking/ebics/utils.py:265
 msgid "Banking Warning"
 msgstr "Avertissement Banking"
 
@@ -202,11 +207,11 @@ msgstr ""
 msgid "Cannot create Journal Entry for a Bank Transaction with both Deposit and Withdrawal"
 msgstr "Impossible de créer une écriture comptable pour une transaction bancaire avec un dépôt et un retrait"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:288
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:360
 msgid "Cannot make Reconciliation Payment Entry against multiple doctypes"
 msgstr "Impossible de faire une écriture comptable de rapprochement contre plusieurs types de documents"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:295
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:367
 msgid "Cannot make Reconciliation Payment Entry against multiple parties"
 msgstr "Impossible de faire une écriture comptable de rapprochement contre plusieurs parties"
 
@@ -267,6 +272,10 @@ msgstr "Le mode développeur est activé. Veuillez le désactiver pour continuer
 msgid "Did you mean {0}?"
 msgstr "Voulez-vous dire {0}?"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:174
+msgid "DocType must be Supplier or Employee."
+msgstr "Le DocType doit être Fournisseur ou Employé."
+
 #: banking/ebics/doctype/ebics_user/ebics_user.js:105
 #: banking/ebics/doctype/ebics_user/ebics_user.js:296
 msgid "Download Bank Statements"
@@ -289,7 +298,7 @@ msgstr "Télécharger les fichiers de réponse"
 msgid "Downloaded"
 msgstr "Téléchargé"
 
-#: banking/overrides/bank_transaction.py:33
+#: banking/overrides/bank_transaction.py:51
 msgid "Due to Period Closing, you cannot reconcile unpaid vouchers with a Bank Transaction before {0}"
 msgstr "En raison de la clôture de la période, vous ne pouvez pas rapprocher les chèques impayés avec une transaction bancaire avant le {0}"
 
@@ -331,7 +340,7 @@ msgstr "URL EBICS"
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:142
 msgid "EBICS User"
 msgstr "Utilisateur EBICS"
 
@@ -406,7 +415,7 @@ msgstr "Entrez le mot de passe"
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr "Saisissez uniquement si une exécution programmée à la banque est souhaitée."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:190
 msgid "Enter your passphrase"
 msgstr "Entrez votre phrase secrète"
 
@@ -415,7 +424,7 @@ msgstr "Entrez votre phrase secrète"
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr "Entrez votre mot de passe pour activer la synchronisation automatique et régulière. Laissez vide si vous préférez une synchronisation manuelle."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:183
 msgid "Enter your signature passphrase"
 msgstr "Entrez votre phrase secrète de signature"
 
@@ -475,7 +484,7 @@ msgstr "Clé de licence Fintech"
 msgid "Fintech Licensee Name"
 msgstr "Nom du titulaire de la licence Fintech"
 
-#: banking/utils.py:58
+#: banking/utils.py:62
 msgid "For non-German IBANs, a Bank must be provided."
 msgstr "Pour les IBAN non allemands, une banque doit être fournie."
 
@@ -568,7 +577,7 @@ msgstr "Les données disponibles pour le téléchargement sont invalides."
 msgid "Invalid data for re-import."
 msgstr "Données invalides pour le reimport."
 
-#: banking/ebics/utils.py:237
+#: banking/ebics/utils.py:266
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr "Il semble que l'utilisateur EBICS n'ait pas les permissions pour le type de commande '{0}'. Les types autorisés sont: {1}."
 
@@ -585,7 +594,7 @@ msgstr ""
 msgid "Last Renewed On"
 msgstr "Dernier renouvellement le"
 
-#: banking/ebics/utils.py:574
+#: banking/ebics/utils.py:652
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr "Clé de licence non trouvée. Veuillez activer la case à cocher 'Activer EBICS' dans le {0} et vérifier que votre abonnement est actif."
 
@@ -603,6 +612,10 @@ msgstr "Nécessite un certificat"
 msgid "No Data Available"
 msgstr "Aucune donnée disponible"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:192
+msgid "No IBAN for {0} {1}."
+msgstr "Aucune IBAN pour {0} {1}."
+
 #: banking/public/js/bank_reconciliation_beta/panel_manager.js:84
 msgid "No Transactions found for the current filters."
 msgstr "Aucune transaction trouvée pour les filtres actuels."
@@ -611,7 +624,11 @@ msgstr "Aucune transaction trouvée pour les filtres actuels."
 msgid "No data available for download."
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:415
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:185
+msgid "No default bank account for Supplier {0}."
+msgstr "Aucun compte bancaire par défaut pour le Fournisseur {0}."
+
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:417
 msgid "No matches occurred via Auto Reconciliation"
 msgstr "Aucun rapprochement automatique n'a eu lieu"
 
@@ -641,11 +658,11 @@ msgstr "Uniquement les justificatifs impayés"
 msgid "Open Billing Portal"
 msgstr "Ouvrir le portail de facturation"
 
-#: banking/overrides/bank_transaction.py:73
+#: banking/overrides/bank_transaction.py:106
 msgid "Over Allocation"
 msgstr "Allocation excessive"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:279
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:351
 msgid "Overallocated Returns"
 msgstr "Retours alloués en trop"
 
@@ -668,19 +685,19 @@ msgstr "IBAN de la partie"
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:188
 msgid "Passphrase"
 msgstr "Phrase secrète"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:207
 msgid "Payment Order has been sent to bank."
 msgstr "L'ordre de paiement a été envoyé à la banque."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:213
 msgid "Payment Order has not been sent to bank."
 msgstr "L'ordre de paiement n'a pas été envoyé à la banque."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:115
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr ""
 
@@ -770,6 +787,10 @@ msgstr "Reimportation des transactions EBICS ..."
 msgid "Reconciling ..."
 msgstr "Rapprochement en cours..."
 
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:162
+msgid "Reconciling multiple multi-currency invoices at once is not supported. Please reconcile one invoice at a time."
+msgstr ""
+
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js:38
 msgid "Redirecting to Customer Portal ..."
 msgstr "Redirection vers le portail client ..."
@@ -846,7 +867,7 @@ msgid "Show Protocol Versions"
 msgstr "Afficher les versions de protocole"
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:181
 msgid "Signature Passphrase"
 msgstr "Phrase secrète de signature"
 
@@ -899,15 +920,15 @@ msgstr "Le compte bancaire fournisseur a été créé."
 msgid "Supplier Bank Account was not created."
 msgstr "Le compte bancaire fournisseur n'a pas été créé."
 
-#: banking/overrides/bank_transaction.py:70
+#: banking/overrides/bank_transaction.py:103
 msgid "The Bank Transaction is over-allocated by {0} at row {1}."
 msgstr "La transaction bancaire est sur-allouée de {0} à la ligne {1}."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:280
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:352
 msgid "The allocated amount cannot be negative. Please adjust the selected return vouchers."
 msgstr "Le montant alloué ne peut pas être négatif. Veuillez ajuster les chèques de retour sélectionnés."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:155
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:200
 msgid "The currency of the second account ({0} : {1}) must be the same as of the bank account ({2} : {3})"
 msgstr "La devise du second compte ({0} : {1}) doit être la même que celle du compte bancaire ({2} : {3})"
 
@@ -947,7 +968,11 @@ msgstr "Date et heure de transmission"
 msgid "Transmission Type"
 msgstr "Type de transmission"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/utils.py:208
+msgid "Unable to resolve batch transaction: camt.054 not available. Please try again later."
+msgstr ""
+
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:38
 msgid "Update Amounts"
 msgstr ""
 
@@ -1015,8 +1040,8 @@ msgstr ""
 msgid "to import bank transactions for {0}."
 msgstr "pour importer les transactions bancaires pour {0}."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:418
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:427
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:420
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:429
 msgid "{0} {1} {2}"
 msgstr "{0} {1} {2}"
 

--- a/banking/locale/it.po
+++ b/banking/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-01-27 18:03+0053\n"
+"POT-Creation-Date: 2026-03-04 13:08+0053\n"
 "PO-Revision-Date: 2025-01-31 19:26+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
@@ -44,6 +44,11 @@ msgstr "Bancario ALYF"
 msgid "Account Holder"
 msgstr "Titolare del conto"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:46
+msgid "Add Recipient"
+msgstr ""
+
 #. Label of a Data field in DocType 'Banking Settings'
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.json
 msgid "Admin URL"
@@ -53,11 +58,11 @@ msgstr "URL amministratore"
 msgid "Amount updated to {0} in row {1}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:233
 msgid "Amounts not updated."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:226
 msgid "Amounts updated."
 msgstr ""
 
@@ -79,7 +84,7 @@ msgstr "Stai cercando di conciliare ricevute di parti diverse? Questa azione con
 msgid "Authentication error due to invalid credentials."
 msgstr "Errore di autenticazione dovuto a credenziali non valide."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:434
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:436
 msgid "Auto Reconciliation Complete"
 msgstr "Conciliazione automatica completata"
 
@@ -91,7 +96,7 @@ msgstr "Conciliazione automatica in corso..."
 msgid "Auto reconcile bank transactions based on matching reference numbers?"
 msgstr "Conciliare le transazioni bancarie automaticamente in base ai numeri di riferimento corrispondenti?"
 
-#: banking/ebics/utils.py:216
+#: banking/ebics/utils.py:245
 msgid "Bank Account not found for IBAN {0}"
 msgstr "Conto bancario non trovato per l'IBAN {0}"
 
@@ -154,8 +159,8 @@ msgstr "L'azione di Banking ha fallito a causa dei seguenti errori:"
 #: banking/ebics/doctype/ebics_user/ebics_user.py:72
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
-#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:141
-#: banking/ebics/utils.py:188 banking/ebics/utils.py:215
+#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:153
+#: banking/ebics/utils.py:217 banking/ebics/utils.py:244
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
@@ -184,7 +189,7 @@ msgstr "Mapping dei riferimenti bancari"
 msgid "Banking Settings"
 msgstr "Impostazioni di Banking"
 
-#: banking/ebics/utils.py:236
+#: banking/ebics/utils.py:207 banking/ebics/utils.py:265
 msgid "Banking Warning"
 msgstr "Avviso di Banking"
 
@@ -202,11 +207,11 @@ msgstr ""
 msgid "Cannot create Journal Entry for a Bank Transaction with both Deposit and Withdrawal"
 msgstr "Non è possibile creare un movimento contabile per una transazione bancaria con sia un deposito che un prelievo"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:288
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:360
 msgid "Cannot make Reconciliation Payment Entry against multiple doctypes"
 msgstr "Non è possibile effettuare un pagamento di conciliamento contro più tipi di documenti"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:295
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:367
 msgid "Cannot make Reconciliation Payment Entry against multiple parties"
 msgstr "Non è possibile effettuare un pagamento di conciliamento contro più parti"
 
@@ -267,6 +272,10 @@ msgstr "Il modo sviluppatore è attivo. Per continuare a sincronizzare le transa
 msgid "Did you mean {0}?"
 msgstr "Vuoi dire {0}?"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:174
+msgid "DocType must be Supplier or Employee."
+msgstr "Il DocType deve essere Fornitore o Dipendente."
+
 #: banking/ebics/doctype/ebics_user/ebics_user.js:105
 #: banking/ebics/doctype/ebics_user/ebics_user.js:296
 msgid "Download Bank Statements"
@@ -289,7 +298,7 @@ msgstr "Scarica file di risposta"
 msgid "Downloaded"
 msgstr "Scaricato"
 
-#: banking/overrides/bank_transaction.py:33
+#: banking/overrides/bank_transaction.py:51
 msgid "Due to Period Closing, you cannot reconcile unpaid vouchers with a Bank Transaction before {0}"
 msgstr "A causa della chiusura del periodo, non puoi conciliare le ricevute non pagate con una transazione bancaria prima del {0}"
 
@@ -331,7 +340,7 @@ msgstr "URL EBICS"
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:142
 msgid "EBICS User"
 msgstr "Utente EBICS"
 
@@ -406,7 +415,7 @@ msgstr "Inserisci la passphrase"
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr "Inserire solo se si desidera l'esecuzione programmata presso la banca."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:190
 msgid "Enter your passphrase"
 msgstr "Inserisci la tua passphrase"
 
@@ -415,7 +424,7 @@ msgstr "Inserisci la tua passphrase"
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr "Inserisci la tua password per abilitare il sincronizzazione automatica, regolare. Lascia vuoto se preferisci sincronizzare manualmente."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:183
 msgid "Enter your signature passphrase"
 msgstr "Inserisci la tua passphrase di firma"
 
@@ -475,7 +484,7 @@ msgstr "Chiave di licenza Fintech"
 msgid "Fintech Licensee Name"
 msgstr "Nome della licenziataria Fintech"
 
-#: banking/utils.py:58
+#: banking/utils.py:62
 msgid "For non-German IBANs, a Bank must be provided."
 msgstr "Per IBAN non tedeschi, deve essere fornita una banca."
 
@@ -568,7 +577,7 @@ msgstr "I dati disponibili per il download non sono validi."
 msgid "Invalid data for re-import."
 msgstr "Dati non validi per il riimport."
 
-#: banking/ebics/utils.py:237
+#: banking/ebics/utils.py:266
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr "Sembra che l'utente EBICS non abbia le autorizzazioni per il tipo di ordine '{0}'. I tipi autorizzati sono: {1}."
 
@@ -585,7 +594,7 @@ msgstr "Integrazione Klarna Kosma"
 msgid "Last Renewed On"
 msgstr "Ultimo rinnovo il"
 
-#: banking/ebics/utils.py:574
+#: banking/ebics/utils.py:652
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr "Chiave di licenza non trovata. Per favore attiva il checkbox 'Abilita EBICS' in {0} e assicurati che la tua sottoscrizione sia attiva."
 
@@ -603,6 +612,10 @@ msgstr "Richiede certificato"
 msgid "No Data Available"
 msgstr "Nessun dato disponibile"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:192
+msgid "No IBAN for {0} {1}."
+msgstr "Nessun IBAN per {0} {1}."
+
 #: banking/public/js/bank_reconciliation_beta/panel_manager.js:84
 msgid "No Transactions found for the current filters."
 msgstr "Nessuna transazione trovata per i filtri correnti."
@@ -611,7 +624,11 @@ msgstr "Nessuna transazione trovata per i filtri correnti."
 msgid "No data available for download."
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:415
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:185
+msgid "No default bank account for Supplier {0}."
+msgstr "Nessun conto bancario predefinito per il Fornitore {0}."
+
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:417
 msgid "No matches occurred via Auto Reconciliation"
 msgstr "Nessuna corrispondenza avvenuta durante la conciliazione automatica"
 
@@ -641,11 +658,11 @@ msgstr "Solo ricevute non pagate"
 msgid "Open Billing Portal"
 msgstr "Apri portale di fatturazione"
 
-#: banking/overrides/bank_transaction.py:73
+#: banking/overrides/bank_transaction.py:106
 msgid "Over Allocation"
 msgstr "Sovrallocazione"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:279
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:351
 msgid "Overallocated Returns"
 msgstr "Ritorni sovralocati"
 
@@ -668,19 +685,19 @@ msgstr "IBAN partner"
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:188
 msgid "Passphrase"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:207
 msgid "Payment Order has been sent to bank."
 msgstr "L'ordine di pagamento è stato inviato alla banca."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:213
 msgid "Payment Order has not been sent to bank."
 msgstr "L'ordine di pagamento non è stato inviato alla banca."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:115
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr ""
 
@@ -770,6 +787,10 @@ msgstr "Riimportazione delle transazioni EBICS ..."
 msgid "Reconciling ..."
 msgstr "Conciliazione..."
 
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:162
+msgid "Reconciling multiple multi-currency invoices at once is not supported. Please reconcile one invoice at a time."
+msgstr ""
+
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js:38
 msgid "Redirecting to Customer Portal ..."
 msgstr "Reindirizzamento al portale del cliente ..."
@@ -846,7 +867,7 @@ msgid "Show Protocol Versions"
 msgstr "Mostra versioni protocollo"
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:181
 msgid "Signature Passphrase"
 msgstr "Password per la firma"
 
@@ -899,15 +920,15 @@ msgstr "Il conto bancario del fornitore è stato creato."
 msgid "Supplier Bank Account was not created."
 msgstr "Il conto bancario del fornitore non è stato creato."
 
-#: banking/overrides/bank_transaction.py:70
+#: banking/overrides/bank_transaction.py:103
 msgid "The Bank Transaction is over-allocated by {0} at row {1}."
 msgstr "La transazione bancaria è sovralocata di {0} alla riga {1}."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:280
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:352
 msgid "The allocated amount cannot be negative. Please adjust the selected return vouchers."
 msgstr "L'importo allocato non può essere negativo. Per favore modifica le ricevute di ritorno selezionate."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:155
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:200
 msgid "The currency of the second account ({0} : {1}) must be the same as of the bank account ({2} : {3})"
 msgstr "La valuta del secondo conto ({0} : {1}) deve essere la stessa del conto bancario ({2} : {3})"
 
@@ -947,7 +968,11 @@ msgstr "Data e ora di trasmissione"
 msgid "Transmission Type"
 msgstr "Tipo di trasmissione"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/utils.py:208
+msgid "Unable to resolve batch transaction: camt.054 not available. Please try again later."
+msgstr ""
+
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:38
 msgid "Update Amounts"
 msgstr ""
 
@@ -1015,8 +1040,8 @@ msgstr "Hai selezionato la versione del protocollo {0}, ma la banca {1} supporta
 msgid "to import bank transactions for {0}."
 msgstr "per importare le transazioni bancarie per {0}."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:418
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:427
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:420
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:429
 msgid "{0} {1} {2}"
 msgstr "{0} {1} {2}"
 

--- a/banking/locale/main.pot
+++ b/banking/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-01-27 18:03+0053\n"
-"PO-Revision-Date: 2026-01-27 18:03+0053\n"
+"POT-Creation-Date: 2026-03-04 13:08+0053\n"
+"PO-Revision-Date: 2026-03-04 13:08+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -44,6 +44,11 @@ msgstr ""
 msgid "Account Holder"
 msgstr ""
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:46
+msgid "Add Recipient"
+msgstr ""
+
 #. Label of a Data field in DocType 'Banking Settings'
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.json
 msgid "Admin URL"
@@ -53,11 +58,11 @@ msgstr ""
 msgid "Amount updated to {0} in row {1}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:233
 msgid "Amounts not updated."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:226
 msgid "Amounts updated."
 msgstr ""
 
@@ -79,7 +84,7 @@ msgstr ""
 msgid "Authentication error due to invalid credentials."
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:434
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:436
 msgid "Auto Reconciliation Complete"
 msgstr ""
 
@@ -91,7 +96,7 @@ msgstr ""
 msgid "Auto reconcile bank transactions based on matching reference numbers?"
 msgstr ""
 
-#: banking/ebics/utils.py:216
+#: banking/ebics/utils.py:245
 msgid "Bank Account not found for IBAN {0}"
 msgstr ""
 
@@ -154,8 +159,8 @@ msgstr ""
 #: banking/ebics/doctype/ebics_user/ebics_user.py:72
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
-#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:141
-#: banking/ebics/utils.py:188 banking/ebics/utils.py:215
+#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:153
+#: banking/ebics/utils.py:217 banking/ebics/utils.py:244
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
@@ -184,7 +189,7 @@ msgstr ""
 msgid "Banking Settings"
 msgstr ""
 
-#: banking/ebics/utils.py:236
+#: banking/ebics/utils.py:207 banking/ebics/utils.py:265
 msgid "Banking Warning"
 msgstr ""
 
@@ -202,11 +207,11 @@ msgstr ""
 msgid "Cannot create Journal Entry for a Bank Transaction with both Deposit and Withdrawal"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:288
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:360
 msgid "Cannot make Reconciliation Payment Entry against multiple doctypes"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:295
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:367
 msgid "Cannot make Reconciliation Payment Entry against multiple parties"
 msgstr ""
 
@@ -267,6 +272,10 @@ msgstr ""
 msgid "Did you mean {0}?"
 msgstr ""
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:174
+msgid "DocType must be Supplier or Employee."
+msgstr ""
+
 #: banking/ebics/doctype/ebics_user/ebics_user.js:105
 #: banking/ebics/doctype/ebics_user/ebics_user.js:296
 msgid "Download Bank Statements"
@@ -289,7 +298,7 @@ msgstr ""
 msgid "Downloaded"
 msgstr ""
 
-#: banking/overrides/bank_transaction.py:33
+#: banking/overrides/bank_transaction.py:51
 msgid "Due to Period Closing, you cannot reconcile unpaid vouchers with a Bank Transaction before {0}"
 msgstr ""
 
@@ -331,7 +340,7 @@ msgstr ""
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:142
 msgid "EBICS User"
 msgstr ""
 
@@ -406,7 +415,7 @@ msgstr ""
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:190
 msgid "Enter your passphrase"
 msgstr ""
 
@@ -415,7 +424,7 @@ msgstr ""
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:183
 msgid "Enter your signature passphrase"
 msgstr ""
 
@@ -475,7 +484,7 @@ msgstr ""
 msgid "Fintech Licensee Name"
 msgstr ""
 
-#: banking/utils.py:58
+#: banking/utils.py:62
 msgid "For non-German IBANs, a Bank must be provided."
 msgstr ""
 
@@ -568,7 +577,7 @@ msgstr ""
 msgid "Invalid data for re-import."
 msgstr ""
 
-#: banking/ebics/utils.py:237
+#: banking/ebics/utils.py:266
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr ""
 
@@ -585,7 +594,7 @@ msgstr ""
 msgid "Last Renewed On"
 msgstr ""
 
-#: banking/ebics/utils.py:574
+#: banking/ebics/utils.py:652
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr ""
 
@@ -603,6 +612,10 @@ msgstr ""
 msgid "No Data Available"
 msgstr ""
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:192
+msgid "No IBAN for {0} {1}."
+msgstr ""
+
 #: banking/public/js/bank_reconciliation_beta/panel_manager.js:84
 msgid "No Transactions found for the current filters."
 msgstr ""
@@ -611,7 +624,11 @@ msgstr ""
 msgid "No data available for download."
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:415
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:185
+msgid "No default bank account for Supplier {0}."
+msgstr ""
+
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:417
 msgid "No matches occurred via Auto Reconciliation"
 msgstr ""
 
@@ -641,11 +658,11 @@ msgstr ""
 msgid "Open Billing Portal"
 msgstr ""
 
-#: banking/overrides/bank_transaction.py:73
+#: banking/overrides/bank_transaction.py:106
 msgid "Over Allocation"
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:279
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:351
 msgid "Overallocated Returns"
 msgstr ""
 
@@ -668,19 +685,19 @@ msgstr ""
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:188
 msgid "Passphrase"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:207
 msgid "Payment Order has been sent to bank."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:213
 msgid "Payment Order has not been sent to bank."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:115
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr ""
 
@@ -770,6 +787,10 @@ msgstr ""
 msgid "Reconciling ..."
 msgstr ""
 
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:162
+msgid "Reconciling multiple multi-currency invoices at once is not supported. Please reconcile one invoice at a time."
+msgstr ""
+
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js:38
 msgid "Redirecting to Customer Portal ..."
 msgstr ""
@@ -846,7 +867,7 @@ msgid "Show Protocol Versions"
 msgstr ""
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:181
 msgid "Signature Passphrase"
 msgstr ""
 
@@ -899,15 +920,15 @@ msgstr ""
 msgid "Supplier Bank Account was not created."
 msgstr ""
 
-#: banking/overrides/bank_transaction.py:70
+#: banking/overrides/bank_transaction.py:103
 msgid "The Bank Transaction is over-allocated by {0} at row {1}."
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:280
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:352
 msgid "The allocated amount cannot be negative. Please adjust the selected return vouchers."
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:155
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:200
 msgid "The currency of the second account ({0} : {1}) must be the same as of the bank account ({2} : {3})"
 msgstr ""
 
@@ -947,7 +968,11 @@ msgstr ""
 msgid "Transmission Type"
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/utils.py:208
+msgid "Unable to resolve batch transaction: camt.054 not available. Please try again later."
+msgstr ""
+
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:38
 msgid "Update Amounts"
 msgstr ""
 
@@ -1015,8 +1040,8 @@ msgstr ""
 msgid "to import bank transactions for {0}."
 msgstr ""
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:418
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:427
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:420
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:429
 msgid "{0} {1} {2}"
 msgstr ""
 

--- a/banking/locale/nl.po
+++ b/banking/locale/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ALYF Banking VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-01-27 18:03+0053\n"
+"POT-Creation-Date: 2026-03-04 13:08+0053\n"
 "PO-Revision-Date: 2025-09-29 23:38+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: nl\n"
@@ -46,6 +46,11 @@ msgstr ""
 msgid "Account Holder"
 msgstr "Rekeninghouder"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:46
+msgid "Add Recipient"
+msgstr ""
+
 #. Label of a Data field in DocType 'Banking Settings'
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.json
 msgid "Admin URL"
@@ -55,11 +60,11 @@ msgstr "Admin-URL"
 msgid "Amount updated to {0} in row {1}."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:174
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:233
 msgid "Amounts not updated."
 msgstr ""
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:167
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:226
 msgid "Amounts updated."
 msgstr ""
 
@@ -81,7 +86,7 @@ msgstr "Probeert u documenten van verschillende partijen af te stemmen? Deze act
 msgid "Authentication error due to invalid credentials."
 msgstr "Authenticatiefout door ongeldige inloggegevens."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:434
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:436
 msgid "Auto Reconciliation Complete"
 msgstr "Automatische afstemming voltooid"
 
@@ -93,7 +98,7 @@ msgstr "Automatisch afstemmen ..."
 msgid "Auto reconcile bank transactions based on matching reference numbers?"
 msgstr "Banktransacties automatisch afstemmen op basis van overeenkomende referentienummers?"
 
-#: banking/ebics/utils.py:216
+#: banking/ebics/utils.py:245
 msgid "Bank Account not found for IBAN {0}"
 msgstr "Bankrekening niet gevonden voor IBAN {0}"
 
@@ -156,8 +161,8 @@ msgstr "Banking-actie is mislukt door de volgende fout(en):"
 #: banking/ebics/doctype/ebics_user/ebics_user.py:72
 #: banking/ebics/doctype/ebics_user/ebics_user.py:75
 #: banking/ebics/doctype/ebics_user/ebics_user.py:82
-#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:141
-#: banking/ebics/utils.py:188 banking/ebics/utils.py:215
+#: banking/ebics/doctype/ebics_user/ebics_user.py:85 banking/ebics/utils.py:153
+#: banking/ebics/utils.py:217 banking/ebics/utils.py:244
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py:242
 #: banking/klarna_kosma_integration/exception_handler.py:23
 #: banking/klarna_kosma_integration/exception_handler.py:39
@@ -186,7 +191,7 @@ msgstr "Banking Referentietoewijzing"
 msgid "Banking Settings"
 msgstr "Banking-instellingen"
 
-#: banking/ebics/utils.py:236
+#: banking/ebics/utils.py:207 banking/ebics/utils.py:265
 msgid "Banking Warning"
 msgstr "Banking-waarschuwing"
 
@@ -204,11 +209,11 @@ msgstr ""
 msgid "Cannot create Journal Entry for a Bank Transaction with both Deposit and Withdrawal"
 msgstr "Kan geen dagboekboeking aanmaken voor een banktransactie met zowel storting als opname"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:288
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:360
 msgid "Cannot make Reconciliation Payment Entry against multiple doctypes"
 msgstr "Kan geen afstemmingsbetalingsboeking aanmaken tegen meerdere documenttypen"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:295
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:367
 msgid "Cannot make Reconciliation Payment Entry against multiple parties"
 msgstr "Kan geen afstemmingsbetalingsboeking aanmaken tegen meerdere partijen"
 
@@ -269,6 +274,10 @@ msgstr "Ontwikkelaarsmodus is ingeschakeld. Schakel deze uit om automatische syn
 msgid "Did you mean {0}?"
 msgstr "Meent u {0}?"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:174
+msgid "DocType must be Supplier or Employee."
+msgstr "DocType moet Leverancier of Werknemer zijn."
+
 #: banking/ebics/doctype/ebics_user/ebics_user.js:105
 #: banking/ebics/doctype/ebics_user/ebics_user.js:296
 msgid "Download Bank Statements"
@@ -291,7 +300,7 @@ msgstr "Antwoordbestanden downloaden"
 msgid "Downloaded"
 msgstr "Gedownload"
 
-#: banking/overrides/bank_transaction.py:33
+#: banking/overrides/bank_transaction.py:51
 msgid "Due to Period Closing, you cannot reconcile unpaid vouchers with a Bank Transaction before {0}"
 msgstr "Vanwege periode-afsluiting kunt u onbetaalde documenten niet afstemmen met een banktransactie vóór {0}"
 
@@ -333,7 +342,7 @@ msgstr ""
 #. Name of a DocType
 #: banking/ebics/doctype/ebics_request/ebics_request.json
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:83
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:142
 msgid "EBICS User"
 msgstr ""
 
@@ -408,7 +417,7 @@ msgstr "Wachtwoord invoeren"
 msgid "Enter only if scheduled execution at the bank is desired."
 msgstr "Vul alleen in als geplande uitvoering bij de bank gewenst is."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:131
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:190
 msgid "Enter your passphrase"
 msgstr "Voer uw wachtwoord in"
 
@@ -417,7 +426,7 @@ msgstr "Voer uw wachtwoord in"
 msgid "Enter your password to enable automated, regular syncing. Leave blank if you prefer to sync manually."
 msgstr "Voer uw wachtwoord in om geautomatiseerde, regelmatige synchronisatie in te schakelen. Laat leeg als u handmatig wilt synchroniseren."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:124
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:183
 msgid "Enter your signature passphrase"
 msgstr "Voer uw handtekeningwachtwoord in"
 
@@ -477,7 +486,7 @@ msgstr "Fintech-licentiesleutel"
 msgid "Fintech Licensee Name"
 msgstr "Fintech-licentiehouder"
 
-#: banking/utils.py:58
+#: banking/utils.py:62
 msgid "For non-German IBANs, a Bank must be provided."
 msgstr "Voor niet-Duitse IBANs moet een bank worden opgegeven."
 
@@ -570,7 +579,7 @@ msgstr "Ongeldige gegevens beschikbaar voor downloaden."
 msgid "Invalid data for re-import."
 msgstr "Ongeldige gegevens voor reimporteren."
 
-#: banking/ebics/utils.py:237
+#: banking/ebics/utils.py:266
 msgid "It seems like the EBICS User lacks permissions for order type '{0}'. The permitted types are: {1}."
 msgstr "Het lijkt erop dat de EBICS-gebruiker geen toestemmingen heeft voor ordertype '{0}'. De toegestane typen zijn: {1}."
 
@@ -587,7 +596,7 @@ msgstr "Klarna Kosma-integratie"
 msgid "Last Renewed On"
 msgstr "Laatst vernieuwd op"
 
-#: banking/ebics/utils.py:574
+#: banking/ebics/utils.py:652
 msgid "License key not found. Please activate the checkbox 'Enable EBICS' in the {0} and ensure that your subscription is active."
 msgstr "Licentiesleutel niet gevonden. Activeer het selectievakje 'EBICS inschakelen' in de {0} en zorg ervoor dat uw abonnement actief is."
 
@@ -605,6 +614,10 @@ msgstr "Certificaat vereist"
 msgid "No Data Available"
 msgstr "Geen gegevens beschikbaar"
 
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:192
+msgid "No IBAN for {0} {1}."
+msgstr "Geen IBAN voor {0} {1}."
+
 #: banking/public/js/bank_reconciliation_beta/panel_manager.js:84
 msgid "No Transactions found for the current filters."
 msgstr "Geen transacties gevonden voor de huidige filters."
@@ -613,7 +626,11 @@ msgstr "Geen transacties gevonden voor de huidige filters."
 msgid "No data available for download."
 msgstr "Geen gegevens beschikbaar voor downloaden."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:415
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.py:185
+msgid "No default bank account for Supplier {0}."
+msgstr "Geen standaardbankrekening voor Leverancier {0}."
+
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:417
 msgid "No matches occurred via Auto Reconciliation"
 msgstr "Geen overeenkomsten gevonden via automatische afstemming"
 
@@ -643,11 +660,11 @@ msgstr "Alleen onbetaalde documenten"
 msgid "Open Billing Portal"
 msgstr "Facturatieportaal openen"
 
-#: banking/overrides/bank_transaction.py:73
+#: banking/overrides/bank_transaction.py:106
 msgid "Over Allocation"
 msgstr "Overboeking"
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:279
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:351
 msgid "Overallocated Returns"
 msgstr "Overgeboekte retouren"
 
@@ -670,19 +687,19 @@ msgstr "Partij IBAN"
 #: banking/ebics/doctype/ebics_user/ebics_user.js:173
 #: banking/ebics/doctype/ebics_user/ebics_user.js:261
 #: banking/ebics/doctype/ebics_user/ebics_user.json
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:129
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:188
 msgid "Passphrase"
 msgstr "Wachtwoord"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:148
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:207
 msgid "Payment Order has been sent to bank."
 msgstr "Betalingsopdracht is naar de bank verzonden."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:154
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:213
 msgid "Payment Order has not been sent to bank."
 msgstr "Betalingsopdracht is niet naar de bank verzonden."
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:56
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:115
 msgid "Payment amounts have changed. Are you sure you want to submit without updating them first?"
 msgstr ""
 
@@ -772,6 +789,10 @@ msgstr "Reimporteren van EBICS-transacties ..."
 msgid "Reconciling ..."
 msgstr "Afstemmen ..."
 
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:162
+msgid "Reconciling multiple multi-currency invoices at once is not supported. Please reconcile one invoice at a time."
+msgstr ""
+
 #: banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.js:38
 msgid "Redirecting to Customer Portal ..."
 msgstr "Doorverwijzen naar klantportaal ..."
@@ -848,7 +869,7 @@ msgid "Show Protocol Versions"
 msgstr "Toon protocolversies"
 
 #: banking/ebics/doctype/ebics_user/ebics_user.js:39
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:122
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:181
 msgid "Signature Passphrase"
 msgstr "Handtekeningwachtwoord"
 
@@ -901,15 +922,15 @@ msgstr "Leveranciersbankrekening is aangemaakt."
 msgid "Supplier Bank Account was not created."
 msgstr "Leveranciersbankrekening is niet aangemaakt."
 
-#: banking/overrides/bank_transaction.py:70
+#: banking/overrides/bank_transaction.py:103
 msgid "The Bank Transaction is over-allocated by {0} at row {1}."
 msgstr "De banktransactie is overgeboekt met {0} op rij {1}."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:280
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py:352
 msgid "The allocated amount cannot be negative. Please adjust the selected return vouchers."
 msgstr "Het toegewezen bedrag kan niet negatief zijn. Pas de geselecteerde retourdocumenten aan."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:155
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:200
 msgid "The currency of the second account ({0} : {1}) must be the same as of the bank account ({2} : {3})"
 msgstr "De valuta van de tweede rekening ({0} : {1}) moet hetzelfde zijn als die van de bankrekening ({2} : {3})"
 
@@ -949,7 +970,11 @@ msgstr "Transmissiedatum"
 msgid "Transmission Type"
 msgstr "Transmissietype"
 
-#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:35
+#: banking/ebics/utils.py:208
+msgid "Unable to resolve batch transaction: camt.054 not available. Please try again later."
+msgstr ""
+
+#: banking/ebics/doctype/sepa_payment_order/sepa_payment_order.js:38
 msgid "Update Amounts"
 msgstr ""
 
@@ -1017,8 +1042,8 @@ msgstr "U heeft protocolversie {0} geselecteerd, maar bank {1} ondersteunt allee
 msgid "to import bank transactions for {0}."
 msgstr "om banktransacties voor {0} te importeren."
 
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:418
-#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:427
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:420
+#: banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py:429
 msgid "{0} {1} {2}"
 msgstr ""
 


### PR DESCRIPTION
Adds a button to select a recipient from existing data when creating a **SEPA Payment Order**.

The button opens a dialog with three fields:

- DocType: restricted to Supplier or Employee
- Name: Link field based on the selected DocType
- Purpose
- Amount

The dialog is also opened automatically when adding a new row to the table.

After selecting a recipient, the system fetches the Name and IBAN from the selected record.

Closes #350 