### PR TITLE
chore: fix eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,11 @@
-import js from "@eslint/js";
-import globals from "globals";
+import { realpathSync } from "node:fs";
+import { createRequire } from "node:module";
+
+// pre-commit installs ESLint dependencies next to the ESLint binary, not in the repo.
+const eslintRequire = createRequire(realpathSync(process.argv[1]));
+
+const js = eslintRequire("@eslint/js");
+const globals = eslintRequire("globals");
 
 export default [
 	js.configs.recommended,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,8 +4,8 @@ import { createRequire } from "node:module";
 // pre-commit installs ESLint dependencies next to the ESLint binary, not in the repo.
 const eslintRequire = createRequire(realpathSync(process.argv[1]));
 
-const js = eslintRequire("@eslint/js");
-const globals = eslintRequire("globals");
+const js = (await import(eslintRequire.resolve("@eslint/js"))).default;
+const globals = (await import(eslintRequire.resolve("globals"))).default;
 
 export default [
 	js.configs.recommended,


### PR DESCRIPTION
Fixed the CI ESLint failure in `eslint.config.mjs`.

The config now resolves `@eslint/js` and `globals` from the ESLint executable’s install location, which matches how `pre-commit` installs node hook dependencies in GitHub Actions.

Verified with:
- `pre-commit run prettier --files eslint.config.mjs`
- `pre-commit run eslint --files eslint.config.mjs`
- fresh `pre-commit==4.6.0` ESLint run before cleanup

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CI ESLint failure in `eslint.config.mjs` by changing how `@eslint/js` and `globals` are resolved. Instead of using static ESM imports (which fail because pre-commit installs hook dependencies next to the ESLint binary rather than in the repo), the config now uses `createRequire` to resolve module paths relative to the ESLint executable, then loads them via dynamic `await import()`.

- `createRequire(realpathSync(process.argv[1]))` creates a CJS resolver anchored at the ESLint binary's real location, so `eslintRequire.resolve()` finds packages in pre-commit's installed node_modules.
- Dynamic `import()` (not `require()`) is used to actually load the resolved modules, which means ESM-only packages like `globals` v14+ are handled correctly without risking `ERR_REQUIRE_ESM`.

<h3>Confidence Score: 5/5</h3>

The change is a targeted, well-reasoned fix that correctly resolves module paths from the ESLint binary's location and loads them via ESM dynamic import, making it safe to merge.

The approach is sound: using eslintRequire.resolve() only to obtain the file path avoids any CJS/ESM incompatibility, and the subsequent await import() handles both CJS and ESM-only packages correctly. The author verified the fix with a fresh pre-commit run.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| eslint.config.mjs | Replaces static ESM imports with a createRequire + dynamic import() pattern to resolve dependencies from the ESLint binary's location; handles both CJS and ESM packages correctly. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: update ESLint config to use dynam..."](https://github.com/alyf-de/banking/commit/a67d316c23f9b5743ff7aeaf228fc2c7f50bf87b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33164900)</sub>

<!-- /greptile_comment -->