### PR TITLE
fix(Bank Reconciliation Beta): use bt.date to determine sconto validity

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -248,6 +248,7 @@ def _create_multi_currency_pe(
 		bank_account=bank_account,
 		bank_amount=bank_amount,
 		payment_type="Receive" if bt.deposit > 0 else "Pay",
+		reference_date=bt.date,
 	)
 
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/unpaid_vouchers.py
@@ -185,6 +185,7 @@ def make_pe_against_invoices(bt: "CustomBankTransaction", invoices_to_bill: list
 			# return SI against a deposit should be considered as "Receive" (discount)
 			# return SI against a withdrawal should be considered as "Pay" (refund)
 			payment_type="Receive" if bt.deposit > 0 else "Pay",
+			reference_date=bt.date,
 		)
 
 	payment_entry.posting_date = bt.date


### PR DESCRIPTION
## Background
`get_payment_entry` in ERPNext uses the `reference_date` to determine, if a potential sconto payment is on time.

## Problem
We didn't pass the **Bank Transaction**'s _Date_. Therefore, `get_payment_entry` used today's date as `reference_date``
-> OUTCOME: Discounts were not considered in some cases.