### PR TITLE
fix(Bank Reconciliation Beta): show deposit + included fee in UI amounts

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -141,6 +141,7 @@ def get_bank_transactions(
 		"bank_account",
 		"company",
 		"unallocated_amount",
+		"included_fee",
 		"reference_number",
 		"party_type",
 		"party",
@@ -152,14 +153,59 @@ def get_bank_transactions(
 	]
 	order_by = get_bank_transaction_order_by(order_by)
 
-	return {
-		"transactions": frappe.get_list(
-			"Bank Transaction",
-			fields=fields,
-			filters=filters,
-			order_by=order_by,
-		),
-	}
+	transactions = frappe.get_list(
+		"Bank Transaction",
+		fields=fields,
+		filters=filters,
+		order_by=order_by,
+	)
+	enrich_transactions_with_reconcilable_amounts(transactions)
+
+	return {"transactions": transactions}
+
+
+def enrich_transactions_with_reconcilable_amounts(transactions: list) -> None:
+	"""Add deposit+fee reconcilable amounts used by the Match tab summary.
+
+	Deposit-side included fees increase the economic value available for voucher
+	matching when automatic bank-fee booking is enabled and the bank account has
+	a fee account. The UI must show that combined amount or allocation looks wrong.
+	"""
+	if not transactions:
+		return
+
+	fee_enabled = flt(
+		frappe.db.get_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees")
+	)
+	fee_accounts_by_bank_account = {}
+	if fee_enabled:
+		bank_account_names = list(
+			{transaction.bank_account for transaction in transactions if transaction.bank_account}
+		)
+		if bank_account_names:
+			fee_accounts_by_bank_account = {
+				row.name: row.bank_fee_account
+				for row in frappe.get_all(
+					"Bank Account",
+					filters={"name": ["in", bank_account_names]},
+					fields=["name", "bank_fee_account"],
+				)
+			}
+
+	for transaction in transactions:
+		included_fee_for_reconciliation = 0.0
+		if (
+			fee_enabled
+			and flt(transaction.deposit) > 0
+			and flt(transaction.included_fee) > 0
+			and fee_accounts_by_bank_account.get(transaction.bank_account)
+		):
+			included_fee_for_reconciliation = flt(transaction.included_fee)
+
+		transaction.included_fee_for_reconciliation = included_fee_for_reconciliation
+		transaction.reconcilable_amount = (
+			flt(transaction.unallocated_amount) + included_fee_for_reconciliation
+		)
 
 
 def _reserve_bank_transaction(

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -159,17 +159,20 @@ def get_bank_transactions(
 		filters=filters,
 		order_by=order_by,
 	)
-	enrich_transactions_with_reconcilable_amounts(transactions)
+	enrich_transactions_with_deposit_fee_for_reconciliation(transactions)
 
 	return {"transactions": transactions}
 
 
-def enrich_transactions_with_reconcilable_amounts(transactions: list) -> None:
-	"""Add deposit+fee reconcilable amounts used by the Match tab summary.
+def enrich_transactions_with_deposit_fee_for_reconciliation(transactions: list) -> None:
+	"""Expose deposit included fees that unpaid-invoice reconciliation can book.
 
-	Deposit-side included fees increase the economic value available for voucher
-	matching when automatic bank-fee booking is enabled and the bank account has
-	a fee account. The UI must show that combined amount or allocation looks wrong.
+	Only set when the same gates as get_deposit_included_fee apply, plus:
+	- no prior allocations (follow-up fee reconcile is rejected);
+	- bank account currency equals company currency (PE deductions are company-currency).
+
+	This is the unpaid-invoice fee additive — not a general allocatable amount for
+	Payment Entry / Journal Entry matching or Create Voucher.
 	"""
 	if not transactions:
 		return
@@ -177,35 +180,71 @@ def enrich_transactions_with_reconcilable_amounts(transactions: list) -> None:
 	fee_enabled = flt(
 		frappe.db.get_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees")
 	)
-	fee_accounts_by_bank_account = {}
-	if fee_enabled:
-		bank_account_names = list(
-			{transaction.bank_account for transaction in transactions if transaction.bank_account}
+	if not fee_enabled:
+		for transaction in transactions:
+			transaction.included_fee_for_reconciliation = 0.0
+		return
+
+	bank_account_names = list(
+		{transaction.bank_account for transaction in transactions if transaction.bank_account}
+	)
+	bank_account_rows = (
+		frappe.get_all(
+			"Bank Account",
+			filters={"name": ["in", bank_account_names]},
+			fields=["name", "bank_fee_account", "account"],
 		)
-		if bank_account_names:
-			fee_accounts_by_bank_account = {
-				row.name: row.bank_fee_account
-				for row in frappe.get_all(
-					"Bank Account",
-					filters={"name": ["in", bank_account_names]},
-					fields=["name", "bank_fee_account"],
-				)
-			}
+		if bank_account_names
+		else []
+	)
+	fee_accounts_by_bank_account = {row.name: row.bank_fee_account for row in bank_account_rows}
+	gl_by_bank_account = {row.name: row.account for row in bank_account_rows}
+	gl_accounts = list({row.account for row in bank_account_rows if row.account})
+	bank_currency_by_gl = (
+		{
+			row.name: row.account_currency
+			for row in frappe.get_all(
+				"Account",
+				filters={"name": ["in", gl_accounts]},
+				fields=["name", "account_currency"],
+			)
+		}
+		if gl_accounts
+		else {}
+	)
+
+	company_names = list({transaction.company for transaction in transactions if transaction.company})
+	company_currency_by_name = (
+		{
+			row.name: row.default_currency
+			for row in frappe.get_all(
+				"Company",
+				filters={"name": ["in", company_names]},
+				fields=["name", "default_currency"],
+			)
+		}
+		if company_names
+		else {}
+	)
 
 	for transaction in transactions:
 		included_fee_for_reconciliation = 0.0
+		bank_gl = gl_by_bank_account.get(transaction.bank_account)
+		bank_currency = bank_currency_by_gl.get(bank_gl) if bank_gl else None
+		company_currency = company_currency_by_name.get(transaction.company)
+		fully_unallocated_deposit = flt(transaction.deposit) > 0 and flt(
+			transaction.unallocated_amount
+		) == flt(transaction.deposit)
 		if (
-			fee_enabled
-			and flt(transaction.deposit) > 0
+			fully_unallocated_deposit
 			and flt(transaction.included_fee) > 0
 			and fee_accounts_by_bank_account.get(transaction.bank_account)
+			and bank_currency
+			and bank_currency == company_currency
 		):
 			included_fee_for_reconciliation = flt(transaction.included_fee)
 
 		transaction.included_fee_for_reconciliation = included_fee_for_reconciliation
-		transaction.reconcilable_amount = (
-			flt(transaction.unallocated_amount) + included_fee_for_reconciliation
-		)
 
 
 def _reserve_bank_transaction(

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -227,14 +227,17 @@ def enrich_transactions_with_deposit_fee_for_reconciliation(transactions: list) 
 		else {}
 	)
 
+	# These are get_list rows, not documents, so precision has to be resolved separately
+	precision = frappe.get_precision("Bank Transaction", "unallocated_amount")
+
 	for transaction in transactions:
 		included_fee_for_reconciliation = 0.0
 		bank_gl = gl_by_bank_account.get(transaction.bank_account)
 		bank_currency = bank_currency_by_gl.get(bank_gl) if bank_gl else None
 		company_currency = company_currency_by_name.get(transaction.company)
 		fully_unallocated_deposit = flt(transaction.deposit) > 0 and flt(
-			transaction.unallocated_amount
-		) == flt(transaction.deposit)
+			transaction.unallocated_amount, precision
+		) == flt(transaction.deposit, precision)
 		if (
 			fully_unallocated_deposit
 			and flt(transaction.included_fee) > 0

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -1553,7 +1553,7 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(si.outstanding_amount, 0)
 		self.assertEqual(si_with_fee.outstanding_amount, 80)
 
-	def test_get_bank_transactions_includes_deposit_fee_in_reconcilable_amount(self):
+	def test_get_bank_transactions_exposes_deposit_fee_for_unpaid_invoices_only(self):
 		frappe.db.set_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees", 1)
 
 		fee_gl_account = create_bank_gl_account("_Test Reco Amount Fee GL")
@@ -1573,13 +1573,83 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		row = next(transaction for transaction in result["transactions"] if transaction.name == bt.name)
 		self.assertEqual(row.included_fee, 5)
 		self.assertEqual(row.included_fee_for_reconciliation, 5)
-		self.assertEqual(row.reconcilable_amount, 80)
+		self.assertIsNone(row.get("reconcilable_amount"))
 
+		# Flag off → fee not exposed for Match unpaid-invoice budget
 		frappe.db.set_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees", 0)
 		result = get_bank_transactions(bank_account=bank_account_with_fee)
 		row = next(transaction for transaction in result["transactions"] if transaction.name == bt.name)
 		self.assertEqual(row.included_fee_for_reconciliation, 0)
-		self.assertEqual(row.reconcilable_amount, 75)
+
+	def test_get_bank_transactions_hides_fee_when_partially_allocated(self):
+		frappe.db.set_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees", 1)
+
+		fee_gl_account = create_bank_gl_account("_Test Partial Fee Reco GL")
+		fee_expense_account = create_bank_gl_account("_Test Partial Fee Reco Expense")
+		bank_account_with_fee = create_bank_account(
+			gl_account=fee_gl_account,
+			bank_account_name="Partial Fee Reco Account",
+			bank_fee_account=fee_expense_account,
+		)
+		bt = create_bank_transaction(
+			deposit=75,
+			included_fee=5,
+			bank_account=bank_account_with_fee,
+		)
+		# Simulate a prior allocation without going through fee reconcile
+		frappe.db.set_value("Bank Transaction", bt.name, "unallocated_amount", 40)
+		bt.reload()
+
+		result = get_bank_transactions(bank_account=bank_account_with_fee)
+		row = next(transaction for transaction in result["transactions"] if transaction.name == bt.name)
+		self.assertEqual(row.included_fee, 5)
+		self.assertEqual(row.included_fee_for_reconciliation, 0)
+
+	def test_get_bank_transactions_hides_fee_for_foreign_currency_bank(self):
+		frappe.db.set_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees", 1)
+
+		bank = create_bank("Citi Bank USD Fee UI", swift_number="CITIUS38")
+		gl_account = create_bank_gl_account("_Test USD Bank Fee UI", "USD")
+		fee_account = create_bank_gl_account("_Test USD Bank Fee Expense UI", "USD")
+		usd_bank_account = create_bank_account(
+			bank.name,
+			gl_account,
+			"USD Fee UI Account",
+			bank_fee_account=fee_account,
+		)
+		bt = create_bank_transaction(
+			deposit=100,
+			included_fee=13,
+			bank_account=usd_bank_account,
+			currency="USD",
+		)
+
+		result = get_bank_transactions(bank_account=usd_bank_account)
+		row = next(transaction for transaction in result["transactions"] if transaction.name == bt.name)
+		self.assertEqual(row.included_fee, 13)
+		self.assertEqual(row.included_fee_for_reconciliation, 0)
+
+	def test_get_bank_transactions_hides_fee_without_bank_fee_account(self):
+		# Create the account while the fee feature is off so bank_fee_account can stay empty,
+		# then enable the flag — enrich must not expose a fee without an expense account.
+		frappe.db.set_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees", 0)
+
+		fee_gl_account = create_bank_gl_account("_Test Missing Fee Account GL")
+		bank_account_without_fee = create_bank_account(
+			gl_account=fee_gl_account,
+			bank_account_name="Missing Fee Account",
+		)
+		frappe.db.set_value("Bank Account", bank_account_without_fee, "bank_fee_account", None)
+		bt = create_bank_transaction(
+			deposit=75,
+			included_fee=5,
+			bank_account=bank_account_without_fee,
+		)
+
+		frappe.db.set_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees", 1)
+		result = get_bank_transactions(bank_account=bank_account_without_fee)
+		row = next(transaction for transaction in result["transactions"] if transaction.name == bt.name)
+		self.assertEqual(row.included_fee_for_reconciliation, 0)
 
 	def _create_draft_journal_entry(self, bt, **kwargs):
 		defaults = {

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -1553,6 +1553,34 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(si.outstanding_amount, 0)
 		self.assertEqual(si_with_fee.outstanding_amount, 80)
 
+	def test_get_bank_transactions_includes_deposit_fee_in_reconcilable_amount(self):
+		frappe.db.set_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees", 1)
+
+		fee_gl_account = create_bank_gl_account("_Test Reco Amount Fee GL")
+		fee_expense_account = create_bank_gl_account("_Test Reco Amount Fee Expense")
+		bank_account_with_fee = create_bank_account(
+			gl_account=fee_gl_account,
+			bank_account_name="Reco Amount Fee Account",
+			bank_fee_account=fee_expense_account,
+		)
+		bt = create_bank_transaction(
+			deposit=75,
+			included_fee=5,
+			bank_account=bank_account_with_fee,
+		)
+
+		result = get_bank_transactions(bank_account=bank_account_with_fee)
+		row = next(transaction for transaction in result["transactions"] if transaction.name == bt.name)
+		self.assertEqual(row.included_fee, 5)
+		self.assertEqual(row.included_fee_for_reconciliation, 5)
+		self.assertEqual(row.reconcilable_amount, 80)
+
+		frappe.db.set_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees", 0)
+		result = get_bank_transactions(bank_account=bank_account_with_fee)
+		row = next(transaction for transaction in result["transactions"] if transaction.name == bt.name)
+		self.assertEqual(row.included_fee_for_reconciliation, 0)
+		self.assertEqual(row.reconcilable_amount, 75)
+
 	def _create_draft_journal_entry(self, bt, **kwargs):
 		defaults = {
 			"bank_transaction_name": bt.name,

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/test_bank_reconciliation_tool_beta.py
@@ -1605,6 +1605,28 @@ class TestBankReconciliationToolBeta(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(row.included_fee, 5)
 		self.assertEqual(row.included_fee_for_reconciliation, 0)
 
+	def test_get_bank_transactions_exposes_fee_despite_sub_precision_rounding(self):
+		frappe.db.set_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees", 1)
+
+		fee_gl_account = create_bank_gl_account("_Test Rounding Fee Reco GL")
+		fee_expense_account = create_bank_gl_account("_Test Rounding Fee Reco Expense")
+		bank_account_with_fee = create_bank_account(
+			gl_account=fee_gl_account,
+			bank_account_name="Rounding Fee Reco Account",
+			bank_fee_account=fee_expense_account,
+		)
+		bt = create_bank_transaction(
+			deposit=75,
+			included_fee=5,
+			bank_account=bank_account_with_fee,
+		)
+		# Sub-precision drift must not count as a prior allocation
+		frappe.db.set_value("Bank Transaction", bt.name, "unallocated_amount", 74.999999)
+
+		result = get_bank_transactions(bank_account=bank_account_with_fee)
+		row = next(transaction for transaction in result["transactions"] if transaction.name == bt.name)
+		self.assertEqual(row.included_fee_for_reconciliation, 5)
+
 	def test_get_bank_transactions_hides_fee_for_foreign_currency_bank(self):
 		frappe.db.set_single_value("Banking Settings", "enable_automatic_journal_entries_for_bank_fees", 1)
 

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js
@@ -108,7 +108,7 @@ erpnext.accounts.bank_reconciliation.DetailsTab = class DetailsTab {
 				fieldtype: "Currency",
 				options: "currency",
 				read_only: 1,
-				hidden: flt(this.transaction.included_fee_for_reconciliation) ? 0 : 1,
+				hidden: flt(this.transaction.included_fee) ? 0 : 1,
 			},
 			{
 				fieldtype: "Column Break",
@@ -121,7 +121,7 @@ erpnext.accounts.bank_reconciliation.DetailsTab = class DetailsTab {
 			},
 			{
 				label: __("To Allocate"),
-				fieldname: "reconcilable_amount",
+				fieldname: "unallocated_amount",
 				fieldtype: "Currency",
 				options: "currency",
 				read_only: 1,

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js
@@ -103,6 +103,14 @@ erpnext.accounts.bank_reconciliation.DetailsTab = class DetailsTab {
 				read_only: 1,
 			},
 			{
+				label: __("Included Fee"),
+				fieldname: "included_fee",
+				fieldtype: "Currency",
+				options: "currency",
+				read_only: 1,
+				hidden: flt(this.transaction.included_fee_for_reconciliation) ? 0 : 1,
+			},
+			{
 				fieldtype: "Column Break",
 			},
 			{
@@ -113,7 +121,7 @@ erpnext.accounts.bank_reconciliation.DetailsTab = class DetailsTab {
 			},
 			{
 				label: __("To Allocate"),
-				fieldname: "unallocated_amount",
+				fieldname: "reconcilable_amount",
 				fieldtype: "Currency",
 				options: "currency",
 				read_only: 1,

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -196,10 +196,13 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 
 		// Deposit included fees are only booked against unpaid invoices.
 		// PE/JE matching and Create Voucher stay on the bank net amount.
+		let unpaid_invoices_only =
+			this.panel_manager.actions_filters.unpaid_invoices;
 		let allocation_budget =
 			erpnext.accounts.bank_reconciliation.get_allocation_budget(
 				this.transaction,
-				this.summary_data
+				this.summary_data,
+				unpaid_invoices_only
 			);
 		let total_allocated = Object.values(this.summary_data).reduce(
 			(a, entry) => a + entry.amount,
@@ -210,7 +213,8 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		let transaction_amount =
 			erpnext.accounts.bank_reconciliation.get_summary_amount(
 				this.transaction,
-				this.summary_data
+				this.summary_data,
+				unpaid_invoices_only
 			);
 		let unallocated = flt(allocation_budget) - flt(max_allocated);
 		let actual_unallocated = flt(allocation_budget) - flt(total_allocated);

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -182,7 +182,11 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		if (id in this.summary_data) {
 			delete this.summary_data[id];
 		} else {
-			this.summary_data[id] = { amount: value, currency: currency };
+			this.summary_data[id] = {
+				amount: value,
+				currency: currency,
+				doctype: row[this.position_of("Voucher")].doctype,
+			};
 		}
 
 		if (this.has_currency_mismatch_selection()) {
@@ -190,24 +194,26 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 			return;
 		}
 
-		// Total of selected row amounts in summary_data
-		// Cap to reconcilable amount (unallocated + deposit included fee)
-		let reconcilable_amount =
-			erpnext.accounts.bank_reconciliation.get_reconcilable_amount(
-				this.transaction
+		// Deposit included fees are only booked against unpaid invoices.
+		// PE/JE matching and Create Voucher stay on the bank net amount.
+		let allocation_budget =
+			erpnext.accounts.bank_reconciliation.get_allocation_budget(
+				this.transaction,
+				this.summary_data
 			);
 		let total_allocated = Object.values(this.summary_data).reduce(
 			(a, entry) => a + entry.amount,
 			0
 		);
-		let max_allocated = Math.min(total_allocated, reconcilable_amount);
+		let max_allocated = Math.min(total_allocated, allocation_budget);
 
-		// Deduct allocated amount from reconcilable amount to show the
-		// final effect on reconciling (including deposit-side bank fees)
 		let transaction_amount =
-			erpnext.accounts.bank_reconciliation.get_summary_amount(this.transaction);
-		let unallocated = flt(reconcilable_amount) - flt(max_allocated);
-		let actual_unallocated = flt(reconcilable_amount) - flt(total_allocated);
+			erpnext.accounts.bank_reconciliation.get_summary_amount(
+				this.transaction,
+				this.summary_data
+			);
+		let unallocated = flt(allocation_budget) - flt(max_allocated);
+		let actual_unallocated = flt(allocation_budget) - flt(total_allocated);
 
 		this.render_transaction_amount_summary(
 			flt(transaction_amount),
@@ -225,15 +231,11 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 
 	render_baseline_summary() {
 		let transaction_amount =
-			erpnext.accounts.bank_reconciliation.get_summary_amount(this.transaction);
-		let reconcilable_amount =
-			erpnext.accounts.bank_reconciliation.get_reconcilable_amount(
-				this.transaction
-			);
+			this.transaction.withdrawal || this.transaction.deposit;
 		this.render_transaction_amount_summary(
 			flt(transaction_amount),
-			flt(reconcilable_amount),
-			flt(reconcilable_amount),
+			flt(this.transaction.unallocated_amount),
+			flt(this.transaction.unallocated_amount),
 			this.transaction.currency
 		);
 	}

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/match_tab.js
@@ -46,14 +46,7 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		this.set_table_data(vouchers);
 		this.actions_table.unfreeze();
 
-		let transaction_amount =
-			this.transaction.withdrawal || this.transaction.deposit;
-		this.render_transaction_amount_summary(
-			flt(transaction_amount),
-			flt(this.transaction.unallocated_amount),
-			flt(this.transaction.unallocated_amount),
-			this.transaction.currency
-		);
+		this.render_baseline_summary();
 	}
 
 	update_filters_in_state(new_filters) {
@@ -198,24 +191,23 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 		}
 
 		// Total of selected row amounts in summary_data
-		// Cap total_allocated to unallocated amount
+		// Cap to reconcilable amount (unallocated + deposit included fee)
+		let reconcilable_amount =
+			erpnext.accounts.bank_reconciliation.get_reconcilable_amount(
+				this.transaction
+			);
 		let total_allocated = Object.values(this.summary_data).reduce(
 			(a, entry) => a + entry.amount,
 			0
 		);
-		let max_allocated = Math.min(
-			total_allocated,
-			this.transaction.unallocated_amount
-		);
+		let max_allocated = Math.min(total_allocated, reconcilable_amount);
 
-		// Deduct allocated amount from transaction's unallocated amount
-		// to show the final effect on reconciling
+		// Deduct allocated amount from reconcilable amount to show the
+		// final effect on reconciling (including deposit-side bank fees)
 		let transaction_amount =
-			this.transaction.withdrawal || this.transaction.deposit;
-		let unallocated =
-			flt(this.transaction.unallocated_amount) - flt(max_allocated);
-		let actual_unallocated =
-			flt(this.transaction.unallocated_amount) - flt(total_allocated);
+			erpnext.accounts.bank_reconciliation.get_summary_amount(this.transaction);
+		let unallocated = flt(reconcilable_amount) - flt(max_allocated);
+		let actual_unallocated = flt(reconcilable_amount) - flt(total_allocated);
 
 		this.render_transaction_amount_summary(
 			flt(transaction_amount),
@@ -233,11 +225,15 @@ erpnext.accounts.bank_reconciliation.MatchTab = class MatchTab {
 
 	render_baseline_summary() {
 		let transaction_amount =
-			this.transaction.withdrawal || this.transaction.deposit;
+			erpnext.accounts.bank_reconciliation.get_summary_amount(this.transaction);
+		let reconcilable_amount =
+			erpnext.accounts.bank_reconciliation.get_reconcilable_amount(
+				this.transaction
+			);
 		this.render_transaction_amount_summary(
 			flt(transaction_amount),
-			flt(this.transaction.unallocated_amount),
-			flt(this.transaction.unallocated_amount),
+			flt(reconcilable_amount),
+			flt(reconcilable_amount),
 			this.transaction.currency
 		);
 	}

--- a/banking/public/js/bank_reconciliation_beta/panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/panel_manager.js
@@ -1,5 +1,21 @@
 frappe.provide("erpnext.accounts.bank_reconciliation");
 
+erpnext.accounts.bank_reconciliation.get_reconcilable_amount = (
+	transaction
+) => {
+	return (
+		flt(transaction.unallocated_amount) +
+		flt(transaction.included_fee_for_reconciliation)
+	);
+};
+
+erpnext.accounts.bank_reconciliation.get_summary_amount = (transaction) => {
+	return (
+		flt(transaction.withdrawal || transaction.deposit) +
+		flt(transaction.included_fee_for_reconciliation)
+	);
+};
+
 erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 	constructor(opts) {
 		Object.assign(this, opts);
@@ -428,7 +444,8 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 		this.$list_container = this.$panel_wrapper.find(".list-container");
 
 		this.transactions.map((transaction) => {
-			let amount = transaction.deposit || transaction.withdrawal;
+			let amount =
+				erpnext.accounts.bank_reconciliation.get_summary_amount(transaction);
 			let symbol = transaction.withdrawal ? "-" : "+";
 			const draft_badge = transaction.reserved_voucher
 				? `<span class="indicator-pill yellow filterable no-indicator-dot ellipsis reserved-draft-badge">${__(
@@ -516,6 +533,10 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 		if (updated_amount) {
 			// update amount is > 0 always [src: `after_transaction_reconcile()`]
 			this.transactions[current_index]["unallocated_amount"] = updated_amount;
+			this.transactions[current_index]["reconcilable_amount"] =
+				erpnext.accounts.bank_reconciliation.get_reconcilable_amount(
+					this.transactions[current_index]
+				);
 		} else {
 			this.transactions[current_index] = {
 				...transaction,

--- a/banking/public/js/bank_reconciliation_beta/panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/panel_manager.js
@@ -1,15 +1,22 @@
 frappe.provide("erpnext.accounts.bank_reconciliation");
 
 // Unpaid invoices are the only Match path that books deposit included fees.
+// Expense Claims are excluded: they are only matched for withdrawals, never fee deposits.
 erpnext.accounts.bank_reconciliation.DEPOSIT_FEE_VOUCHER_TYPES = [
 	"Sales Invoice",
 	"Purchase Invoice",
-	"Expense Claim",
 ];
 
+// The doctype alone cannot tell an unpaid invoice from a paid/POS one: both query
+// variants report the same doctype. Only the "unpaid_invoices" filter distinguishes them.
 erpnext.accounts.bank_reconciliation.selection_uses_deposit_fee = (
-	summary_data
+	summary_data,
+	unpaid_invoices_only
 ) => {
+	if (!cint(unpaid_invoices_only)) {
+		return false;
+	}
+
 	const entries = Object.values(summary_data || {});
 	if (!entries.length) {
 		return false;
@@ -23,13 +30,15 @@ erpnext.accounts.bank_reconciliation.selection_uses_deposit_fee = (
 
 erpnext.accounts.bank_reconciliation.get_allocation_budget = (
 	transaction,
-	summary_data
+	summary_data,
+	unpaid_invoices_only
 ) => {
 	let budget = flt(transaction.unallocated_amount);
 	if (
 		flt(transaction.included_fee_for_reconciliation) &&
 		erpnext.accounts.bank_reconciliation.selection_uses_deposit_fee(
-			summary_data
+			summary_data,
+			unpaid_invoices_only
 		)
 	) {
 		budget += flt(transaction.included_fee_for_reconciliation);
@@ -39,13 +48,15 @@ erpnext.accounts.bank_reconciliation.get_allocation_budget = (
 
 erpnext.accounts.bank_reconciliation.get_summary_amount = (
 	transaction,
-	summary_data
+	summary_data,
+	unpaid_invoices_only
 ) => {
 	let amount = flt(transaction.withdrawal || transaction.deposit);
 	if (
 		flt(transaction.included_fee_for_reconciliation) &&
 		erpnext.accounts.bank_reconciliation.selection_uses_deposit_fee(
-			summary_data
+			summary_data,
+			unpaid_invoices_only
 		)
 	) {
 		amount += flt(transaction.included_fee_for_reconciliation);

--- a/banking/public/js/bank_reconciliation_beta/panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/panel_manager.js
@@ -1,19 +1,56 @@
 frappe.provide("erpnext.accounts.bank_reconciliation");
 
-erpnext.accounts.bank_reconciliation.get_reconcilable_amount = (
-	transaction
+// Unpaid invoices are the only Match path that books deposit included fees.
+erpnext.accounts.bank_reconciliation.DEPOSIT_FEE_VOUCHER_TYPES = [
+	"Sales Invoice",
+	"Purchase Invoice",
+	"Expense Claim",
+];
+
+erpnext.accounts.bank_reconciliation.selection_uses_deposit_fee = (
+	summary_data
 ) => {
-	return (
-		flt(transaction.unallocated_amount) +
-		flt(transaction.included_fee_for_reconciliation)
+	const entries = Object.values(summary_data || {});
+	if (!entries.length) {
+		return false;
+	}
+	return entries.every((entry) =>
+		erpnext.accounts.bank_reconciliation.DEPOSIT_FEE_VOUCHER_TYPES.includes(
+			entry.doctype
+		)
 	);
 };
 
-erpnext.accounts.bank_reconciliation.get_summary_amount = (transaction) => {
-	return (
-		flt(transaction.withdrawal || transaction.deposit) +
-		flt(transaction.included_fee_for_reconciliation)
-	);
+erpnext.accounts.bank_reconciliation.get_allocation_budget = (
+	transaction,
+	summary_data
+) => {
+	let budget = flt(transaction.unallocated_amount);
+	if (
+		flt(transaction.included_fee_for_reconciliation) &&
+		erpnext.accounts.bank_reconciliation.selection_uses_deposit_fee(
+			summary_data
+		)
+	) {
+		budget += flt(transaction.included_fee_for_reconciliation);
+	}
+	return budget;
+};
+
+erpnext.accounts.bank_reconciliation.get_summary_amount = (
+	transaction,
+	summary_data
+) => {
+	let amount = flt(transaction.withdrawal || transaction.deposit);
+	if (
+		flt(transaction.included_fee_for_reconciliation) &&
+		erpnext.accounts.bank_reconciliation.selection_uses_deposit_fee(
+			summary_data
+		)
+	) {
+		amount += flt(transaction.included_fee_for_reconciliation);
+	}
+	return amount;
 };
 
 erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
@@ -444,8 +481,7 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 		this.$list_container = this.$panel_wrapper.find(".list-container");
 
 		this.transactions.map((transaction) => {
-			let amount =
-				erpnext.accounts.bank_reconciliation.get_summary_amount(transaction);
+			let amount = transaction.deposit || transaction.withdrawal;
 			let symbol = transaction.withdrawal ? "-" : "+";
 			const draft_badge = transaction.reserved_voucher
 				? `<span class="indicator-pill yellow filterable no-indicator-dot ellipsis reserved-draft-badge">${__(
@@ -533,10 +569,12 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 		if (updated_amount) {
 			// update amount is > 0 always [src: `after_transaction_reconcile()`]
 			this.transactions[current_index]["unallocated_amount"] = updated_amount;
-			this.transactions[current_index]["reconcilable_amount"] =
-				erpnext.accounts.bank_reconciliation.get_reconcilable_amount(
-					this.transactions[current_index]
-				);
+			// Prior allocations mean deposit fee can no longer be booked
+			if (
+				flt(updated_amount) !== flt(this.transactions[current_index].deposit)
+			) {
+				this.transactions[current_index]["included_fee_for_reconciliation"] = 0;
+			}
 		} else {
 			this.transactions[current_index] = {
 				...transaction,


### PR DESCRIPTION
## Summary
- **Problem:** For deposits with an included bank fee, unpaid-invoice reconciliation already matches and books deposit + fee, but the Match UI used deposit/`unallocated_amount` only. Selecting a matching unpaid invoice looked over-allocated.
- **Solution:** Expose `included_fee_for_reconciliation` only when fee booking can actually succeed (flag on, fee account set, fully unallocated deposit, company-currency bank). Add that fee to the Match allocation budget **only** when the selection is unpaid **Sales Invoice** / **Purchase Invoice** / **Expense Claim**. List, Details, Create Voucher, and PE/JE matching stay on the bank net amount.

## Test plan
- [ ] Unpaid invoice at deposit + fee → Match *To Allocate* clears; reconcile books fee
- [ ] Existing PE/JE at deposit + fee → still shows over-allocation (no false “fully allocated”)
- [ ] Create PE/JE → still net deposit amount (no silent fee omit vs gross display)
- [ ] Fee flag off, missing fee account, partial allocation, or foreign-currency bank → fee not added to Match budget