### PR TITLE
chore: resave doctypes with v16 metadata

### DIFF
--- a/banking/ebics/doctype/ebics_request/ebics_request.json
+++ b/banking/ebics/doctype/ebics_request/ebics_request.json
@@ -53,7 +53,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2026-01-21 13:31:17.168084",
+ "modified": "2026-05-21 02:05:40.304549",
  "modified_by": "Administrator",
  "module": "EBICS",
  "name": "EBICS Request",
@@ -66,7 +66,8 @@
    "role": "System Manager"
   }
  ],
- "sort_field": "modified",
+ "row_format": "Dynamic",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/banking/ebics/doctype/ebics_request/ebics_request.py
+++ b/banking/ebics/doctype/ebics_request/ebics_request.py
@@ -11,6 +11,22 @@ from banking.ebics.utils import import_ebics_json, register_fintech
 
 
 class EBICSRequest(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		ebics_user: DF.Link | None
+		order_type: DF.Data | None
+		parameters: DF.Code | None
+		requested_by: DF.Literal["System", "User"]
+		response: DF.Code | None
+		status: DF.Literal["Successful", "No Data Available", "Failed", "Skipped"]
+	# end: auto-generated types
+
 	@frappe.whitelist()
 	def re_import(self):
 		"""Re-import the EBICS transactions from the response."""

--- a/banking/ebics/doctype/ebics_user/ebics_user.json
+++ b/banking/ebics/doctype/ebics_user/ebics_user.json
@@ -162,13 +162,14 @@
    "label": "Download Batch Transactions"
   }
  ],
+ "grid_page_length": 50,
  "links": [
   {
    "link_doctype": "EBICS Request",
    "link_fieldname": "ebics_user"
   }
  ],
- "modified": "2025-10-08 15:37:25.273496",
+ "modified": "2026-05-21 02:05:40.039153",
  "modified_by": "Administrator",
  "module": "EBICS",
  "name": "EBICS User",
@@ -200,8 +201,9 @@
   }
  ],
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "search_fields": "full_name,bank,company",
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
  "title_field": "full_name"

--- a/banking/ebics/doctype/sepa_payment/sepa_payment.json
+++ b/banking/ebics/doctype/sepa_payment/sepa_payment.json
@@ -110,14 +110,15 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-11 22:42:58.100459",
+ "modified": "2026-05-21 02:05:39.938394",
  "modified_by": "Administrator",
  "module": "EBICS",
  "name": "SEPA Payment",
  "owner": "Administrator",
  "permissions": [],
  "row_format": "Dynamic",
- "sort_field": "modified",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/banking/ebics/doctype/sepa_payment/sepa_payment.py
+++ b/banking/ebics/doctype/sepa_payment/sepa_payment.py
@@ -30,4 +30,5 @@ class SEPAPayment(Document):
 		reference_row_name: DF.Data | None
 		swift_number: DF.Data | None
 	# end: auto-generated types
+
 	pass

--- a/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
+++ b/banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json
@@ -146,7 +146,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-17 21:50:42.728623",
+ "modified": "2026-05-21 02:05:39.522868",
  "modified_by": "Administrator",
  "module": "EBICS",
  "name": "SEPA Payment Order",
@@ -189,7 +189,7 @@
   }
  ],
  "row_format": "Dynamic",
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
  "track_changes": 1

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.json
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.json
@@ -95,7 +95,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-28 02:28:06.918430",
+ "modified": "2026-05-21 02:05:39.142185",
  "modified_by": "Administrator",
  "module": "Klarna Kosma Integration",
  "name": "Bank Reconciliation Rule",
@@ -143,7 +143,7 @@
  ],
  "row_format": "Dynamic",
  "rows_threshold_for_grid_search": 20,
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py
@@ -30,8 +30,8 @@ class BankReconciliationRule(Document):
 		filters: DF.Code | None
 		priority: DF.Int
 		target_account: DF.Link
-
 	# end: auto-generated types
+
 	def validate(self):
 		self.validate_account_currencies()
 		self.validate_filters()

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.json
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.json
@@ -123,7 +123,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-14 17:12:13.850366",
+ "modified": "2026-05-21 02:05:38.999291",
  "modified_by": "Administrator",
  "module": "Klarna Kosma Integration",
  "name": "Bank Reconciliation Tool Beta",
@@ -154,7 +154,7 @@
  ],
  "quick_entry": 1,
  "row_format": "Dynamic",
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/banking/klarna_kosma_integration/doctype/banking_reference_mapping/banking_reference_mapping.json
+++ b/banking/klarna_kosma_integration/doctype/banking_reference_mapping/banking_reference_mapping.json
@@ -26,16 +26,19 @@
    "reqd": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-20 17:12:39.739249",
+ "modified": "2026-05-21 02:05:38.899161",
  "modified_by": "Administrator",
  "module": "Klarna Kosma Integration",
  "name": "Banking Reference Mapping",
  "owner": "Administrator",
  "permissions": [],
