### PR TITLE
fix!: remove date filter from matched vouchers

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.js
@@ -44,16 +44,6 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 		}
 	},
 
-	filter_by_reference_date: function (frm) {
-		if (frm.doc.filter_by_reference_date) {
-			frm.set_value("bank_statement_from_date", "");
-			frm.set_value("bank_statement_to_date", "");
-		} else {
-			frm.set_value("from_reference_date", "");
-			frm.set_value("to_reference_date", "");
-		}
-	},
-
 	/**
 	 * Handles reconcile-time currency conversion for mismatched voucher selections.
 	 *
@@ -111,9 +101,6 @@ frappe.ui.form.on("Bank Reconciliation Tool Beta", {
 							bank_account: frm.doc.bank_account,
 							from_date: frm.doc.bank_statement_from_date,
 							to_date: frm.doc.bank_statement_to_date,
-							filter_by_reference_date: frm.doc.filter_by_reference_date,
-							from_reference_date: frm.doc.from_reference_date,
-							to_reference_date: frm.doc.to_reference_date,
 						},
 						freeze: true,
 						freeze_message: __("Auto Reconciling ..."),

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.json
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.json
@@ -16,9 +16,6 @@
   "column_break_1",
   "bank_statement_from_date",
   "bank_statement_to_date",
-  "from_reference_date",
-  "to_reference_date",
-  "filter_by_reference_date",
   "section_break_1",
   "reconciliation_tool_cards",
   "reconciliation_action_area"
@@ -70,34 +67,14 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval: !doc.filter_by_reference_date",
    "fieldname": "bank_statement_from_date",
    "fieldtype": "Date",
    "label": "From Date"
   },
   {
-   "depends_on": "eval: !doc.filter_by_reference_date",
    "fieldname": "bank_statement_to_date",
    "fieldtype": "Date",
    "label": "To Date"
-  },
-  {
-   "depends_on": "eval:doc.filter_by_reference_date",
-   "fieldname": "from_reference_date",
-   "fieldtype": "Date",
-   "label": "From Reference Date"
-  },
-  {
-   "depends_on": "eval:doc.filter_by_reference_date",
-   "fieldname": "to_reference_date",
-   "fieldtype": "Date",
-   "label": "To Reference Date"
-  },
-  {
-   "default": "0",
-   "fieldname": "filter_by_reference_date",
-   "fieldtype": "Check",
-   "label": "Filter by Reference Date"
   },
   {
    "fieldname": "section_break_1",
@@ -123,7 +100,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-05-21 02:05:38.999291",
+ "modified": "2026-06-02 06:51:36.041676",
  "modified_by": "Administrator",
  "module": "Klarna Kosma Integration",
  "name": "Bank Reconciliation Tool Beta",

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -58,10 +58,8 @@ class BankReconciliationToolBeta(Document):
 		bank_statement_from_date: DF.Date | None
 		bank_statement_to_date: DF.Date | None
 		company: DF.Link | None
-		filter_by_reference_date: DF.Check
-		from_reference_date: DF.Date | None
-		to_reference_date: DF.Date | None
 	# end: auto-generated types
+
 	pass
 
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -643,6 +643,11 @@ def get_queries(
 				document_types,
 				exact_match,
 				account_from_to,
+				from_date=None,
+				to_date=None,
+				filter_by_reference_date=False,
+				from_reference_date=None,
+				to_reference_date=None,
 				common_filters=common_filters,
 			)
 			or []
@@ -658,8 +663,12 @@ def get_matching_queries(
 	document_types: list,
 	exact_match: bool = False,
 	account_from_to: str | None = None,
+	from_date: str | datetime.date | None = None,
+	to_date: str | datetime.date | None = None,
+	filter_by_reference_date: bool = False,
+	from_reference_date: str | datetime.date | None = None,
+	to_reference_date: str | datetime.date | None = None,
 	common_filters: frappe._dict | None = None,
-	**kwargs,
 ):
 	if not common_filters:
 		common_filters = frappe._dict()

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -17,7 +17,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import Cast, Coalesce, Sum
-from frappe.utils import cint, flt, sbool
+from frappe.utils import flt, sbool
 from pypika import Order
 
 from banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.utils import (
@@ -404,9 +404,6 @@ def auto_reconcile_vouchers(
 	bank_account: str | None = None,
 	from_date: str | datetime.date | None = None,
 	to_date: str | datetime.date | None = None,
-	filter_by_reference_date: str | bool = False,
-	from_reference_date: str | datetime.date | None = None,
-	to_reference_date: str | datetime.date | None = None,
 ):
 	# Auto reconcile vouchers with matching reference numbers
 	frappe.flags.auto_reconcile_vouchers = True
@@ -419,11 +416,6 @@ def auto_reconcile_vouchers(
 		linked_payments = get_linked_payments(
 			transaction.name,
 			["payment_entry", "journal_entry"],
-			from_date,
-			to_date,
-			filter_by_reference_date,
-			from_reference_date,
-			to_reference_date,
 		)
 
 		if not linked_payments:
@@ -478,11 +470,6 @@ def auto_reconcile_vouchers(
 def get_linked_payments(
 	bank_transaction_name: str,
 	document_types: str | list,
-	from_date: str | datetime.date | None = None,
-	to_date: str | datetime.date | None = None,
-	filter_by_reference_date: str | bool = False,
-	from_reference_date: str | datetime.date | None = None,
-	to_reference_date: str | datetime.date | None = None,
 ) -> list:
 	"""Get all matching payments for a bank transaction"""
 	transaction: CustomBankTransaction = frappe.get_doc("Bank Transaction", bank_transaction_name)
@@ -500,11 +487,6 @@ def get_linked_payments(
 		company,
 		transaction,
 		document_types,
-		from_date,
-		to_date,
-		sbool(filter_by_reference_date),
-		from_reference_date,
-		to_reference_date,
 	)
 	subtract_allocations(gl_account, vouchers=matching)
 
@@ -599,11 +581,6 @@ def check_matching(
 	company: str,
 	transaction: CustomBankTransaction,
 	document_types: list,
-	from_date: str | datetime.date | None = None,
-	to_date: str | datetime.date | None = None,
-	filter_by_reference_date: bool = False,
-	from_reference_date: str | datetime.date | None = None,
-	to_reference_date: str | datetime.date | None = None,
 ):
 	common_filters = frappe._dict(
 		amount=transaction.unallocated_amount,
@@ -621,11 +598,6 @@ def check_matching(
 		company,
 		transaction,
 		document_types,
-		from_date,
-		to_date,
-		filter_by_reference_date,
-		from_reference_date,
-		to_reference_date,
 		common_filters,
 	)
 
@@ -656,11 +628,6 @@ def get_queries(
 	company: str,
 	transaction: CustomBankTransaction,
 	document_types: list,
-	from_date: str | datetime.date | None = None,
-	to_date: str | datetime.date | None = None,
-	filter_by_reference_date: bool = False,
-	from_reference_date: str | datetime.date | None = None,
-	to_reference_date: str | datetime.date | None = None,
 	common_filters: frappe._dict | None = None,
 ):
 	# get queries to get matching vouchers
@@ -678,12 +645,7 @@ def get_queries(
 				document_types,
 				exact_match,
 				account_from_to,
-				from_date,
-				to_date,
-				filter_by_reference_date,
-				from_reference_date,
-				to_reference_date,
-				common_filters,
+				common_filters=common_filters,
 			)
 			or []
 		)
@@ -698,12 +660,8 @@ def get_matching_queries(
 	document_types: list,
 	exact_match: bool = False,
 	account_from_to: str | None = None,
-	from_date: str | datetime.date | None = None,
-	to_date: str | datetime.date | None = None,
-	filter_by_reference_date: bool = False,
-	from_reference_date: str | datetime.date | None = None,
-	to_reference_date: str | datetime.date | None = None,
 	common_filters: frappe._dict | None = None,
+	**kwargs,
 ):
 	if not common_filters:
 		common_filters = frappe._dict()
@@ -722,11 +680,6 @@ def get_matching_queries(
 			exact_match,
 			common_filters,
 			account_from_to,
-			from_date,
-			to_date,
-			filter_by_reference_date,
-			from_reference_date,
-			to_reference_date,
 		)
 		queries.append(query)
 
@@ -735,11 +688,6 @@ def get_matching_queries(
 		query = get_je_matching_query(
 			exact_match,
 			common_filters,
-			from_date,
-			to_date,
-			filter_by_reference_date,
-			from_reference_date,
-			to_reference_date,
 			transaction.name,
 		)
 		queries.append(query)
@@ -947,11 +895,6 @@ def get_pe_matching_query(
 	exact_match: bool,
 	common_filters: frappe._dict,
 	account_from_to: str,
-	from_date: str | datetime.date | None = None,
-	to_date: str | datetime.date | None = None,
-	filter_by_reference_date: bool = False,
-	from_reference_date: str | datetime.date | None = None,
-	to_reference_date: str | datetime.date | None = None,
 ):
 	pe = frappe.qb.DocType("Payment Entry")
 	to_from = "to" if common_filters.payment_type == "Receive" else "from"
@@ -969,10 +912,6 @@ def get_pe_matching_query(
 		& (pe.party.isnotnull())
 	)
 	party_rank = frappe.qb.terms.Case().when(party_filter, 1).else_(0)
-
-	filter_by_date = pe.posting_date.between(from_date, to_date)
-	if cint(filter_by_reference_date):
-		filter_by_date = pe.reference_date.between(from_reference_date, to_reference_date)
 
 	date_condition = Coalesce(pe.reference_date, pe.posting_date) == common_filters.date
 	date_rank = frappe.qb.terms.Case().when(date_condition, 1).else_(0)
@@ -1003,7 +942,6 @@ def get_pe_matching_query(
 		.where(pe.clearance_date.isnull())
 		.where(getattr(pe, account_from_to) == common_filters.bank_account)
 		.where(amount_filter)
-		.where(filter_by_date)
 		.orderby(rank_expression, order=Order.desc)
 		.limit(MAX_QUERY_RESULTS)
 	)
@@ -1019,11 +957,6 @@ def get_pe_matching_query(
 def get_je_matching_query(
 	exact_match: bool,
 	common_filters: frappe._dict,
-	from_date: str | datetime.date | None = None,
-	to_date: str | datetime.date | None = None,
-	filter_by_reference_date: bool = False,
-	from_reference_date: str | datetime.date | None = None,
-	to_reference_date: str | datetime.date | None = None,
 	bank_transaction_name: str | None = None,
 ):
 	# get matching journal entry query
@@ -1035,10 +968,6 @@ def get_je_matching_query(
 
 	cr_or_dr = "credit" if common_filters.payment_type == "Pay" else "debit"
 	amount_field = getattr(jea, f"{cr_or_dr}_in_account_currency")
-
-	filter_by_date = je.posting_date.between(from_date, to_date)
-	if cint(filter_by_reference_date):
-		filter_by_date = je.cheque_date.between(from_reference_date, to_reference_date)
 
 	subquery = (
 		frappe.qb.from_(jea)
@@ -1059,9 +988,8 @@ def get_je_matching_query(
 		.where(je.voucher_type != "Opening Entry")
 		.where(je.clearance_date.isnull())
 		.where(jea.account == common_filters.bank_account)
-		.where(filter_by_date)
 		.groupby(je.name)
-		.orderby(je.cheque_date if cint(filter_by_reference_date) else je.posting_date)
+		.orderby(je.posting_date)
 	)
 
 	if bank_transaction_name:

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -472,8 +472,36 @@ def auto_reconcile_vouchers(
 def get_linked_payments(
 	bank_transaction_name: str,
 	document_types: str | list,
+	from_date: str | datetime.date | None = None,
+	to_date: str | datetime.date | None = None,
+	filter_by_reference_date: str | bool | None = None,
+	from_reference_date: str | datetime.date | None = None,
+	to_reference_date: str | datetime.date | None = None,
 ) -> list:
-	"""Get all matching payments for a bank transaction"""
+	"""Get all matching payments for a bank transaction.
+
+	Date arguments are accepted for compatibility with stale clients, but voucher
+	matching is intentionally not date-filtered.
+	"""
+	if any(
+		arg is not None
+		for arg in (
+			from_date,
+			to_date,
+			filter_by_reference_date,
+			from_reference_date,
+			to_reference_date,
+		)
+	):
+		from frappe.deprecation_dumpster import deprecation_warning
+
+		deprecation_warning(
+			"2026-06-29",
+			"v17",
+			"Date filter arguments for get_linked_payments are deprecated and ignored. "
+			"Use statement date filters only when fetching Bank Transactions.",
+		)
+
 	transaction: CustomBankTransaction = frappe.get_doc("Bank Transaction", bank_transaction_name)
 	transaction.check_permission("read")
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -466,7 +466,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 			bank_account=self.bank_account,
 			from_date=day_before_yesterday,
 			to_date=add_days(getdate(), 1),
-			filter_by_reference_date=False,
 		)
 		bt.reload()
 
@@ -588,8 +587,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched_vouchers = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["sales_invoice", "unpaid_invoices"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		first_match, second_match = matched_vouchers[0], matched_vouchers[1]
 
@@ -631,8 +628,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched_vouchers = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["sales_invoice", "unpaid_invoices"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		first_match = matched_vouchers[0]
 
@@ -679,8 +674,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched_vouchers = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["journal_entry"],
-			from_date=getdate(),
-			to_date=getdate(),
 		)
 		first_match = matched_vouchers[0]
 
@@ -720,8 +713,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["purchase_invoice", "unpaid_invoices"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		pi_match = next(m for m in matched if m["name"] == pi.name)
 		self.assertEqual(pi_match["paid_amount"], 100)  # converted from 8000 INR
@@ -772,8 +763,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["purchase_invoice", "unpaid_invoices"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		pi_match = next(m for m in matched if m["name"] == pi.name)
 		self.assertEqual(pi_match["paid_amount"], 8000)  # INR, unchanged
@@ -828,8 +817,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["sales_invoice", "unpaid_invoices"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		si_match = next(m for m in matched if m["name"] == si.name)
 		self.assertEqual(si_match["paid_amount"], 100)  # converted from 8000 INR
@@ -881,8 +868,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["sales_invoice", "unpaid_invoices"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		si_match = next(m for m in matched if m["name"] == si.name)
 		self.assertEqual(si_match["paid_amount"], 8000)  # INR, unchanged

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -14,6 +14,7 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
 )
 from erpnext.accounts.test.accounts_mixin import AccountsTestMixin
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+from frappe.deprecation_dumpster import PendingFrappeDeprecationWarning
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, getdate
 from hrms.hr.doctype.expense_claim.test_expense_claim import make_expense_claim
@@ -659,8 +660,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched_vouchers = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["sales_invoice", "unpaid_invoices"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		first_match = matched_vouchers[0]
 
@@ -668,6 +667,17 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(first_match["name"], si.name)
 		self.assertEqual(first_match["rank"], 5)
 		self.assertEqual(first_match["reference_number_match"], 1)
+
+	def test_legacy_date_filters_emit_deprecation_warning(self):
+		bt = create_bank_transaction(deposit=300, bank_account=self.bank_account)
+
+		with self.assertWarns(PendingFrappeDeprecationWarning):
+			get_linked_payments(
+				bank_transaction_name=bt.name,
+				document_types=["sales_invoice", "unpaid_invoices"],
+				from_date=add_days(getdate(), -1),
+				to_date=add_days(getdate(), 1),
+			)
 
 	def test_split_jv_match_against_transaction(self):
 		"""
@@ -762,8 +772,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched_vouchers = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["journal_entry"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		matched_names = [voucher["name"] for voucher in matched_vouchers]
 
@@ -806,8 +814,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched_vouchers = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["journal_entry"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		matched_names = [voucher["name"] for voucher in matched_vouchers]
 
@@ -1001,8 +1007,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["sales_invoice", "unpaid_invoices", "exact_match"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		si_match = next(m for m in matched if m["name"] == si.name)
 		self.assertEqual(si_match["paid_amount"], 8000)
@@ -1134,8 +1138,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["sales_invoice", "unpaid_invoices", "exact_match"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		si_match = next(m for m in matched if m["name"] == si.name)
 		self.assertEqual(si_match["paid_amount"], 113)
@@ -1289,8 +1291,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["sales_invoice", "unpaid_invoices", "exact_match"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		si_match = next(m for m in matched if m["name"] == si.name)
 		self.assertEqual(si_match["paid_amount"], 80)
@@ -1448,8 +1448,6 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		matched = get_linked_payments(
 			bank_transaction_name=bt.name,
 			document_types=["sales_invoice", "unpaid_invoices", "exact_match"],
-			from_date=add_days(getdate(), -1),
-			to_date=add_days(getdate(), 1),
 		)
 		matched_names = [voucher["name"] for voucher in matched]
 		self.assertIn(si.name, matched_names)

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -71,11 +71,6 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 				args: {
 					bank_transaction_name: this.transaction.name,
 					document_types: document_types,
-					from_date: this.frm.doc.bank_statement_from_date,
-					to_date: this.frm.doc.bank_statement_to_date,
-					filter_by_reference_date: this.frm.doc.filter_by_reference_date,
-					from_reference_date: this.frm.doc.from_reference_date,
-					to_reference_date: this.frm.doc.to_reference_date,
 				},
 			})
 			.then((result) => result.message);


### PR DESCRIPTION
tl;dr: Payment Entry & Journal Entry in "Match Voucher" are no longer filtered by date, matching the other voucher types. We remove these filters wherever we don't need them.

Statement date filters were applied inconsistently: they scoped bank transactions and Payment Entry / Journal Entry matching, but not invoices or other voucher types. That made the same date fields mean different things depending on voucher type, and optional or partial dates could silently return no PE/JE matches.

Date filters now only define the statement period you are reconciling. Voucher discovery is per bank transaction and relies on ranking (amount, reference, party, date proximity) instead of hard date cutoffs, so older open invoices and backdated entries remain matchable.

Removed the reference-date filter UI because it only ever affected PE/JE and no longer matches how matching works.

