### PR TITLE
fix: use "Expense Claim" features only if hrms is installed

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -31,10 +31,8 @@ bench get-app payments --branch version-16
 bench get-app erpnext --branch version-16
 bench get-app hrms --branch version-16
 bench get-app banking "${GITHUB_WORKSPACE}"
+bench setup requirements --dev
 
 bench start &> bench_start.log &
 bench new-site --db-root-password root --admin-password admin test_site --install-app erpnext
 bench --site test_site install-app payments
-bench --site test_site install-app hrms
-bench --site test_site install-app banking
-bench setup requirements --dev

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -93,6 +93,14 @@ jobs:
         run: |
           bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
 
+      - name: Install hrms after banking
+        working-directory: /home/runner/frappe-bench
+        run: |
+          bench --site test_site install-app banking
+          bench --site test_site install-app hrms
+        env:
+          TYPE: server
+
       - name: Run Tests
         working-directory: /home/runner/frappe-bench
         run: |
@@ -101,9 +109,10 @@ jobs:
         env:
           TYPE: server
 
-      - name: Uninstall app
+      - name: Uninstall hrms before banking
         working-directory: /home/runner/frappe-bench
         run: |
+          bench --site test_site uninstall-app --yes --no-backup hrms
           bench --site test_site uninstall-app --yes --no-backup banking
         env:
           TYPE: server

--- a/banking/custom_fields.py
+++ b/banking/custom_fields.py
@@ -1,9 +1,11 @@
+import frappe
+
 from banking.ebics.doctype.sepa_payment_order.sepa_payment_order import PaymentOrderStatus
 from banking.utils import identity as _
 
 
 def get_custom_fields():
