### PR TITLE
chore: install node in linter workflow

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -17,6 +17,12 @@ jobs:
           python-version: '3.14'
           cache: pip
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          check-latest: true
+
       - name: Install and Run Pre-commit
         uses: pre-commit/action@v3.0.1
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Node.js 24 setup step to the linter workflow, ensuring a compatible Node runtime is available before pre-commit hooks run. It also fixes a missing trailing newline at the end of the file.

- Inserts `actions/setup-node@v4` with `node-version: 24` and `check-latest: true` so Node-based pre-commit hooks (e.g. Prettier, ESLint) have the correct runtime available.
- Cleans up the missing newline at end of file on the `semgrep ci` run step.

<h3>Confidence Score: 5/5</h3>

This is a minimal CI configuration change that adds a Node.js runtime setup step and fixes a missing trailing newline — safe to merge.

The change is limited to adding a well-known, widely-used setup action (actions/setup-node@v4) with a standard Node.js 24 configuration. The check-latest flag adds a small network call each run but is not harmful. The trailing-newline fix is purely cosmetic. No logic, application code, or security-sensitive paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/linters.yaml | Adds a `Setup Node` step (Node.js 24, check-latest) before the pre-commit action, and fixes a missing trailing newline at EOF. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant PY as actions/setup-python@v5
    participant NODE as actions/setup-node@v4
    participant PC as pre-commit/action@v3.0.1
    participant SG as semgrep

    GH->>PY: Set up Python 3.14
    GH->>NODE: Setup Node 24 (check-latest)
    GH->>PC: Install and Run Pre-commit hooks
    GH->>SG: Download semgrep rules (git clone)
    GH->>SG: pip install semgrep
    GH->>SG: semgrep ci --config rules
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: install node in linter workflow"](https://github.com/alyf-de/banking/commit/78bdeb1eaf471f43da6059a6252919f07cbfe62b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33165933)</sub>

<!-- /greptile_comment -->