### PR TITLE
fix!: handle multiple companies' bank accounts with one EBICS User

### DIFF
--- a/banking/ebics/doctype/ebics_user/ebics_user.json
+++ b/banking/ebics/doctype/ebics_user/ebics_user.json
@@ -10,7 +10,7 @@
   "initialized",
   "bank_keys_activated",
   "column_break_hlxa",
-  "company",
+  "organization_name",
   "country",
   "bank",
   "intraday_sync",
@@ -39,12 +39,12 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "company",
-   "fieldtype": "Link",
+   "description": "Used as the organization name in the user certificates.",
+   "fieldname": "organization_name",
+   "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Company",
-   "mandatory_depends_on": "needs_certificates",
-   "options": "Company"
+   "label": "Organization Name",
+   "mandatory_depends_on": "needs_certificates"
   },
   {
    "fieldname": "country",
@@ -169,7 +169,7 @@
    "link_fieldname": "ebics_user"
   }
  ],
- "modified": "2026-05-21 02:05:40.039153",
+ "modified": "2026-09-02 09:23:23.036356",
  "modified_by": "Administrator",
  "module": "EBICS",
  "name": "EBICS User",
@@ -202,7 +202,7 @@
  ],
  "row_format": "Dynamic",
  "rows_threshold_for_grid_search": 20,
- "search_fields": "full_name,bank,company",
+ "search_fields": "full_name,bank,organization_name",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/banking/ebics/doctype/ebics_user/ebics_user.py
+++ b/banking/ebics/doctype/ebics_user/ebics_user.py
@@ -24,7 +24,6 @@ class EBICSUser(Document):
 
 		bank: DF.Link | None
 		bank_keys_activated: DF.Check
-		company: DF.Link | None
 		country: DF.Link | None
 		download_batch_transactions: DF.Check
 		full_name: DF.Data | None
@@ -32,6 +31,7 @@ class EBICSUser(Document):
 		intraday_sync: DF.Check
 		keyring: DF.Code | None
 		needs_certificates: DF.Check
+		organization_name: DF.Data | None
 		partner_id: DF.Data | None
 		passphrase: DF.Password | None
 		protocol_version: DF.Literal["H004", "H005"]
