### PR TITLE
ci: update v16 GitHub action versions

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -9,13 +9,19 @@ jobs:
     name: linters
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
           cache: pip
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          check-latest: true
 
       - name: Install and Run Pre-commit
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,14 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Entire Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false # https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md#pushing-packagejson-changes-to-a-master-branch
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "lts/*"
+          node-version: "24"
+          check-latest: true
       - name: Setup dependencies
         run: |
           npm install @semantic-release/git @semantic-release/exec --no-save

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -69,7 +69,7 @@ jobs:
           echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
@@ -81,7 +81,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -51,15 +51,15 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           check-latest: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.11
+    rev: v0.15.13
     hooks:
       - id: ruff
         name: "Run ruff linter and apply fixes"
@@ -57,7 +57,7 @@ repos:
           )$
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.24.0
+    rev: v9.25.0
     hooks:
       - id: commitlint
         stages: [commit-msg]


### PR DESCRIPTION
## Summary
- Update GitHub Actions pins to the v16-ready action majors.
- Add explicit Node 24 setup for linting and release workflows.
- Refresh stable pre-commit hook revisions without moving Prettier to an alpha.

## Test plan
- `pre-commit run check-yaml --files .github/workflows/linters.yaml .github/workflows/release.yaml .github/workflows/server-tests.yml .pre-commit-config.yaml`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates GitHub Actions versions across all three CI workflows to their v6 major releases (`actions/checkout`, `actions/setup-python`, `actions/setup-node`), pins the Node.js runtime to an explicit `24` (dropping `lts/*`), adds a Node.js setup step to the linters workflow for Prettier/ESLint pre-commit hooks, and refreshes `ruff` and `commitlint-pre-commit-hook` to their latest patch/minor revisions.

- All bumped action versions (`checkout@v6`, `setup-python@v6`, `setup-node@v6`) exist and are the current stable majors; the explicit Node 24 pin with `check-latest: true` is a safe, stable choice.
- The `pre-commit-config.yaml` refreshes ruff (v0.15.11 → v0.15.13) and commitlint (v9.24.0 → v9.25.0); Prettier intentionally stays at v3.1.0 to avoid an alpha.
- `actions/cache` in `server-tests.yml` is still at v4 while every other action in that file moves to v6 — the latest cache major is v5.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all action bumps target real, stable major releases and no workflow logic is changed.

The changes are purely CI infrastructure maintenance: action version bumps that all resolve to published, stable majors, a Node version pin from the floating `lts/*` to the explicit `24`, and minor pre-commit hook revisions. The only loose end is `actions/cache` remaining at v4 while everything else moves forward, which has no impact on correctness.