-	return {
+	fields = {
 		"Bank": [
 			dict(
 				fieldname="ebics_section",
@@ -66,18 +68,6 @@ def get_custom_fields():
 				depends_on="eval:doc.docstatus === 0 && doc.business_trip_employee && !doc.employee_bank_account && doc.pay_to_employee && frappe.model.can_create('Bank Account')",
 			),
 		],
-		"Expense Claim": [
-			dict(
-				fieldname="sepa_payment_order_status",
-				label=_("SEPA Payment Order Status"),
-				fieldtype="Select",
-				options="\n".join(PaymentOrderStatus),
-				insert_after="payable_account",
-				no_copy=1,
-				read_only=1,
-				allow_on_submit=1,
-			),
-		],
 		"Payment Schedule": [
 			dict(
 				fieldname="sepa_payment_order_status",
@@ -100,3 +90,19 @@ def get_custom_fields():
 			),
 		],
 	}
+
+	if "hrms" in frappe.get_installed_apps():
+		fields["Expense Claim"] = [
+			dict(
+				fieldname="sepa_payment_order_status",
+				label=_("SEPA Payment Order Status"),
+				fieldtype="Select",
+				options="\n".join(PaymentOrderStatus),
+				insert_after="payable_account",
+				no_copy=1,
+				read_only=1,
+				allow_on_submit=1,
+			),
+		]
+
+	return fields

--- a/banking/custom_fields.py
+++ b/banking/custom_fields.py
@@ -5,7 +5,7 @@ from banking.utils import identity as _
 
 
 def get_custom_fields():
-	fields = {
+	custom_fields = {
 		"Bank": [
 			dict(
 				fieldname="ebics_section",
@@ -92,7 +92,7 @@ def get_custom_fields():
 	}
 
 	if "hrms" in frappe.get_installed_apps():
-		fields["Expense Claim"] = [
+		custom_fields["Expense Claim"] = [
 			dict(
 				fieldname="sepa_payment_order_status",
 				label=_("SEPA Payment Order Status"),
@@ -105,4 +105,4 @@ def get_custom_fields():
 			),
 		]
 
-	return fields
+	return custom_fields

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -1,3 +1,5 @@
+import frappe
+
 app_name = "banking"
 app_title = "ALYF Banking"
 app_publisher = "ALYF GmbH"
@@ -6,7 +8,9 @@ app_email = "hallo@alyf.de"
 app_license = "GPLv3"
 notification_email_logo = "/assets/banking/images/alyf-logo.png"
 
-required_apps = ["erpnext", "hrms"]
+required_apps = ["erpnext"]
+
+_hrms_is_installed = "hrms" in frappe.get_installed_apps()
 
 # Includes in <head>
 # ------------------
@@ -32,16 +36,19 @@ app_include_js = "banking.bundle.js"
 # include js in doctype views
 doctype_js = {
 	"Bank": "custom/bank.js",
-	"Expense Claim": "custom/expense_claim.js",
 	"Purchase Invoice": "custom/purchase_invoice.js",
 	"Employee": "custom/employee.js",
 	"Supplier": "custom/supplier.js",
 	"Bank Reconciliation Tool": "custom/bank_reconciliation_tool.js",
 }
+if _hrms_is_installed:
+	doctype_js["Expense Claim"] = "custom/expense_claim.js"
+
 doctype_list_js = {
-	"Expense Claim": "custom/expense_claim_list.js",
 	"Purchase Invoice": "custom/purchase_invoice_list.js",
 }
+if _hrms_is_installed:
+	doctype_list_js["Expense Claim"] = "custom/expense_claim_list.js"
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
 
@@ -125,15 +132,16 @@ doc_events = {
 	"Employee": {
 		"validate": "banking.custom.employee.validate",
 	},
-	"Expense Claim": {
-		"sepa_payment_order_status_changed": "banking.custom.expense_claim.sepa_payment_order_status_changed",
-		"get_sepa_payment_amount": "banking.custom.expense_claim.get_sepa_payment_amount",
-	},
 	"Purchase Invoice": {
 		"sepa_payment_order_status_changed": "banking.custom.purchase_invoice.sepa_payment_order_status_changed",
 		"get_sepa_payment_amount": "banking.custom.purchase_invoice.get_sepa_payment_amount",
 	},
 }
+if _hrms_is_installed:
+	doc_events["Expense Claim"] = {
+		"sepa_payment_order_status_changed": "banking.custom.expense_claim.sepa_payment_order_status_changed",
+		"get_sepa_payment_amount": "banking.custom.expense_claim.get_sepa_payment_amount",
+	}
 
 # Scheduled Tasks
 # ---------------
@@ -213,7 +221,7 @@ export_python_type_annotations = True
 # Translation
 # ------------
 # List of apps whose translatable strings should be excluded from this app's translations.
-ignore_translatable_strings_from = ["frappe", "erpnext", "hrms"]
+ignore_translatable_strings_from = ["frappe", "erpnext"]
 
 
 alyf_banking_property_setters = {
@@ -252,16 +260,6 @@ get_payment_entries = "banking.klarna_kosma_integration.doctype.bank_reconciliat
 alyf_banking_custom_records = [
 	{
 		"doctype": "DocType Link",
-		"parent": "Expense Claim",
-		"parentfield": "links",
-		"parenttype": "Customize Form",
-		"group": "Payment",
-		"link_doctype": "SEPA Payment Order",
-		"link_fieldname": "reference_name",
-		"custom": 1,
-	},
-	{
-		"doctype": "DocType Link",
 		"parent": "Purchase Invoice",
 		"parentfield": "links",
 		"parenttype": "Customize Form",
@@ -271,3 +269,16 @@ alyf_banking_custom_records = [
 		"custom": 1,
 	},
 ]
+if _hrms_is_installed:
+	alyf_banking_custom_records.append(
+		{
+			"doctype": "DocType Link",
+			"parent": "Expense Claim",
+			"parentfield": "links",
+			"parenttype": "Customize Form",
+			"group": "Payment",
+			"link_doctype": "SEPA Payment Order",
+			"link_fieldname": "reference_name",
+			"custom": 1,
+		}
+	)

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -32,18 +32,16 @@ app_include_js = "banking.bundle.js"
 # include js in doctype views
 doctype_js = {
 	"Bank": "custom/bank.js",
+	"Expense Claim": "custom/expense_claim.js",
 	"Purchase Invoice": "custom/purchase_invoice.js",
 	"Employee": "custom/employee.js",
 	"Supplier": "custom/supplier.js",
 	"Bank Reconciliation Tool": "custom/bank_reconciliation_tool.js",
-	"Expense Claim": "custom/expense_claim.js",
 }
-
 doctype_list_js = {
-	"Purchase Invoice": "custom/purchase_invoice_list.js",
 	"Expense Claim": "custom/expense_claim_list.js",
+	"Purchase Invoice": "custom/purchase_invoice_list.js",
 }
-
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
 
@@ -127,13 +125,13 @@ doc_events = {
 	"Employee": {
 		"validate": "banking.custom.employee.validate",
 	},
-	"Purchase Invoice": {
-		"sepa_payment_order_status_changed": "banking.custom.purchase_invoice.sepa_payment_order_status_changed",
-		"get_sepa_payment_amount": "banking.custom.purchase_invoice.get_sepa_payment_amount",
-	},
 	"Expense Claim": {
 		"sepa_payment_order_status_changed": "banking.custom.expense_claim.sepa_payment_order_status_changed",
 		"get_sepa_payment_amount": "banking.custom.expense_claim.get_sepa_payment_amount",
+	},
+	"Purchase Invoice": {
+		"sepa_payment_order_status_changed": "banking.custom.purchase_invoice.sepa_payment_order_status_changed",
+		"get_sepa_payment_amount": "banking.custom.purchase_invoice.get_sepa_payment_amount",
 	},
 }
 

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -40,15 +40,14 @@ doctype_js = {
 	"Employee": "custom/employee.js",
 	"Supplier": "custom/supplier.js",
 	"Bank Reconciliation Tool": "custom/bank_reconciliation_tool.js",
+	"Expense Claim": "custom/expense_claim.js",
 }
-if _hrms_is_installed:
-	doctype_js["Expense Claim"] = "custom/expense_claim.js"
 
 doctype_list_js = {
 	"Purchase Invoice": "custom/purchase_invoice_list.js",
+	"Expense Claim": "custom/expense_claim_list.js",
 }
-if _hrms_is_installed:
-	doctype_list_js["Expense Claim"] = "custom/expense_claim_list.js"
+
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
 
@@ -136,12 +135,11 @@ doc_events = {
 		"sepa_payment_order_status_changed": "banking.custom.purchase_invoice.sepa_payment_order_status_changed",
 		"get_sepa_payment_amount": "banking.custom.purchase_invoice.get_sepa_payment_amount",
 	},
-}
-if _hrms_is_installed:
-	doc_events["Expense Claim"] = {
+	"Expense Claim": {
 		"sepa_payment_order_status_changed": "banking.custom.expense_claim.sepa_payment_order_status_changed",
 		"get_sepa_payment_amount": "banking.custom.expense_claim.get_sepa_payment_amount",
-	}
+	},
+}
 
 # Scheduled Tasks
 # ---------------

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -254,16 +254,6 @@ get_payment_entries = "banking.klarna_kosma_integration.doctype.bank_reconciliat
 alyf_banking_custom_records = [
 	{
 		"doctype": "DocType Link",
-		"parent": "Purchase Invoice",
-		"parentfield": "links",
-		"parenttype": "Customize Form",
-		"group": "Payment",
-		"link_doctype": "SEPA Payment Order",
-		"link_fieldname": "reference_name",
-		"custom": 1,
-	},
-	{
-		"doctype": "DocType Link",
 		"parent": "Expense Claim",
 		"parentfield": "links",
 		"parenttype": "Customize Form",
@@ -272,5 +262,15 @@ alyf_banking_custom_records = [
 		"link_fieldname": "reference_name",
 		"custom": 1,
 		"_required_apps": ["hrms"],
+	},
+	{
+		"doctype": "DocType Link",
+		"parent": "Purchase Invoice",
+		"parentfield": "links",
+		"parenttype": "Customize Form",
+		"group": "Payment",
+		"link_doctype": "SEPA Payment Order",
+		"link_fieldname": "reference_name",
+		"custom": 1,
 	},
 ]

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -8,7 +8,7 @@ app_email = "hallo@alyf.de"
 app_license = "GPLv3"
 notification_email_logo = "/assets/banking/images/alyf-logo.png"
 
-required_apps = ["erpnext"]
+required_apps = ["frappe/erpnext"]
 
 _hrms_is_installed = "hrms" in frappe.get_installed_apps()
 

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -6,6 +6,8 @@ app_email = "hallo@alyf.de"
 app_license = "GPLv3"
 notification_email_logo = "/assets/banking/images/alyf-logo.png"
 
+required_apps = ["erpnext", "hrms"]
+
 # Includes in <head>
 # ------------------
 
@@ -211,7 +213,7 @@ export_python_type_annotations = True
 # Translation
 # ------------
 # List of apps whose translatable strings should be excluded from this app's translations.
-ignore_translatable_strings_from = ["frappe", "erpnext"]
+ignore_translatable_strings_from = ["frappe", "erpnext", "hrms"]
 
 
 alyf_banking_property_setters = {

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -76,11 +76,13 @@ doctype_list_js = {
 
 # before_install = "banking.install.before_install"
 after_install = "banking.install.after_install"
+after_app_install = "banking.install.after_app_install"
 
 # Uninstallation
 # ------------
 
 before_uninstall = "banking.uninstall.before_uninstall"
+before_app_uninstall = "banking.uninstall.before_app_uninstall"
 # after_uninstall = "banking.uninstall.after_uninstall"
 
 # Desk Notifications

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -1,5 +1,3 @@
-import frappe
-
 app_name = "banking"
 app_title = "ALYF Banking"
 app_publisher = "ALYF GmbH"
@@ -9,8 +7,6 @@ app_license = "GPLv3"
 notification_email_logo = "/assets/banking/images/alyf-logo.png"
 
 required_apps = ["frappe/erpnext"]
-
-_hrms_is_installed = "hrms" in frappe.get_installed_apps()
 
 # Includes in <head>
 # ------------------
@@ -266,17 +262,15 @@ alyf_banking_custom_records = [
 		"link_fieldname": "reference_name",
 		"custom": 1,
 	},
+	{
+		"doctype": "DocType Link",
+		"parent": "Expense Claim",
+		"parentfield": "links",
+		"parenttype": "Customize Form",
+		"group": "Payment",
+		"link_doctype": "SEPA Payment Order",
+		"link_fieldname": "reference_name",
+		"custom": 1,
+		"_required_apps": ["hrms"],
+	},
 ]
-if _hrms_is_installed:
-	alyf_banking_custom_records.append(
-		{
-			"doctype": "DocType Link",
-			"parent": "Expense Claim",
-			"parentfield": "links",
-			"parenttype": "Customize Form",
-			"group": "Payment",
-			"link_doctype": "SEPA Payment Order",
-			"link_fieldname": "reference_name",
-			"custom": 1,
-		}
-	)

--- a/banking/install.py
+++ b/banking/install.py
@@ -31,6 +31,11 @@ def make_property_setters():
 
 def insert_custom_records():
 	for custom_record in frappe.get_hooks("alyf_banking_custom_records"):
+		if required_apps := custom_record.pop("_required_apps", None):
+			installed_apps = frappe.get_installed_apps()
+			if any(app not in installed_apps for app in required_apps):
+				continue
+
 		filters = custom_record.copy()
 		# Clean up filters. They need to be a plain dict without nested dicts or lists.
 		for key, value in custom_record.items():

--- a/banking/install.py
+++ b/banking/install.py
@@ -31,16 +31,17 @@ def make_property_setters():
 
 def insert_custom_records():
 	for custom_record in frappe.get_hooks("alyf_banking_custom_records"):
-		if required_apps := custom_record.pop("_required_apps", None):
+		custom_record_copy = custom_record.copy()
+		if required_apps := custom_record_copy.pop("_required_apps", None):
 			installed_apps = frappe.get_installed_apps()
 			if any(app not in installed_apps for app in required_apps):
 				continue
 
-		filters = custom_record.copy()
+		filters = custom_record_copy.copy()
 		# Clean up filters. They need to be a plain dict without nested dicts or lists.
-		for key, value in custom_record.items():
+		for key, value in custom_record_copy.items():
 			if isinstance(value, list | dict):
 				del filters[key]
 
 		if not frappe.db.exists(filters):
-			frappe.get_doc(custom_record).insert(ignore_if_duplicate=True)
+			frappe.get_doc(custom_record_copy).insert(ignore_if_duplicate=True)

--- a/banking/install.py
+++ b/banking/install.py
@@ -14,6 +14,24 @@ def after_install():
 	insert_custom_records()
 
 
+def after_app_install(app_name):
+	if app_name == "banking":
+		return
+
+	print(f"Installing {app_name}-specific Banking customizations ...")
+
+	app_custom_fields = {}
+	for doctype, fields in get_custom_fields().items():
+		module = frappe.db.get_value("DocType", doctype, "module")
+		if module and frappe.db.get_value("Module Def", module, "app_name") == app_name:
+			app_custom_fields[doctype] = fields
+
+	if app_custom_fields:
+		create_custom_fields(app_custom_fields)
+
+	insert_custom_records()
+
+
 def make_property_setters():
 	for doctypes, property_setters in frappe.get_hooks("alyf_banking_property_setters", {}).items():
 		if isinstance(doctypes, str):

--- a/banking/uninstall.py
+++ b/banking/uninstall.py
@@ -9,6 +9,54 @@ def before_uninstall():
 	remove_property_setters()
 
 
+def before_app_uninstall(app_name):
+	if app_name == "banking":
+		return
+
+	print(f"* removing {app_name}-specific Banking customizations...")
+	remove_app_custom_fields(app_name)
+	remove_app_custom_records(app_name)
+
+
+def remove_app_custom_fields(app_name):
+	print(f"* removing {app_name} custom fields...")
+	from frappe.custom.doctype.custom_field.custom_field import delete_custom_fields
+
+	from banking.custom_fields import get_custom_fields
+
+	app_custom_fields = {}
+	for doctype, fields in get_custom_fields().items():
+		module = frappe.db.get_value("DocType", doctype, "module")
+		if module and frappe.db.get_value("Module Def", module, "app_name") == app_name:
+			app_custom_fields[doctype] = fields
+
+	if app_custom_fields:
+		delete_custom_fields(app_custom_fields)
+
+
+def remove_app_custom_records(app_name):
+	print(f"* removing {app_name} custom records...")
+	doctypes_to_clear = set()
+	for record in frappe.get_hooks("alyf_banking_custom_records"):
+		record_copy = record.copy()
+		required_apps = record_copy.pop("_required_apps", None)
+		if required_apps and app_name in required_apps:
+			doctype = record_copy.pop("doctype")
+
+			filters = record_copy.copy()
+			# Clean up filters. They need to be a plain dict without nested dicts or lists.
+			for key, value in record_copy.items():
+				if isinstance(value, list | dict):
+					del filters[key]
+
+			frappe.db.delete(doctype, filters)
+			if parent := filters.get("parent"):
+				doctypes_to_clear.add(parent)
+
+	for parent in doctypes_to_clear:
+		frappe.clear_cache(doctype=parent)
+
+
 def remove_custom_records():
 	print("* removing custom records...")
 	doctypes_to_clear = set()

--- a/banking/uninstall.py
+++ b/banking/uninstall.py
@@ -11,42 +11,53 @@ def before_uninstall():
 
 def remove_custom_records():
 	print("* removing custom records...")
+	doctypes_to_clear = set()
 	for record in frappe.get_hooks("alyf_banking_custom_records"):
-		doctype = record.pop("doctype")
-		frappe.db.delete(doctype, record)
+		record_copy = record.copy()
+		record_copy.pop("_required_apps", None)
+		doctype = record_copy.pop("doctype")
+
+		filters = record_copy.copy()
+		# Clean up filters. They need to be a plain dict without nested dicts or lists.
+		for key, value in record_copy.items():
+			if isinstance(value, list | dict):
+				del filters[key]
+
+		frappe.db.delete(doctype, filters)
+		if parent := filters.get("parent"):
+			doctypes_to_clear.add(parent)
+
+	for parent in doctypes_to_clear:
+		frappe.clear_cache(doctype=parent)
 
 
 def remove_custom_fields():
 	print("* removing custom fields...")
+	from frappe.custom.doctype.custom_field.custom_field import delete_custom_fields
+
+	custom_fields_to_delete = {}
 	for doctypes, custom_fields in get_custom_fields().items():
 		if isinstance(doctypes, str):
 			doctypes = (doctypes,)
 
 		for doctype in doctypes:
-			for cf in custom_fields:
-				frappe.db.delete(
-					"Custom Field",
-					{
-						"dt": doctype,
-						"fieldname": cf.get("fieldname"),
-					},
-				)
+			custom_fields_to_delete[doctype] = custom_fields
+
+	delete_custom_fields(custom_fields_to_delete)
 
 
 def remove_property_setters():
 	print("* removing property setters...")
+	from frappe.custom.doctype.property_setter.property_setter import delete_property_setter
+
 	for doctypes, property_setters in frappe.get_hooks("alyf_banking_property_setters", {}).items():
 		if isinstance(doctypes, str):
 			doctypes = (doctypes,)
 
 		for doctype in doctypes:
 			for property_setter in property_setters:
-				frappe.db.delete(
-					"Property Setter",
-					{
-						"doc_type": doctype,
-						"field_name": property_setter.get("fieldname"),
-						"property": property_setter.get("property"),
-						"value": property_setter.get("value"),
-					},
+				delete_property_setter(
+					doctype,
+					property=property_setter.get("property"),
+					field_name=property_setter.get("fieldname"),
 				)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ build-backend = "flit_core.buildapi"
 [tool.bench.frappe-dependencies]
 frappe = ">=16.15.0,<17.0.0"
 erpnext = ">=16.14.0,<17.0.0"
+hrms = ">=16.0.0,<17.0.0"
 
 [tool.ruff]
 line-length = 110

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ build-backend = "flit_core.buildapi"
 [tool.bench.frappe-dependencies]
 frappe = ">=16.15.0,<17.0.0"
 erpnext = ">=16.14.0,<17.0.0"
-hrms = ">=16.0.0,<17.0.0"
 
 [tool.ruff]
 line-length = 110


### PR DESCRIPTION
## Summary

Declare **HRMS** as a required app for `banking`.

The app's **Expense Claim** integration (custom field, hooks, custom records, SEPA Payment Order workflow, reconciliation queries) hard-depends on HRMS. Without it, `bench install-app banking` / `bench migrate` fails with `LinkValidationError: Could not find DocType: Expense Claim`.