### PR TITLE
fix: harden reconciliation query sorting

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
 	from banking.overrides.bank_transaction import CustomBankTransaction
 
 MAX_QUERY_RESULTS = 150
+BANK_TRANSACTION_SORT_FIELDS = {"date", "withdrawal", "deposit", "unallocated_amount"}
+BANK_TRANSACTION_SORT_DIRECTIONS = {"asc", "desc"}
 
 
 class BankReconciliationToolBeta(Document):
@@ -63,6 +65,23 @@ class BankReconciliationToolBeta(Document):
 	pass
 
 
+def get_bank_transaction_order_by(order_by: str | None) -> str:
+	"""Validate client-provided transaction sorting before passing it to get_list."""
+	if not order_by:
+		return "date asc"
+
+	parts = order_by.strip().split()
+	if len(parts) != 2:
+		frappe.throw(_("Invalid sort order."))
+
+	fieldname, direction = parts
+	direction = direction.lower()
+	if fieldname not in BANK_TRANSACTION_SORT_FIELDS or direction not in BANK_TRANSACTION_SORT_DIRECTIONS:
+		frappe.throw(_("Invalid sort order."))
+
+	return f"{fieldname} {direction}"
+
+
 @frappe.whitelist()
 def get_bank_transactions(
 	company: str | None = None,
@@ -70,7 +89,7 @@ def get_bank_transactions(
 	bank_account: str | None = None,
 	from_date: str | datetime.date | None = None,
 	to_date: str | datetime.date | None = None,
-	order_by: str | datetime.date | None = "date asc",
+	order_by: str | None = "date asc",
 ) -> tuple[dict[str, Any], ...] | None:
 	"""Return bank transactions for a bank account"""
 	filters: list[list] = [
@@ -116,7 +135,7 @@ def get_bank_transactions(
 			"bank_party_iban",
 		],
 		filters=filters,
-		order_by=order_by,
+		order_by=get_bank_transaction_order_by(order_by),
 	)
 
 
@@ -819,9 +838,8 @@ def get_bt_matching_query(exact_match: bool, common_filters: frappe._dict, trans
 
 def get_ld_matching_query(exact_match: bool, common_filters: frappe._dict):
 	loan_disbursement = frappe.qb.DocType("Loan Disbursement")
-	matching_party = (
-		loan_disbursement.applicant_type == common_filters.party_type
-		and loan_disbursement.applicant == common_filters.matching_party
+	matching_party = (loan_disbursement.applicant_type == common_filters.party_type) & (
+		loan_disbursement.applicant == common_filters.matching_party
 	)
 
 	date_condition = (
@@ -859,18 +877,17 @@ def get_ld_matching_query(exact_match: bool, common_filters: frappe._dict):
 	)
 
 	if exact_match:
-		query.where(loan_disbursement.disbursed_amount == common_filters.amount)
+		query = query.where(loan_disbursement.disbursed_amount == common_filters.amount)
 	else:
-		query.where(loan_disbursement.disbursed_amount > 0.0)
+		query = query.where(loan_disbursement.disbursed_amount > 0.0)
 
 	return query
 
 
 def get_lr_matching_query(exact_match: bool, common_filters: frappe._dict):
 	loan_repayment = frappe.qb.DocType("Loan Repayment")
-	matching_party = (
-		loan_repayment.applicant_type == common_filters.party_type
-		and loan_repayment.applicant == common_filters.party
+	matching_party = (loan_repayment.applicant_type == common_filters.party_type) & (
+		loan_repayment.applicant == common_filters.party
 	)
 
 	date_condition = (
@@ -1060,7 +1077,15 @@ def get_je_matching_query(
 	query = (
 		frappe.qb.from_(subquery)
 		.select(
-			"*",
+			subquery.paid_amount,
+			subquery.doctype,
+			subquery.name,
+			subquery.reference_no,
+			subquery.reference_date,
+			subquery.party,
+			subquery.party_type,
+			subquery.posting_date,
+			subquery.currency,
 			rank_expression.as_("rank"),
 			ref_rank.as_("reference_number_match"),
 			amount_rank.as_("amount_match"),

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -928,9 +928,9 @@ def get_lr_matching_query(exact_match: bool, common_filters: frappe._dict):
 		query = query.where(loan_repayment.repay_from_salary == 0)
 
 	if exact_match:
-		query.where(loan_repayment.amount_paid == common_filters.amount)
+		query = query.where(loan_repayment.amount_paid == common_filters.amount)
 	else:
-		query.where(loan_repayment.amount_paid > 0.0)
+		query = query.where(loan_repayment.amount_paid > 0.0)
 
 	return query
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -67,7 +67,7 @@ class BankReconciliationToolBeta(Document):
 
 def get_bank_transaction_order_by(order_by: str | None) -> str:
 	"""Validate client-provided transaction sorting before passing it to get_list."""
-	if not order_by:
+	if not order_by or order_by == "date asc":
 		return "date asc"
 
 	parts = order_by.strip().split()


### PR DESCRIPTION
## Summary
- Validate Bank Transaction sort fields and directions before passing client-provided ordering into the query.
- Fix query-builder conditions for Loan Disbursement and Loan Repayment matching so criteria are combined and applied correctly.
- Select explicit Journal Entry subquery columns instead of `*`; this may mechanically conflict with the PR346 backport, but the change is independent.