server-tests.yml — two `actions/cache@v4` steps were not bumped alongside the other actions in the same file.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/linters.yaml | Bumps checkout, setup-python, and setup-node to v6; adds an explicit Node.js 24 setup step needed for prettier/eslint pre-commit hooks. |
| .github/workflows/release.yaml | Bumps checkout and setup-node to v6; switches Node version from `lts/*` to the explicit `"24"` with check-latest. |
| .github/workflows/server-tests.yml | Bumps checkout, setup-python, and setup-node to v6; leaves two actions/cache steps at v4 while the current latest major is v5. |
| .pre-commit-config.yaml | Bumps ruff from v0.15.11 to v0.15.13 and commitlint-pre-commit-hook from v9.24.0 to v9.25.0; Prettier stays at v3.1.0 as intended. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[Pull Request or Push] --> LW[linters.yaml]
    PR --> SW[server-tests.yml]
    PUSH[Push to version-16] --> RW[release.yaml]

    LW --> CO1[checkout v6]
    LW --> SP1[setup-python v6 Python 3.14]
    LW --> SN1[setup-node v6 Node 24 NEW]
    LW --> PC[pre-commit action v3.0.1]
    LW --> SG[semgrep]

    SW --> CO2[checkout v6]
    SW --> SP2[setup-python v6 Python 3.14]
    SW --> SN2[setup-node v6 Node 24]
    SW --> CA[actions/cache v4 not bumped]
    SW --> IT[install and run tests]

    RW --> CO3[checkout v6 persist-credentials false]
    RW --> SN3[setup-node v6 Node 24 was lts]
    RW --> SR[npx semantic-release]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/server-tests.yml`, line 71-85 ([link](https://github.com/alyf-de/banking/blob/f7dfbb7b444831880898b92ce3550ff51393d6d9/.github/workflows/server-tests.yml#L71-L85)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> The two `actions/cache` steps are still pinned at `v4` while every other action in this PR has been bumped to its latest major. The current latest major for `actions/cache` is `v5`, which integrates with the new cache service backend. `v4` continues to work, but bumping here keeps all actions in the file at a consistent, up-to-date generation.

   

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fserver-tests.yml%0ALine%3A%2071-85%0A%0AComment%3A%0AThe%20two%20%60actions%2Fcache%60%20steps%20are%20still%20pinned%20at%20%60v4%60%20while%20every%20other%20action%20in%20this%20PR%20has%20been%20bumped%20to%20its%20latest%20major.%20The%20current%20latest%20major%20for%20%60actions%2Fcache%60%20is%20%60v5%60%2C%20which%20integrates%20with%20the%20new%20cache%20service%20backend.%20%60v4%60%20continues%20to%20work%2C%20but%20bumping%20here%20keeps%20all%20actions%20in%20the%20file%20at%20a%20consistent%2C%20up-to-date%20generation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Cache%20pip%0A%20%20%20%20%20%20%20%20uses%3A%20actions%2Fcache%40v5%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20path%3A%20~%2F.cache%2Fpip%0A%20%20%20%20%20%20%20%20%20%20key%3A%20%24%7B%7B%20runner.os%20%7D%7D-pip-%24%7B%7B%20hashFiles%28'**%2F*requirements.txt'%2C%20'**%2Fpyproject.toml'%2C%20'**%2Fsetup.py'%2C%20'**%2Fsetup.cfg'%29%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20restore-keys%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20%24%7B%7B%20runner.os%20%7D%7D-pip-%0A%20%20%20%20%20%20%20%20%20%20%20%20%24%7B%7B%20runner.os%20%7D%7D-%0A%0A%20%20%20%20%20%20-%20name%3A%20Get%20yarn%20cache%20directory%20path%0A%20%20%20%20%20%20%20%20id%3A%20yarn-cache-dir-path%0A%20%20%20%20%20%20%20%20run%3A%20echo%20%22dir%3D%24%28yarn%20cache%20dir%29%22%20%3E%3E%20%22%24GITHUB_OUTPUT%22%0A%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fcache%40v5%0A%20%20%20%20%20%20%20%20id%3A%20yarn-cache%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=372&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fserver-tests.yml%3A71-85%0AThe%20two%20%60actions%2Fcache%60%20steps%20are%20still%20pinned%20at%20%60v4%60%20while%20every%20other%20action%20in%20this%20PR%20has%20been%20bumped%20to%20its%20latest%20major.%20The%20current%20latest%20major%20for%20%60actions%2Fcache%60%20is%20%60v5%60%2C%20which%20integrates%20with%20the%20new%20cache%20service%20backend.%20%60v4%60%20continues%20to%20work%2C%20but%20bumping%20here%20keeps%20all%20actions%20in%20the%20file%20at%20a%20consistent%2C%20up-to-date%20generation.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Cache%20pip%0A%20%20%20%20%20%20%20%20uses%3A%20actions%2Fcache%40v5%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20path%3A%20~%2F.cache%2Fpip%0A%20%20%20%20%20%20%20%20%20%20key%3A%20%24%7B%7B%20runner.os%20%7D%7D-pip-%24%7B%7B%20hashFiles%28'**%2F*requirements.txt'%2C%20'**%2Fpyproject.toml'%2C%20'**%2Fsetup.py'%2C%20'**%2Fsetup.cfg'%29%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20restore-keys%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20%24%7B%7B%20runner.os%20%7D%7D-pip-%0A%20%20%20%20%20%20%20%20%20%20%20%20%24%7B%7B%20runner.os%20%7D%7D-%0A%0A%20%20%20%20%20%20-%20name%3A%20Get%20yarn%20cache%20directory%20path%0A%20%20%20%20%20%20%20%20id%3A%20yarn-cache-dir-path%0A%20%20%20%20%20%20%20%20run%3A%20echo%20%22dir%3D%24%28yarn%20cache%20dir%29%22%20%3E%3E%20%22%24GITHUB_OUTPUT%22%0A%0A%20%20%20%20%20%20-%20uses%3A%20actions%2Fcache%40v5%0A%20%20%20%20%20%20%20%20id%3A%20yarn-cache%0A%60%60%60%0A%0A&pr=372&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci: update v16 GitHub action versions"](https://github.com/alyf-de/banking/commit/f7dfbb7b444831880898b92ce3550ff51393d6d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33154078)</sub>

<!-- /greptile_comment -->