### PR TITLE
fix: apply project to both legs of Journal Entry

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -214,6 +214,7 @@ def create_journal_entry_bts(
 				"credit_in_account_currency": bank_credit_amount,
 				"debit_in_account_currency": bank_debit_amount,
 				"cost_center": cost_center,
+				"project": project,
 			},
 		],
 	)


### PR DESCRIPTION
This is the same way Payment Entry handles it.
It ensures that filters on Balance Sheet produce sensible (balanced) results.