- "sort_field": "modified",
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/banking/klarna_kosma_integration/doctype/banking_reference_mapping/banking_reference_mapping.py
+++ b/banking/klarna_kosma_integration/doctype/banking_reference_mapping/banking_reference_mapping.py
@@ -6,4 +6,19 @@ from frappe.model.document import Document
 
 
 class BankingReferenceMapping(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		document_type: DF.Literal["Sales Invoice", "Purchase Invoice", "Expense Claim"]
+		field_name: DF.Literal[None]
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/banking/klarna_kosma_integration/doctype/voucher_matching_default/voucher_matching_default.json
+++ b/banking/klarna_kosma_integration/doctype/voucher_matching_default/voucher_matching_default.json
@@ -20,7 +20,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-07 18:42:00.279989",
+ "modified": "2026-05-21 02:05:38.810932",
  "modified_by": "Administrator",
  "module": "Klarna Kosma Integration",
  "name": "Voucher Matching Default",
@@ -28,7 +28,7 @@
  "permissions": [],
  "row_format": "Dynamic",
  "rows_threshold_for_grid_search": 20,
- "sort_field": "modified",
+ "sort_field": "creation",
  "sort_order": "DESC",
  "states": []
 }

--- a/banking/klarna_kosma_integration/doctype/voucher_matching_default/voucher_matching_default.py
+++ b/banking/klarna_kosma_integration/doctype/voucher_matching_default/voucher_matching_default.py
@@ -19,4 +19,5 @@ class VoucherMatchingDefault(Document):
 		parentfield: DF.Data
 		parenttype: DF.Data
 	# end: auto-generated types
+
 	pass


### PR DESCRIPTION
## Summary
- Resave non-overlapping standard DocTypes with v16-generated metadata.
- Move their default sorting from `modified` to `creation`.
- Include generated type-stub/format updates produced by the DocType save flow.

## Test plan
- `pre-commit run check-json --files <changed DocType JSON files>`
- `pre-commit run ruff --files <changed Python controller files>`
- `pre-commit run ruff-format --files <changed Python controller files>`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This chore PR resaves 8 DocType JSON definitions with v16-generated metadata and updates accompanying Python controller stubs. There are no logic or schema changes — every edit is the result of running the Frappe v16 DocType save flow.

- **`sort_field` changed from `modified` to `creation`** across all touched DocTypes, so list views will now default to sorting by creation date instead of last-modified date.
- **New v16 metadata fields** (`row_format: \"Dynamic\"`, `rows_threshold_for_grid_search: 20`, `grid_page_length: 50`) are added to DocTypes that were missing them, and trailing-newline / blank-line formatting is normalised in every file.
- **Auto-generated type stubs** are added to `banking_reference_mapping.py`; existing stubs in other `.py` files receive minor whitespace-only adjustments produced by `ruff format`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are auto-generated DocType metadata with no logic modifications.

Every file change is the direct output of Frappe v16's DocType save flow: timestamp updates, new display-configuration fields, the intentional sort_field shift from modified to creation, and auto-generated Python type stubs. No controller logic, SQL, or business rules are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| banking/ebics/doctype/ebics_request/ebics_request.json | Timestamp bumped, sort_field changed to creation, row_format Dynamic added, trailing newline fixed |
| banking/ebics/doctype/ebics_user/ebics_user.json | Timestamp bumped, sort_field to creation, grid_page_length and rows_threshold_for_grid_search added by v16 save flow |
| banking/ebics/doctype/sepa_payment/sepa_payment.json | Timestamp bumped, sort_field to creation, rows_threshold_for_grid_search added; istable child DocType |
| banking/ebics/doctype/sepa_payment/sepa_payment.py | Blank line added before pass — trivial formatting change from v16 ruff format |
| banking/ebics/doctype/sepa_payment_order/sepa_payment_order.json | Timestamp bumped, sort_field changed to creation, trailing newline fixed |
| banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.json | Timestamp bumped, sort_field to creation, trailing newline fixed |
| banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py | Blank line moved from before to after the auto-generated types block end marker — formatting only |
| banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.json | Timestamp bumped, sort_field to creation, trailing newline fixed; issingle DocType so sort order is effectively unused |
| banking/klarna_kosma_integration/doctype/banking_reference_mapping/banking_reference_mapping.json | Timestamp bumped, row_format Dynamic and rows_threshold_for_grid_search added, sort_field to creation; grid_page_length 50 added |
| banking/klarna_kosma_integration/doctype/banking_reference_mapping/banking_reference_mapping.py | Auto-generated type stubs added; field_name typed as DF.Literal[None] (correct for a dynamically-populated Select with no hardcoded options) |
| banking/klarna_kosma_integration/doctype/voucher_matching_default/voucher_matching_default.json | Timestamp bumped, sort_field to creation, trailing newline fixed |
| banking/klarna_kosma_integration/doctype/voucher_matching_default/voucher_matching_default.py | Blank line added before pass — trivial formatting change from v16 ruff format |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Frappe v16 DocType Save Flow] --> B[Updated modified timestamp]
    A --> C[sort_field: modified → creation]
    A --> D[New metadata fields]
    A --> E[Python type-stub regeneration]
    A --> F[Trailing newline / formatting fixes]

    D --> D1[row_format: Dynamic]
    D --> D2[rows_threshold_for_grid_search: 20]
    D --> D3[grid_page_length: 50]

    E --> E1[banking_reference_mapping.py auto-generated types added]
    E --> E2[Other .py files blank-line normalisation only]

    C --> C1[EBICS Request]
    C --> C2[EBICS User]
    C --> C3[SEPA Payment]
    C --> C4[SEPA Payment Order]
    C --> C5[Bank Reconciliation Rule]
    C --> C6[Bank Reconciliation Tool Beta]
    C --> C7[Banking Reference Mapping]
    C --> C8[Voucher Matching Default]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: resave doctypes with v16 metadata"](https://github.com/alyf-de/banking/commit/d4be029729cc43a5842fbf0c6ff6ab9d1cbd5197) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33154077)</sub>

<!-- /greptile_comment -->