### PR TITLE
fix: fallback to address for SEPA party name

### DIFF
--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -359,7 +359,12 @@ def create_sepa_bank_transaction(
 		withdrawal=abs(min(amount, 0)),
 		date=sepa_transaction.date,
 		reference_number=sepa_transaction.eref,
-		bank_party_name=sepa_transaction.ultimate_name or sepa_transaction.name,
+		bank_party_name=sepa_transaction.ultimate_name
+		or sepa_transaction.name
+		or (
+			# some swiss banks specify the address only
+			", ".join(sepa_transaction.address) if sepa_transaction.address else None
+		),
 		bank_party_iban=party_iban,
 		bank_party_account_number=party_account_number,
 		included_fee=parse_included_fees(sepa_transaction, currency),


### PR DESCRIPTION
Use the SEPA transaction address as a fallback for `bank_party_name` when neither `ultimate_name` nor `name` is provided. This fixes imports from some Swiss banks that only send address data, so imported bank transactions still retain useful counterparty information.