### PR TITLE
fix: check all successful EBICS requests

### DIFF
--- a/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/banking_settings.py
@@ -114,32 +114,29 @@ def daily_sync_ebics():
 
 
 def successful_request_exists(ebics_user: str | None, order_type: str, request_date: date) -> bool:
-	existing_request = frappe.db.get_value(
+	existing_requests = frappe.get_all(
 		"EBICS Request",
-		{
+		filters={
 			"ebics_user": ebics_user,
 			"order_type": order_type,
 			"status": "Successful",
 		},
-		["name", "parameters"],
-		as_dict=True,
+		fields=["parameters"],
 	)
 
-	if not existing_request:
-		return False
-
-	try:
-		params = json.loads(existing_request.parameters)
-		start_date = params.get("start_date")
-		end_date = params.get("end_date")
-		if (
-			start_date
-			and end_date
-			and date.fromisoformat(start_date) <= request_date <= date.fromisoformat(end_date)
-		):
-			return True
-	except json.JSONDecodeError:
-		pass  # If we can't parse, let the sync attempt
+	for existing_request in existing_requests:
+		try:
+			params = json.loads(existing_request.parameters)
+			start_date = params.get("start_date")
+			end_date = params.get("end_date")
+			if (
+				start_date
+				and end_date
+				and date.fromisoformat(start_date) <= request_date <= date.fromisoformat(end_date)
+			):
+				return True
+		except json.JSONDecodeError:
+			pass  # If we can't parse, let the sync attempt
 
 	return False
 

--- a/banking/klarna_kosma_integration/doctype/banking_settings/test_banking_settings.py
+++ b/banking/klarna_kosma_integration/doctype/banking_settings/test_banking_settings.py
@@ -19,6 +19,11 @@ class TestBankingSettings(FrappeTestCase):
 			self.assertTrue(successful_request_exists(None, request.order_type, date(2025, 1, 1)))
 			self.assertFalse(successful_request_exists(None, request.order_type, date(2025, 1, 2)))
 
+	def test_successful_request_exists_checks_all_matching_requests(self):
+		with create_successful_request("C53", date(2025, 1, 2), date(2025, 1, 2)):
+			with create_successful_request("C53", date(2025, 1, 1), date(2025, 1, 1)):
+				self.assertTrue(successful_request_exists(None, "C53", date(2025, 1, 1)))
+
 
 @contextmanager
 def create_successful_request(order_type: str, start_date: date, end_date: date):


### PR DESCRIPTION
- Check every matching successful **EBICS Request** when deciding whether a request date was already covered.
- Add a regression test for multiple successful requests where only a later row might be returned first.