@@ -197,7 +197,7 @@ def initialize(ebics_user: str, passphrase: str, signature_passphrase: str, stor
 			raise e
 
 	if user.needs_certificates:
-		manager.create_user_certificates(user.full_name, user.company)
+		manager.create_user_certificates(user.full_name, user.organization_name)
 
 	manager.send_keys_to_bank()
 
@@ -275,7 +275,7 @@ def change_protocol_version(ebics_user: str, protocol_version: str, passphrase: 
 
 	if user.needs_certificates:
 		manager = get_ebics_manager(user, passphrase=passphrase)
-		manager.create_user_certificates(user.full_name, user.company)
+		manager.create_user_certificates(user.full_name, user.organization_name)
 
 
 def ensure_ebics_is_enabled():

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -240,7 +240,7 @@ def import_ebics_json(user: EBICSUser, main_data: dict, batch_data: dict | None 
 
 	for name in sorted(main_data):
 		camt_document = CAMTDocument(xml=main_data[name], camt54=batch_data)
-		bank_account = get_bank_account(camt_document.iban, user.bank, user.company)
+		bank_account = get_bank_account(camt_document.iban, user.bank)
 		if not bank_account:
 			frappe.log_error(
 				title=_("Banking Error"),
@@ -273,7 +273,7 @@ def validated_perms(ebics_user, permitted_types, required_type):
 		)
 
 
-def get_bank_account(iban: str, bank: str, company: str) -> str | None:
+def get_bank_account(iban: str, bank: str) -> str | None:
 	return frappe.db.get_value(
 		"Bank Account",
 		{
@@ -281,7 +281,6 @@ def get_bank_account(iban: str, bank: str, company: str) -> str | None:
 			"disabled": 0,
 			"bank": bank,
 			"is_company_account": 1,
-			"company": company,
 		},
 	)
 

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -273,15 +273,23 @@ def validated_perms(ebics_user, permitted_types, required_type):
 
 
 def get_bank_account(iban: str, bank: str) -> str | None:
-	return frappe.db.get_value(
+	bank_accounts = frappe.get_all(
 		"Bank Account",
-		{
-			"iban": iban,
-			"disabled": 0,
-			"bank": bank,
-			"is_company_account": 1,
-		},
+		filters={"iban": iban, "disabled": 0, "bank": bank, "is_company_account": 1},
+		pluck="name",
 	)
+
+	if len(bank_accounts) > 1:
+		# This actually is prevented by a unique IBAN validation in bank_account.py
+		# historically, this was possible though. So we handle it with an Error Log.
+		frappe.log_error(
+			title=_("Banking Error"),
+			message=_("Found {0} Bank Accounts for IBAN {1}. Using {2}.").format(
+				len(bank_accounts), iban, bank_accounts[0]
+			),
+		)
+
+	return bank_accounts[0] if bank_accounts else None
 
 
 def process_camt_document(
@@ -290,8 +298,6 @@ def process_camt_document(
 	earliest_date: date | None = None,
 	split_batch_transactions: bool = False,
 ):
-	company = frappe.db.get_value("Bank Account", bank_account, "company")
-
 	for transaction in camt_document:
 		if transaction.status and transaction.status != "BOOK":
 			# Skip PDNG and INFO transactions
@@ -311,7 +317,6 @@ def process_camt_document(
 				sub_transaction_id = get_transaction_id(sub_transaction, sub_transaction_index)
 				create_sepa_bank_transaction(
 					bank_account,
-					company,
 					sub_transaction,
 					transaction_id=transaction_id,
 					subtransaction_id=sub_transaction_id,
@@ -320,7 +325,6 @@ def process_camt_document(
 		else:
 			create_sepa_bank_transaction(
 				bank_account,
-				company,
 				transaction,
 				transaction_id=transaction_id,
 				start_date=earliest_date,
@@ -329,7 +333,6 @@ def process_camt_document(
 
 def create_sepa_bank_transaction(
 	bank_account: str,
-	company: str,
 	sepa_transaction: SEPATransaction,
 	transaction_id: str,
 	subtransaction_id: str | None = None,
@@ -350,7 +353,6 @@ def create_sepa_bank_transaction(
 		bank_account=bank_account,
 		transaction_id=transaction_id,
 		subtransaction_id=subtransaction_id,
-		company=company,
 		currency=currency,
 		description="\n".join(sepa_transaction.purpose) or sepa_transaction.info,
 		deposit=max(amount, 0),
@@ -518,14 +520,13 @@ def upload_mt940_file():
 def process_mt940_statement(statement: MT940Statement, bank_account: str):
 	"""Process a single MT940 statement and create bank transactions"""
 
-	company = frappe.db.get_value("Bank Account", bank_account, "company")
 	currency = statement["balance_open"]["currency"]
 	for transaction in statement["transactions"]:
-		create_mt940_bank_transaction(bank_account, company, transaction, currency)
+		create_mt940_bank_transaction(bank_account, transaction, currency)
 
 
 def create_mt940_bank_transaction(
-	bank_account: str, company: str, transaction: MT940Transaction, currency: str
+	bank_account: str, transaction: MT940Transaction, currency: str
 ):
 	"""Create a bank transaction from MT940 transaction data"""
 	transaction_date = transaction.get("date") or transaction["valuta"]
@@ -561,7 +562,6 @@ def create_mt940_bank_transaction(
 	create_bank_transaction(
 		bank_account=bank_account,
 		transaction_id=get_transaction_hash(values_to_hash),
-		company=company,
 		currency=currency,
 		description=description,
 		deposit=max(amount, 0),

--- a/banking/ebics/utils.py
+++ b/banking/ebics/utils.py
@@ -253,9 +253,8 @@ def import_ebics_json(user: EBICSUser, main_data: dict, batch_data: dict | None 
 		process_camt_document(
 			camt_document,
 			bank_account,
-			user.company,
-			user.start_date,
-			user.split_batch_transactions,
+			earliest_date=user.start_date,
+			split_batch_transactions=user.split_batch_transactions,
 		)
 
 
@@ -288,12 +287,10 @@ def get_bank_account(iban: str, bank: str) -> str | None:
 def process_camt_document(
 	camt_document: CAMTDocument,
 	bank_account: str,
-	company: str | None = None,
 	earliest_date: date | None = None,
 	split_batch_transactions: bool = False,
 ):
-	if not company:
-		company = frappe.db.get_value("Bank Account", bank_account, "company")
+	company = frappe.db.get_value("Bank Account", bank_account, "company")
 
 	for transaction in camt_document:
 		if transaction.status and transaction.status != "BOOK":

--- a/banking/overrides/bank_account.py
+++ b/banking/overrides/bank_account.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe import _
-from frappe.utils import cint
+from frappe.utils import cint, get_link_to_form
 
 
 def before_validate(doc, method):
@@ -12,6 +12,7 @@ def before_validate(doc, method):
 def validate(doc, method):
 	validate_account_currencies(doc)
 	validate_required_bank_fee_account(doc)
+	validate_unique_iban(doc)
 
 
 def validate_account_currencies(doc):
@@ -31,6 +32,24 @@ def validate_required_bank_fee_account(doc):
 			"Bank Fee Account is mandatory for company Bank Accounts while automatic journal entries for bank fees are enabled in Banking Settings."
 		)
 	)
+
+
+def validate_unique_iban(doc):
+	if not doc.iban:
+		return
+
+	existing = frappe.db.get_value(
+		"Bank Account",
+		{"iban": doc.iban, "name": ["!=", doc.name]},
+		"name",
+	)
+
+	if existing:
+		frappe.throw(
+			_("A Bank Account with IBAN {0} already exists: {1}").format(
+				doc.iban, get_link_to_form("Bank Account", existing)
+			)
+		)
 
 
 def automatic_fee_entries_enabled() -> bool:

--- a/banking/patches.txt
+++ b/banking/patches.txt
@@ -13,4 +13,5 @@ banking.patches.set_voucher_matching_defaults
 banking.patches.download_batch_transactions
 banking.patches.truncate_legacy_filter_hidden_flag
 banking.patches.add_voucher_reservation_fields
+banking.patches.ebics_user_organization_name
 execute:from banking.install import make_property_setters; make_property_setters()

--- a/banking/patches/ebics_user_organization_name.py
+++ b/banking/patches/ebics_user_organization_name.py
@@ -1,0 +1,10 @@
+import frappe
+
+
+def execute():
+	"""Copy the previously linked Company name into the new organization_name field."""
+	if "company" not in frappe.db.get_table_columns("EBICS User"):
+		return
+
+	eu = frappe.qb.DocType("EBICS User")
+	frappe.qb.update(eu).set(eu.organization_name, eu.company).where(eu.company.isnotnull()).run()


### PR DESCRIPTION
Solves: https://github.com/alyf-de/banking/issues/404 

Further note:
`process_camt_document` had to be adjusted, because it relied on transactions for one **Company** per **EBICS User**.