### PR TITLE
feat: add banking app screen hook

### DIFF
--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -4,7 +4,17 @@ app_publisher = "ALYF GmbH"
 app_description = "Banking Integration by ALYF GmbH"
 app_email = "hallo@alyf.de"
 app_license = "GPLv3"
+app_home = "/desk/alyf-banking"
 notification_email_logo = "/assets/banking/images/alyf-logo.png"
+
+add_to_apps_screen = [
+	{
+		"name": app_name,
+		"logo": "/assets/banking/images/logo.png",
+		"title": app_title,
+		"route": app_home,
+	}
+]
 
 # Includes in <head>
 # ------------------


### PR DESCRIPTION
## Summary
- Add an apps-screen entry for the banking app.
- Route the app card to the v16 desk path for the banking sidebar.

## Test plan
- `pre-commit run ruff --files banking/hooks.py`
- `pre-commit run ruff-format --files banking/hooks.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an apps-screen entry for the ALYF Banking app by introducing the `add_to_apps_screen` hook and an `app_home` variable pointing to the v16 workspace sidebar route.

- Adds `app_home = "/desk/alyf-banking"` to define the default landing route for the banking sidebar, and reuses it in the new `add_to_apps_screen` list so the banking tile routes correctly.
- The logo path (`/assets/banking/images/logo.png`) resolves to an existing asset, and `app_name`/`app_title` are used by reference so they stay in sync with the top-level declarations.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is small and isolated to hook registration with no impact on existing functionality.

The change is minimal — two new module-level declarations in `hooks.py`. The logo asset already exists, variables are referenced correctly, and the target route matches the `Workspace Sidebar` record. The only open question is whether the apps-screen tile should carry a `has_permission` check to avoid showing it to users without banking access.

No files require special attention beyond the optional `has_permission` consideration in `banking/hooks.py`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| banking/hooks.py | Adds `app_home` variable and `add_to_apps_screen` hook to register the banking app on Frappe's apps screen; logo path resolves correctly, no breaking changes to existing hooks. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant AppsScreen as Frappe Apps Screen
    participant Hook as add_to_apps_screen hook
    participant BankingApp as Banking App (/desk/alyf-banking)

    User->>AppsScreen: Open apps screen
    AppsScreen->>Hook: Load app entries
    Hook-->>AppsScreen: "{name:"banking", logo, title:"ALYF Banking", route:"/desk/alyf-banking"}"
    AppsScreen-->>User: Render Banking tile
    User->>AppsScreen: Click Banking tile
    AppsScreen->>BankingApp: Navigate to /desk/alyf-banking
    BankingApp-->>User: Workspace Sidebar (ALYF Banking)
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Abanking%2Fhooks.py%3A10-17%0A**Missing%20%60has_permission%60%20guard%20on%20apps-screen%20entry**%0A%0AWithout%20a%20%60has_permission%60%20callable%2C%20the%20Banking%20app%20card%20is%20shown%20to%20every%20authenticated%20user%20on%20the%20apps%20screen%20%E2%80%94%20including%20users%20who%20have%20no%20banking-related%20roles%20or%20permissions.%20Frappe's%20%60add_to_apps_screen%60%20hook%20supports%20an%20optional%20%60has_permission%60%20dotted-path%20string%20%28e.g.%20%60%22banking.hooks.has_banking_permission%22%60%29%20that%20lets%20you%20hide%20the%20tile%20for%20users%20who%20shouldn't%20see%20it.%0A%0A&pr=369&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: add banking app screen hook"](https://github.com/alyf-de/banking/commit/595d2dd7985fde47517e14ecc0ffcd3e89dd4c6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33154079)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->