### PR TITLE
Reliable reconcile with full page edit

### DIFF
--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -125,6 +125,14 @@ doc_events = {
 		"before_validate": "banking.overrides.bank_account.before_validate",
 		"validate": "banking.overrides.bank_account.validate",
 	},
+	"Journal Entry": {
+		"on_submit": "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile.reconcile_if_pending",
+		"on_trash": "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile.clear_if_pending",
+	},
+	"Payment Entry": {
+		"on_submit": "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile.reconcile_if_pending",
+		"on_trash": "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile.clear_if_pending",
+	},
 	"Employee": {
 		"validate": "banking.custom.employee.validate",
 	},

--- a/banking/hooks.py
+++ b/banking/hooks.py
@@ -126,10 +126,12 @@ doc_events = {
 		"validate": "banking.overrides.bank_account.validate",
 	},
 	"Journal Entry": {
+		"before_submit": "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile.validate_pending_reconcile_amount",
 		"on_submit": "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile.reconcile_if_pending",
 		"on_trash": "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile.clear_if_pending",
 	},
 	"Payment Entry": {
+		"before_submit": "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile.validate_pending_reconcile_amount",
 		"on_submit": "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile.reconcile_if_pending",
 		"on_trash": "banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile.clear_if_pending",
 	},

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -397,7 +397,7 @@ def bulk_reconcile_vouchers(
 def reconcile_voucher(
 	transaction_name: str, amount: float, voucher_type: str, voucher_name: str
 ) -> Union[dict, "CustomBankTransaction"]:
-	"""Reconcile a entry with a bank transaction. Called on `doc_update` websocket event."""
+	"""Reconcile an entry with a bank transaction."""
 
 	# Newly created voucher was deleted
 	if not frappe.db.exists(voucher_type, voucher_name):

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -22,6 +22,9 @@ from frappe.utils import cint, flt, sbool
 from pypika import Order
 from pypika.terms import ExistsCriterion
 
+from banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile import (
+	remember_pending_reconcile,
+)
 from banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.unpaid_vouchers import (
 	get_deposit_included_fee,
 )
@@ -253,6 +256,7 @@ def create_journal_entry_bts(
 	journal_entry.insert()
 
 	if allow_edit:
+		remember_pending_reconcile("Journal Entry", journal_entry.name, bank_transaction_name)
 		return journal_entry  # Return saved document
 
 	# This check happens here because the user should be able to make
@@ -342,6 +346,7 @@ def create_payment_entry_bts(
 	payment_entry.insert()
 
 	if allow_edit:
+		remember_pending_reconcile("Payment Entry", payment_entry.name, bank_transaction_name)
 		return payment_entry  # Return saved document
 
 	payment_entry.submit()

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/pending_reconcile.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/pending_reconcile.py
@@ -72,6 +72,13 @@ def validate_pending_reconcile_amount(doc, method: str | None = None) -> None:
 	bank_gl_account, unallocated = _pending_bank_gl_and_unallocated(pending)
 	voucher_amount = _voucher_bank_amount(doc, bank_gl_account)
 
+	if voucher_amount <= 0:
+		frappe.throw(
+			_(
+				"Cannot submit {0} {1}: no bank amount found for Bank Account GL {2}. Restore the bank account row before submitting."
+			).format(doc.doctype, doc.name, bank_gl_account)
+		)
+
 	if voucher_amount > unallocated:
 		frappe.throw(
 			_(
@@ -106,14 +113,20 @@ def reconcile_if_pending(doc, method: str | None = None) -> None:
 		return
 
 	bank_gl_account = frappe.db.get_value("Bank Account", transaction.bank_account, "account")
-	unallocated = flt(transaction.unallocated_amount)
 	voucher_amount = _voucher_bank_amount(doc, bank_gl_account)
-	amount = voucher_amount if voucher_amount > 0 else unallocated
+	if voucher_amount <= 0:
+		# Leave the cache key so the pending link remains discoverable.
+		frappe.log_error(
+			title=_("Cannot reconcile {0} {1} with Bank Transaction {2}: no bank amount for GL {3}").format(
+				doc.doctype, doc.name, transaction_name, bank_gl_account
+			)
+		)
+		return
 
 	try:
 		reconcile_voucher(
 			transaction_name,
-			amount,
+			voucher_amount,
 			doc.doctype,
 			doc.name,
 		)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/pending_reconcile.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/pending_reconcile.py
@@ -1,0 +1,111 @@
+"""Remember draft vouchers from Edit in Full Page and reconcile them on submit.
+
+Pending state is Redis-backed (frappe.cache) with a 24h TTL; it is lost on cache flush.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+CACHE_PREFIX = "banking:pending_bt_reconcile"
+CACHE_TTL_SEC = 60 * 60 * 24  # 1 day
+
+
+def _cache_key(voucher_type: str, voucher_name: str) -> str:
+	return f"{CACHE_PREFIX}:{voucher_type}:{voucher_name}"
+
+
+def remember_pending_reconcile(voucher_type: str, voucher_name: str, transaction_name: str) -> None:
+	frappe.cache().set_value(
+		_cache_key(voucher_type, voucher_name),
+		{"transaction_name": transaction_name},
+		expires_in_sec=CACHE_TTL_SEC,
+	)
+
+
+def clear_pending_reconcile(voucher_type: str, voucher_name: str) -> None:
+	frappe.cache().delete_value(_cache_key(voucher_type, voucher_name))
+
+
+def get_pending_reconcile(voucher_type: str, voucher_name: str) -> dict | None:
+	return frappe.cache().get_value(_cache_key(voucher_type, voucher_name))
+
+
+def _voucher_bank_amount(doc, bank_gl_account: str) -> float:
+	"""Bank-side amount of a Create voucher in account currency."""
+	if doc.doctype == "Payment Entry":
+		return flt(doc.received_amount if doc.payment_type == "Receive" else doc.paid_amount)
+
+	if doc.doctype == "Journal Entry":
+		return sum(
+			flt(row.debit_in_account_currency) + flt(row.credit_in_account_currency)
+			for row in doc.accounts
+			if row.account == bank_gl_account
+		)
+
+	return 0.0
+
+
+def reconcile_if_pending(doc, method: str | None = None) -> None:
+	"""doc_events on_submit for Journal Entry / Payment Entry.
+
+	Create → Edit in Full Page drafts are meant for this Bank Transaction only.
+	Reject submit when the voucher bank amount exceeds the BT unallocated amount.
+	"""
+	pending = get_pending_reconcile(doc.doctype, doc.name)
+	if not pending:
+		return
+
+	from banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank_reconciliation_tool_beta import (
+		reconcile_voucher,
+	)
+
+	transaction_name = pending["transaction_name"]
+	transaction = frappe.get_doc("Bank Transaction", transaction_name)
+
+	already_linked = any(
+		row.payment_document == doc.doctype and row.payment_entry == doc.name
+		for row in transaction.payment_entries
+	)
+	if already_linked or flt(transaction.unallocated_amount) <= 0:
+		clear_pending_reconcile(doc.doctype, doc.name)
+		return
+
+	bank_gl_account = frappe.db.get_value("Bank Account", transaction.bank_account, "account")
+	unallocated = flt(transaction.unallocated_amount)
+	voucher_amount = _voucher_bank_amount(doc, bank_gl_account)
+
+	if voucher_amount > unallocated:
+		# Abort submit so an oversized Create voucher cannot be posted.
+		frappe.throw(
+			_(
+				"Cannot submit {0} {1}: bank amount {2} is greater than Bank Transaction {3} unallocated amount {4}. Reduce the voucher to {4} or less."
+			).format(doc.doctype, doc.name, voucher_amount, transaction_name, unallocated)
+		)
+
+	amount = voucher_amount if voucher_amount > 0 else unallocated
+
+	try:
+		reconcile_voucher(
+			transaction_name,
+			amount,
+			doc.doctype,
+			doc.name,
+		)
+	except Exception:
+		# Leave the cache key so the pending link remains discoverable after a failed attempt.
+		frappe.log_error(
+			title=_("Failed to reconcile {0} {1} with Bank Transaction {2}").format(
+				doc.doctype, doc.name, transaction_name
+			)
+		)
+		return
+
+	clear_pending_reconcile(doc.doctype, doc.name)
+
+
+def clear_if_pending(doc, method: str | None = None) -> None:
+	"""doc_events on_trash for Journal Entry / Payment Entry."""
+	clear_pending_reconcile(doc.doctype, doc.name)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/pending_reconcile.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/pending_reconcile.py
@@ -29,6 +29,11 @@ def clear_pending_reconcile(voucher_type: str, voucher_name: str) -> None:
 	frappe.cache().delete_value(_cache_key(voucher_type, voucher_name))
 
 
+def clear_all_pending_reconciles() -> None:
+	"""Drop all pending keys (e.g. test tearDown; Redis is not covered by DB rollback)."""
+	frappe.cache().delete_keys(CACHE_PREFIX)
+
+
 def get_pending_reconcile(voucher_type: str, voucher_name: str) -> dict | None:
 	return frappe.cache().get_value(_cache_key(voucher_type, voucher_name))
 
@@ -48,14 +53,41 @@ def _voucher_bank_amount(doc, bank_gl_account: str) -> float:
 	return 0.0
 
 
-def reconcile_if_pending(doc, method: str | None = None) -> None:
-	"""doc_events on_submit for Journal Entry / Payment Entry.
+def _pending_bank_gl_and_unallocated(pending: dict) -> tuple[str, float]:
+	transaction = frappe.get_doc("Bank Transaction", pending["transaction_name"])
+	bank_gl_account = frappe.db.get_value("Bank Account", transaction.bank_account, "account")
+	return bank_gl_account, flt(transaction.unallocated_amount)
 
-	Create → Edit in Full Page drafts are meant for this Bank Transaction only.
-	Reject submit when the voucher bank amount exceeds the BT unallocated amount.
-	"""
+
+def validate_pending_reconcile_amount(doc, method: str | None = None) -> None:
+	"""before_submit: Create drafts must not exceed the Bank Transaction unallocated amount."""
 	pending = get_pending_reconcile(doc.doctype, doc.name)
 	if not pending:
+		return
+
+	if not frappe.db.exists("Bank Transaction", pending["transaction_name"]):
+		clear_pending_reconcile(doc.doctype, doc.name)
+		return
+
+	bank_gl_account, unallocated = _pending_bank_gl_and_unallocated(pending)
+	voucher_amount = _voucher_bank_amount(doc, bank_gl_account)
+
+	if voucher_amount > unallocated:
+		frappe.throw(
+			_(
+				"Cannot submit {0} {1}: bank amount {2} is greater than Bank Transaction {3} unallocated amount {4}. Reduce the voucher to {4} or less."
+			).format(doc.doctype, doc.name, voucher_amount, pending["transaction_name"], unallocated)
+		)
+
+
+def reconcile_if_pending(doc, method: str | None = None) -> None:
+	"""doc_events on_submit for Journal Entry / Payment Entry."""
+	pending = get_pending_reconcile(doc.doctype, doc.name)
+	if not pending:
+		return
+
+	if not frappe.db.exists("Bank Transaction", pending["transaction_name"]):
+		clear_pending_reconcile(doc.doctype, doc.name)
 		return
 
 	from banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank_reconciliation_tool_beta import (
@@ -76,15 +108,6 @@ def reconcile_if_pending(doc, method: str | None = None) -> None:
 	bank_gl_account = frappe.db.get_value("Bank Account", transaction.bank_account, "account")
 	unallocated = flt(transaction.unallocated_amount)
 	voucher_amount = _voucher_bank_amount(doc, bank_gl_account)
-
-	if voucher_amount > unallocated:
-		# Abort submit so an oversized Create voucher cannot be posted.
-		frappe.throw(
-			_(
-				"Cannot submit {0} {1}: bank amount {2} is greater than Bank Transaction {3} unallocated amount {4}. Reduce the voucher to {4} or less."
-			).format(doc.doctype, doc.name, voucher_amount, transaction_name, unallocated)
-		)
-
 	amount = voucher_amount if voucher_amount > 0 else unallocated
 
 	try:

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/pending_reconcile.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/pending_reconcile.py
@@ -108,8 +108,18 @@ def reconcile_if_pending(doc, method: str | None = None) -> None:
 		row.payment_document == doc.doctype and row.payment_entry == doc.name
 		for row in transaction.payment_entries
 	)
-	if already_linked or flt(transaction.unallocated_amount) <= 0:
+	if already_linked:
 		clear_pending_reconcile(doc.doctype, doc.name)
+		return
+
+	if flt(transaction.unallocated_amount) <= 0:
+		# Concurrent reconcile may have consumed the BT between before_submit and on_submit.
+		clear_pending_reconcile(doc.doctype, doc.name)
+		frappe.log_error(
+			title=_("Cannot reconcile {0} {1} with Bank Transaction {2}: no unallocated amount left").format(
+				doc.doctype, doc.name, transaction_name
+			)
+		)
 		return
 
 	bank_gl_account = frappe.db.get_value("Bank Account", transaction.bank_account, "account")

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -68,6 +68,13 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 
 	def tearDown(self) -> None:
 		"""Runs after each test."""
+		# Redis is not covered by DB savepoint rollback; stale pending keys can
+		# reuse rolled-back JE/BT names and corrupt later reconciles.
+		from banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile import (
+			clear_all_pending_reconciles,
+		)
+
+		clear_all_pending_reconciles()
 		# Make sure invoices are rolled back to not affect invoice count assertions
 		frappe.db.rollback(save_point="bank_reco_beta_before_tests")
 
@@ -399,6 +406,7 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 				row.debit_in_account_currency = 250
 			if row.credit_in_account_currency:
 				row.credit_in_account_currency = 250
+		journal_entry.save()
 
 		self.assertRaises(frappe.ValidationError, journal_entry.submit)
 

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -344,6 +344,70 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(journal_entry.accounts[1].bank_account, self.bank_account)
 		self.assertEqual(journal_entry.accounts[1].debit_in_account_currency, 200)
 
+	def test_edit_in_full_page_reconciles_on_submit(self):
+		"""Draft JE from allow_edit is linked to the Bank Transaction when submitted."""
+		bt = create_bank_transaction(
+			deposit=200, reference_no="edit-full-page", bank_account=self.bank_account
+		)
+		journal_entry = create_journal_entry_bts(
+			bank_transaction_name=bt.name,
+			party_type="Customer",
+			party=self.customer,
+			posting_date=bt.date,
+			reference_number=bt.reference_number,
+			reference_date=bt.date,
+			entry_type="Bank Entry",
+			second_account=frappe.db.get_value("Company", bt.company, "default_receivable_account"),
+			allow_edit=True,
+		)
+
+		self.assertEqual(journal_entry.docstatus, 0)
+		bt.reload()
+		self.assertEqual(len(bt.payment_entries), 0)
+
+		journal_entry.submit()
+
+		bt.reload()
+		self.assertEqual(len(bt.payment_entries), 1)
+		self.assertEqual(bt.payment_entries[0].payment_entry, journal_entry.name)
+		self.assertEqual(bt.payment_entries[0].allocated_amount, 200)
+		self.assertEqual(bt.status, "Reconciled")
+
+	def test_edit_in_full_page_rejects_voucher_larger_than_unallocated(self):
+		"""Create drafts must not submit with a bank amount above the BT unallocated amount."""
+		from banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.pending_reconcile import (
+			get_pending_reconcile,
+		)
+
+		bt = create_bank_transaction(
+			deposit=200, reference_no="edit-full-page-too-big", bank_account=self.bank_account
+		)
+		journal_entry = create_journal_entry_bts(
+			bank_transaction_name=bt.name,
+			party_type="Customer",
+			party=self.customer,
+			posting_date=bt.date,
+			reference_number=bt.reference_number,
+			reference_date=bt.date,
+			entry_type="Bank Entry",
+			second_account=frappe.db.get_value("Company", bt.company, "default_receivable_account"),
+			allow_edit=True,
+		)
+
+		for row in journal_entry.accounts:
+			if row.debit_in_account_currency:
+				row.debit_in_account_currency = 250
+			if row.credit_in_account_currency:
+				row.credit_in_account_currency = 250
+
+		self.assertRaises(frappe.ValidationError, journal_entry.submit)
+
+		journal_entry.reload()
+		self.assertEqual(journal_entry.docstatus, 0)
+		bt.reload()
+		self.assertEqual(len(bt.payment_entries), 0)
+		self.assertIsNotNone(get_pending_reconcile("Journal Entry", journal_entry.name))
+
 	def test_jv_against_transaction(self):
 		bt = create_bank_transaction(deposit=200, reference_no="abcdef123", bank_account=self.bank_account)
 		create_journal_entry_bts(

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
@@ -46,9 +46,6 @@ erpnext.accounts.bank_reconciliation.ActionsPanelManager = class ActionsPanelMan
 		this.tabs_list_ul = this.$actions_container.find(".form-tabs");
 		this.$tab_content = this.$actions_container.find(".tab-content");
 
-		// Remove any listeners from previous tabs
-		frappe.realtime.off("doc_update");
-
 		const tabs = [
 			{
 				tab_name: "details",

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/actions_panel_manager.js
@@ -7,6 +7,9 @@ erpnext.accounts.bank_reconciliation.ActionsPanelManager = class ActionsPanelMan
 	}
 
 	make() {
+		// Drop stale focus listeners from a previous "Edit in Full Page" flow
+		this.panel_manager.cleanup_edit_in_full_page?.();
+
 		this.init_actions_container();
 		this.render_tabs();
 

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
@@ -46,9 +46,13 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 
 			// Server attaches the voucher on submit. Refresh the list when the user returns.
 			// pagehide covers tab close; router.once covers Frappe SPA navigation (pushState).
+			// panel_manager.cleanup_edit_in_full_page is cleared when another BT is selected.
 			const cleanup = () => {
 				window.removeEventListener("focus", on_focus);
 				window.removeEventListener("pagehide", cleanup);
+				if (this.panel_manager.cleanup_edit_in_full_page === cleanup) {
+					this.panel_manager.cleanup_edit_in_full_page = null;
+				}
 			};
 			const on_focus = () => {
 				frappe.db
@@ -73,6 +77,8 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 						);
 					});
 			};
+			this.panel_manager.cleanup_edit_in_full_page?.();
+			this.panel_manager.cleanup_edit_in_full_page = cleanup;
 			window.addEventListener("focus", on_focus);
 			window.addEventListener("pagehide", cleanup);
 			frappe.router.once("change", cleanup);

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
@@ -45,6 +45,7 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 			const initial_unallocated = flt(this.transaction.unallocated_amount);
 
 			// Server attaches the voucher on submit. Refresh the list when the user returns.
+			// pagehide covers tab close; router.once covers Frappe SPA navigation (pushState).
 			const cleanup = () => {
 				window.removeEventListener("focus", on_focus);
 				window.removeEventListener("pagehide", cleanup);
@@ -74,6 +75,7 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 			};
 			window.addEventListener("focus", on_focus);
 			window.addEventListener("pagehide", cleanup);
+			frappe.router.once("change", cleanup);
 
 			frappe.open_in_new_tab = true;
 			frappe.set_route("Form", doc.doctype, doc.name);

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
@@ -40,22 +40,43 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 
 	edit_in_full_page() {
 		this.create_voucher_bts(true, (message) => {
-			const doc = frappe.model.sync(message);
-			let doctype = doc[0].doctype,
-				docname = doc[0].name;
+			const doc = frappe.model.sync(message)[0];
+			const bt_name = this.transaction.name;
+			const initial_unallocated = flt(this.transaction.unallocated_amount);
 
-			// Reconcile and update the view
-			// when the voucher is submitted in another tab
-			frappe.socketio.doc_subscribe(doctype, docname);
-			frappe.realtime.off("doc_update");
-			frappe.realtime.on("doc_update", (data) => {
-				if (data.doctype === doctype && data.name === docname) {
-					this.reconcile_new_voucher(doctype, docname);
-				}
-			});
+			// Server attaches the voucher on submit. Refresh the list when the user returns.
+			const cleanup = () => {
+				window.removeEventListener("focus", on_focus);
+				window.removeEventListener("pagehide", cleanup);
+			};
+			const on_focus = () => {
+				frappe.db
+					.get_value("Bank Transaction", bt_name, [
+						"name",
+						"unallocated_amount",
+						"status",
+					])
+					.then((r) => {
+						const bt = r?.message;
+						if (!bt) {
+							return;
+						}
+						if (flt(bt.unallocated_amount) >= initial_unallocated) {
+							return;
+						}
+						cleanup();
+						this.actions_panel.after_transaction_reconcile(
+							bt,
+							true,
+							doc.doctype
+						);
+					});
+			};
+			window.addEventListener("focus", on_focus);
+			window.addEventListener("pagehide", cleanup);
 
 			frappe.open_in_new_tab = true;
-			frappe.set_route("Form", doctype, docname);
+			frappe.set_route("Form", doc.doctype, doc.name);
 		});
 	}
 
@@ -125,48 +146,6 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 					return;
 				} else if (response.message) {
 					success_callback(response.message);
-				}
-			},
-		});
-	}
-
-	reconcile_new_voucher(doctype, docname) {
-		// If no response, newly created doc is in draft state
-		// If deleted in response, newly created doc is deleted
-		// If doc object in response, newly created doc is submitted (can be reconciled)
-		frappe.call({
-			method:
-				"banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.bank_reconciliation_tool_beta.reconcile_voucher",
-			args: {
-				transaction_name: this.transaction.name,
-				amount: this.transaction.unallocated_amount,
-				voucher_type: doctype,
-				voucher_name: docname,
-			},
-			callback: (response) => {
-				if (response.exc) {
-					frappe.show_alert({
-						message: __("Failed to reconcile new {0} against {1}", [
-							doctype,
-							this.transaction.name,
-						]),
-						indicator: "red",
-					});
-					return;
-				} else if (
-					response.message &&
-					Object.keys(response.message).length > 0
-				) {
-					if (response.message.deleted) {
-						frappe.realtime.off("doc_update");
-						return;
-					}
-
-					this.actions_panel.after_transaction_reconcile(
-						response.message,
-						true,
-						doctype
-					);
 				}
 			},
 		});


### PR DESCRIPTION
## Summary
- **Bank Reconciliation Tool Beta** → Create → *Edit in Full Page* now attaches the submitted **Journal Entry** / **Payment Entry** to the **Bank Transaction** on the server (`on_submit`), instead of relying on fragile websocket listeners in the desk tab.
- Drafts created with `allow_edit` remember the target **Bank Transaction** in cache (24h TTL). On submit, the voucher is reconciled; the cache entry is cleared only after success (or when already linked / nothing left to allocate). Failed reconcile attempts leave the pending key and write an Error Log.
- Rejects submit when the voucher’s bank-side amount is greater than the **Bank Transaction** *Unallocated Amount* (Create drafts are meant for that transaction only; partial amounts still allowed).
- Desk UI: drop the old `doc_update` reconcile path and the blanket `frappe.realtime.off("doc_update")`; refresh the list on window focus when *Unallocated Amount* decreases (with `pagehide` cleanup).

## Motivation
*Edit in Full Page* opens a draft voucher in another tab and previously relied on a desk `doc_update` listener to call `reconcile_voucher` after submit. That often failed in practice: the listener only lived on the reconciliation tab, background tabs drop sockets, Frappe does not reliably rejoin document rooms on reconnect, and `frappe.realtime.off("doc_update")` could wipe unrelated listeners. Users then saw a submitted voucher that was not linked, or returned to the tool and hit “already reconciled” / a stale list.

Attaching on voucher `on_submit` makes the link a server invariant for Create drafts, independent of which tab is focused. The client only refreshes the UI when the user comes back.

## Test plan
- [ ] Create tab → **Journal Entry** → *Edit in Full Page*: submit the draft; confirm it appears under **Bank Transaction** *Payment Entries* and the transaction reconciles (fully or partially).
- [ ] Same for **Payment Entry**.
- [ ] In the draft, raise the bank-leg amount above *Unallocated Amount* and submit; submit must fail with a clear error; draft stays unsaved-as-submitted and can be fixed and resubmitted.
- [ ] In the draft, lower the bank amount below *Unallocated Amount* and submit; BT is partially reconciled and the list refreshes after returning focus to the tool.
- [ ] Trash a draft created via *Edit in Full Page*; pending cache is cleared (no surprise attach later).
- [ ] `bench run-tests --app banking --module banking.klarna_kosma_integration.doctype.bank_reconciliation_tool_beta.test_bank_reconciliation_tool_beta` (or the two new Edit-in-Full-Page tests).