### PR TITLE
feat: section "Accounting Dimensions" in "Create Voucher" tab

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -131,6 +131,8 @@ def create_journal_entry_bts(
 	mode_of_payment: str | None = None,
 	party_type: str | None = None,
 	party: str | None = None,
+	project: str | None = None,
+	cost_center: str | None = None,
 	allow_edit: bool | str = False,
 ):
 	"""Create a new Journal Entry for Reconciling the Bank Transaction"""
@@ -180,14 +182,14 @@ def create_journal_entry_bts(
 				"debit_in_account_currency": bank_credit_amount,
 				"party_type": party_type,
 				"party": party,
-				"cost_center": get_default_cost_center(company),
+				"cost_center": cost_center or get_default_cost_center(company),
+				"project": project,
 			},
 			{
 				"account": bank_gl_account,
 				"bank_account": bank_transaction.bank_account,
 				"credit_in_account_currency": bank_credit_amount,
 				"debit_in_account_currency": bank_debit_amount,
-				"cost_center": get_default_cost_center(company),
 			},
 		],
 	)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -156,6 +156,10 @@ def create_journal_entry_bts(
 	second_account_type, second_account_currency = frappe.db.get_value(
 		"Account", second_account, ["account_type", "account_currency"]
 	)
+
+	if not cost_center:
+		cost_center = get_default_cost_center(company)
+
 	if second_account_type in ["Receivable", "Payable"] and not (party_type and party):
 		frappe.throw(
 			_("Party Type and Party is required for Receivable / Payable account {0}").format(second_account)
@@ -182,7 +186,7 @@ def create_journal_entry_bts(
 				"debit_in_account_currency": bank_credit_amount,
 				"party_type": party_type,
 				"party": party,
-				"cost_center": cost_center or get_default_cost_center(company),
+				"cost_center": cost_center,
 				"project": project,
 			},
 			{
@@ -190,6 +194,7 @@ def create_journal_entry_bts(
 				"bank_account": bank_transaction.bank_account,
 				"credit_in_account_currency": bank_credit_amount,
 				"debit_in_account_currency": bank_debit_amount,
+				"cost_center": cost_center,
 			},
 		],
 	)

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
@@ -68,15 +68,12 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 			posting_date: values.posting_date,
 			mode_of_payment: values.mode_of_payment,
 			allow_edit: allow_edit,
+			project: values.project,
+			cost_center: values.cost_center,
 		};
 
 		if (document_type === "Payment Entry") {
 			method = method + ".create_payment_entry_bts";
-			args = {
-				...args,
-				project: values.project,
-				cost_center: values.cost_center,
-			};
 		} else {
 			method = method + ".create_journal_entry_bts";
 			args = {
@@ -210,14 +207,6 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 				options: "Mode of Payment",
 			},
 			{
-				fieldname: "edit_in_full_page",
-				fieldtype: "Button",
-				label: __("Edit in Full Page"),
-				click: () => {
-					this.edit_in_full_page();
-				},
-			},
-			{
 				fieldname: "column_break_7",
 				fieldtype: "Column Break",
 			},
@@ -272,27 +261,53 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 				reqd: 1,
 			},
 			{
-				fieldname: "project",
-				fieldtype: "Link",
-				label: "Project",
-				options: "Project",
-				depends_on: "eval: doc.document_type == 'Payment Entry'",
+				fieldname: "accounting_dimensions_section",
+				fieldtype: "Section Break",
+				label: __("Accounting Dimensions"),
+				collapsible: 1,
+				collapsed: 1,
 			},
 			{
 				fieldname: "cost_center",
 				fieldtype: "Link",
-				label: "Cost Center",
+				label: __("Cost Center"),
 				options: "Cost Center",
-				depends_on: "eval: doc.document_type == 'Payment Entry'",
+				get_query: () => {
+					return {
+						filters: {
+							company: this.company,
+							is_group: 0,
+						},
+					};
+				},
+			},
+			{
+				fieldname: "dimension_col_break",
+				fieldtype: "Column Break",
+			},
+			{
+				fieldname: "project",
+				fieldtype: "Link",
+				label: __("Project"),
+				options: "Project",
+				get_query: () => {
+					return {
+						filters: {
+							company: this.company,
+						},
+					};
+				},
 			},
 			{
 				fieldtype: "Section Break",
 			},
 			{
-				label: __("Hidden field for alignment"),
-				fieldname: "hidden_field",
-				fieldtype: "Data",
-				hidden: 1,
+				fieldname: "edit_in_full_page",
+				fieldtype: "Button",
+				label: __("Edit in Full Page"),
+				click: () => {
+					this.edit_in_full_page();
+				},
 			},
 			{
 				fieldtype: "Column Break",

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
@@ -15,6 +15,7 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 			card_layout: true,
 		});
 		this.create_field_group.make();
+		this.create_field_group.refresh_section_collapse();
 	}
 
 	create_voucher() {
@@ -265,7 +266,6 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 				fieldtype: "Section Break",
 				label: __("Accounting Dimensions"),
 				collapsible: 1,
-				collapsed: 1,
 			},
 			{
 				fieldname: "cost_center",


### PR DESCRIPTION
- Group _Cost Center_ and _Project_ into a collapsible *Accounting Dimensions* section in the bank reconciliation **Create Voucher** tab, shown for both **Payment Entry** and **Journal Entry** (previously these were Payment-Entry-only).
- Pass `cost_center` / `project` to `create_journal_entry_bts` (`cost_center` falls back to the company default).
- Add company-scoped `get_query` filters on both fields (and `is_group: 0` for _Cost Center_) so only valid values are selectable.
- Minor layout tidy-up of the tab and translatable field labels.
