### PR TITLE
fix(SEPA Payment Order): allow usage by Accounts Manager / Accounts User

### DIFF
--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
@@ -146,7 +146,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-17 21:35:58.094427",
+ "modified": "2026-03-17 21:50:42.728623",
  "modified_by": "Administrator",
  "module": "EBICS",
  "name": "SEPA Payment Order",
@@ -167,8 +167,6 @@
    "write": 1
   },
   {
-   "amend": 1,
-   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -184,6 +182,7 @@
   {
    "create": 1,
    "delete": 1,
+   "if_owner": 1,
    "read": 1,
    "role": "Accounts User",
    "write": 1

--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
@@ -146,7 +146,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-10-29 15:26:22.373076",
+ "modified": "2026-03-17 21:35:58.094427",
  "modified_by": "Administrator",
  "module": "EBICS",
  "name": "SEPA Payment Order",
@@ -164,6 +164,28 @@
    "role": "System Manager",
    "share": 1,
    "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Accounts User",
    "write": 1
   }
  ],


### PR DESCRIPTION
This pull request updates the permissions for the **SEPA Payment Order** document type in the EBICS banking module.

* Added a new permissions block for the "Accounts Manager" role, granting rights to create, delete, email, export, print, read, report, share, submit, and write.
* Added a new permissions block for the "Accounts User" role, granting rights to create, delete, read, and write only on their own orders.