### PR TITLE
fix: rank vouchers when reference matches bank transaction

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -1185,11 +1185,7 @@ def get_si_matching_query(
 	# Check reference field equality with common_filters.reference_no
 	reference_field_is_set = reference_field and reference_field != "name"
 	reference_number = common_filters.reference_no
-	ref_rank = (
-		ref_equality_condition(si[reference_field], reference_number)
-		if (reference_number and reference_field_is_set)
-		else Cast(0, "int")
-	)
+	ref_rank = ref_equality_condition(si[reference_field or "name"], reference_number)
 
 	# if ref field is configured (!= name), perform desc-name and desc-ref match
 	# otherwise (== name), then perform desc-name match once
@@ -1282,11 +1278,7 @@ def get_unpaid_si_matching_query(
 	# Check reference field equality with common_filters.reference_no
 	reference_field_is_set = reference_field and reference_field != "name"
 	reference_number = common_filters.reference_no
-	ref_rank = (
-		ref_equality_condition(sales_invoice[reference_field], reference_number)
-		if (reference_number and reference_field_is_set)
-		else Cast(0, "int")
-	)
+	ref_rank = ref_equality_condition(sales_invoice[reference_field or "name"], reference_number)
 
 	# if ref field is configured (!= name), perform desc-name and desc-ref match
 	# otherwise (== name), then perform desc-name match once
@@ -1381,11 +1373,7 @@ def get_pi_matching_query(
 	# Check reference field equality with common_filters.reference_no
 	reference_field_is_set = reference_field and reference_field != "name"
 	reference_number = common_filters.reference_no
-	ref_rank = (
-		ref_equality_condition(purchase_invoice[reference_field], reference_number)
-		if (reference_number and reference_field_is_set)
-		else Cast(0, "int")
-	)
+	ref_rank = ref_equality_condition(purchase_invoice[reference_field or "name"], reference_number)
 
 	# if ref field is configured (!= name), perform desc-name and desc-ref match
 	# otherwise (== name), then perform desc-name match once
@@ -1483,11 +1471,7 @@ def get_unpaid_pi_matching_query(
 	# Check reference field equality with common_filters.reference_no
 	reference_field_is_set = reference_field and reference_field != "name"
 	reference_number = common_filters.reference_no
-	ref_rank = (
-		ref_equality_condition(purchase_invoice[reference_field], reference_number)
-		if (reference_number and reference_field_is_set)
-		else Cast(0, "int")
-	)
+	ref_rank = ref_equality_condition(purchase_invoice[reference_field or "name"], reference_number)
 
 	# if ref field is configured (!= name), perform desc-name and desc-ref match
 	# otherwise (== name), then perform desc-name match once
@@ -1574,11 +1558,7 @@ def get_unpaid_ec_matching_query(
 	# Check reference field equality with common_filters.reference_no
 	reference_field_is_set = reference_field and reference_field != "name"
 	reference_number = common_filters.reference_no
-	ref_rank = (
-		ref_equality_condition(expense_claim[reference_field], reference_number)
-		if (reference_number and reference_field_is_set)
-		else Cast(0, "int")
-	)
+	ref_rank = ref_equality_condition(expense_claim[reference_field or "name"], reference_number)
 
 	# if ref field is configured (!= name), perform desc-name and desc-ref match
 	# otherwise (== name), then perform desc-name match once

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -717,6 +717,35 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(first_match["amount_match"], 1)
 		self.assertEqual(first_match["ref_in_desc_match"], 0)
 
+	def test_default_reference_field_matches_bank_transaction_reference_number(self):
+		si = create_sales_invoice(
+			rate=300,
+			warehouse="Finished Goods - _TC",
+			customer=self.customer,
+			cost_center="Main - _TC",
+			item="Reco Item",
+		)
+		bt = create_bank_transaction(
+			date=getdate(),
+			deposit=300,
+			reference_no=si.name,
+			bank_account=self.bank_account,
+			description="Customer transfer",
+		)
+
+		matched_vouchers = get_linked_payments(
+			bank_transaction_name=bt.name,
+			document_types=["sales_invoice", "unpaid_invoices"],
+			from_date=add_days(getdate(), -1),
+			to_date=add_days(getdate(), 1),
+		)
+		first_match = matched_vouchers[0]
+
+		self.assertEqual(first_match["reference_no"], si.name)
+		self.assertEqual(first_match["name"], si.name)
+		self.assertEqual(first_match["rank"], 5)
+		self.assertEqual(first_match["reference_number_match"], 1)
+
 	def test_split_jv_match_against_transaction(self):
 		"""
 		Test if a split JV shows up as a single consolidated row in the tool


### PR DESCRIPTION
Fix voucher matching so the displayed Reference field is treated as a bank transaction reference match even when it falls back to the voucher name. This increases the voucher rank and bolds the Reference column as expected.