### PR TITLE
fix(SEPA Payment Order): avoid overpaying for PIs with relevant returns

### DIFF
--- a/banking/custom/purchase_invoice.py
+++ b/banking/custom/purchase_invoice.py
@@ -169,13 +169,15 @@ def get_sepa_payment_amount(
 		# No Payment Schedule to check.
 		return 0
 
+	# Also consider doc.outstanding_amount to avoid overpaying (typical case: Return PIs reduced the outstanding amount)
+	outstanding = min(scheduled_payment.outstanding, doc.outstanding_amount)
 	if not scheduled_payment.discount_date or getdate(scheduled_payment.discount_date) < execution_date:
 		# If no discount is given or it's too late for the discount: Use the outstanding amount
 		# This is default, but needs to be reset (in case expected_transaction_date changed etc.)
-		return scheduled_payment.outstanding
+		return outstanding
 	else:
 		# Use the discounted amount
 		return round(
-			scheduled_payment.outstanding * ((100 - scheduled_payment.discount) / 100),
+			outstanding * ((100 - scheduled_payment.discount) / 100),
 			scheduled_payment.precision("outstanding"),
 		)

--- a/banking/custom/purchase_invoice.py
+++ b/banking/custom/purchase_invoice.py
@@ -169,8 +169,12 @@ def get_sepa_payment_amount(
 		# No Payment Schedule to check.
 		return 0
 
-	# Also consider doc.outstanding_amount to avoid overpaying (typical case: Return PIs reduced the outstanding amount)
-	outstanding = min(scheduled_payment.outstanding, doc.outstanding_amount)
+	# Cap by invoice outstanding minus other SEPA Payments for this PI
+	# (e.g. returns reduced outstanding, or another schedule row already has a SEPA Payment).
+	# Exclude the current schedule row so recalculating an existing payment does not subtract itself.
+	already_covered = _get_existing_sepa_payment_amount(doc.name, exclude_row=payment_schedule_row_name)
+	payable_cap = max(doc.outstanding_amount - already_covered, 0)
+	outstanding = min(scheduled_payment.outstanding, payable_cap)
 	if not scheduled_payment.discount_date or getdate(scheduled_payment.discount_date) < execution_date:
 		# If no discount is given or it's too late for the discount: Use the outstanding amount
 		# This is default, but needs to be reset (in case expected_transaction_date changed etc.)
@@ -181,3 +185,16 @@ def get_sepa_payment_amount(
 			outstanding * ((100 - scheduled_payment.discount) / 100),
 			scheduled_payment.precision("outstanding"),
 		)
+
+
+def _get_existing_sepa_payment_amount(purchase_invoice: str, exclude_row: str | None = None) -> float:
+	"""Sum amounts of non-cancelled SEPA Payments linked to this Purchase Invoice."""
+	filters: dict = {
+		"reference_doctype": "Purchase Invoice",
+		"reference_name": purchase_invoice,
+		"docstatus": ["<", 2],
+	}
+	if exclude_row:
+		filters["reference_row_name"] = ["!=", exclude_row]
+
+	return frappe.get_all("SEPA Payment", filters=filters, fields=["sum(amount) as total"])[0].total or 0


### PR DESCRIPTION
# Case

- **Purchase Invoice** 1 is submitted.
- A return **Purchase Invoice** is submitted against PI 1 (with `update_outstanding_for_self` deactivated) -> Result: The **Purchase Invoice** has a reduced `outstanding_amount`.
- Now a **SEPA Payment Order** is created that includes **Purchase Invoice** 1

See example of a **Purchase Invoice** 1:
<img width="1134" height="1309" alt="image" src="https://github.com/user-attachments/assets/9d55cb3c-9c33-4ad3-be17-32e222eb699d" />
-> Previous outstanding of 39.000€ (see `grand_total`) was reduced by 10k (see `outstanding_amount`)

# Before
<img width="1134" height="774" alt="image" src="https://github.com/user-attachments/assets/a055b5e4-20d8-432b-9a53-659c0df834a8" />
-> 39k was used from row in `payment_schedule`.

# Cause
Only `outstanding_amount` from `payment_schedule` is used to determine the default payment amount.
Problem is, that this field is not (and can not be) updated by returns.

# After fix
<img width="1134" height="774" alt="image" src="https://github.com/user-attachments/assets/686f868f-cdd9-474e-a1ee-525aaea14dd6" />
-> The minimum of `payment_schedule` and `doc.outstanding_amount` is used as default.

Also for discounted payments the minimum will be considered as base (before discounting).