### PR TITLE
fix: fall back to Employee.iban

### DIFF
--- a/banking/custom/employee.py
+++ b/banking/custom/employee.py
@@ -4,10 +4,14 @@ from frappe import _
 
 def validate(doc, event):
 	if hasattr(doc, "iban") and doc.has_value_changed("iban") and doc.iban:
-		frappe.msgprint(
-			_(
-				"IBAN on Employee is not used in SEPA Payment Orders. Please use Bank Account instead for payment processing."
-			),
-			title=_("IBAN Warning: Not used in SEPA Payment Orders"),
-			indicator="orange",
-		)
+		if frappe.db.exists(
+			"Bank Account",
+			{"party_type": "Employee", "party": doc.name, "disabled": 0},
+		):
+			frappe.msgprint(
+				_(
+					"The IBAN in this form will not be used in SEPA Payment Orders because a Bank Account is already linked to this Employee."
+				),
+				title=_("IBAN Warning: Not used in SEPA Payment Orders"),
+				indicator="orange",
+			)

--- a/banking/custom/purchase_invoice.py
+++ b/banking/custom/purchase_invoice.py
@@ -55,6 +55,8 @@ def make_sepa_payment_order(source_name: str, target_doc=None):
 				target.swift_number = swift_number
 				target.bank_name = bank_name
 			target.iban = bank_account.get("iban")
+		elif pay_to_employee:
+			target.iban = frappe.db.get_value("Employee", pi.business_trip_employee, "iban")
 
 		target.currency = pi.currency
 		target.eref = target.reference_name

--- a/banking/custom/purchase_invoice.py
+++ b/banking/custom/purchase_invoice.py
@@ -12,10 +12,11 @@ if TYPE_CHECKING:
 	from erpnext.accounts.doctype.purchase_invoice.purchase_invoice import PurchaseInvoice
 
 	from banking.ebics.doctype.sepa_payment.sepa_payment import SEPAPayment
+	from banking.ebics.doctype.sepa_payment_order.sepa_payment_order import SEPAPaymentOrder
 
 
 @frappe.whitelist()
-def make_sepa_payment_order(source_name: str, target_doc=None):
+def make_sepa_payment_order(source_name: str, target_doc: "SEPAPaymentOrder | None" = None):
 	def set_missing_values(source, target):
 		if not target.bank_account:
 			bank_account = frappe.db.get_value(


### PR DESCRIPTION
* Modified `purchase_invoice.py` to set the target IBAN from the **Employee** record when making payments to employees (for business trips), if no **Bank Account** is linked.
* Updated the IBAN validation warning in `employee.py` to clarify that if a **Bank Account** is already linked to an **Employee**, the IBAN entered in the **Employee** form will not be used in **SEPA Payment Orders**.