### PR TITLE
fix: set party on rule-generated Journal Entries

### DIFF
--- a/banking/exceptions.py
+++ b/banking/exceptions.py
@@ -14,3 +14,9 @@ class FullReconciliationRequiredError(ValidationError):
 	"""Raised when an action requires reconciling the whole transaction at once."""
 
 	pass
+
+
+class PartyMismatchError(ValidationError):
+	"""Raised when a party cannot be booked against the given account."""
+
+	pass

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py
@@ -12,14 +12,30 @@ from frappe.model.document import Document
 from frappe.utils import add_days, getdate, today
 from frappe.utils.data import get_filter
 
-from banking.exceptions import CurrencyMismatchError
+from banking.exceptions import CurrencyMismatchError, PartyMismatchError
 
 # Same cap as List View (`count_upper_bound`): count at most N rows, show "N-1+" when hit.
 COUNT_UPPER_BOUND = 1001
 
+PARTY_ACCOUNT_TYPES = ("Receivable", "Payable")
+
 
 class NoFiltersError(ValidationError):
 	pass
+
+
+def get_party_account_type(account: str) -> str | None:
+	"""Return the account type if Journal Entry rows on `account` require a party."""
+	account_type = frappe.get_cached_value("Account", account, "account_type")
+	return account_type if account_type in PARTY_ACCOUNT_TYPES else None
+
+
+def party_type_matches_account_type(party_type: str, account_type: str) -> bool:
+	# Employees can be both payable and receivable, same exception as ERPNext makes.
+	if party_type == "Employee":
+		return True
+
+	return frappe.get_cached_value("Party Type", party_type, "account_type") == account_type
 
 
 def _normalize_filter_rows(raw_filters: list) -> list[list[Any]]:
@@ -129,6 +145,7 @@ class BankReconciliationRule(Document):
 	def validate(self):
 		self.validate_account_currencies()
 		self.validate_filters()
+		self.validate_target_account_party()
 
 	def validate_account_currencies(self):
 		bank_account = frappe.db.get_value("Bank Account", self.bank_account, "account")
@@ -149,3 +166,39 @@ class BankReconciliationRule(Document):
 			frappe.throw(_("Invalid filters"), NoFiltersError)
 		if not parsed:
 			frappe.throw(_("Please define at least one filter!"), NoFiltersError)
+
+	def validate_target_account_party(self):
+		"""Receivable and Payable target accounts need a party on the Journal Entry.
+
+		The party is copied from the matched Bank Transaction, so the rule has to
+		restrict itself to transactions with a compatible party type.
+		"""
+		account_type = get_party_account_type(self.target_account)
+		if not account_type:
+			return
+
+		party_type = self.get_filter_value("party_type")
+		if not party_type:
+			frappe.throw(
+				_(
+					"{0} is a {1} account, so the automatic Journal Entry needs a party. "
+					"Please add a {2} filter to restrict this rule to transactions with a party."
+				).format(frappe.bold(self.target_account), _(account_type), frappe.bold(_("Party Type"))),
+				PartyMismatchError,
+			)
+
+		if not party_type_matches_account_type(party_type, account_type):
+			frappe.throw(
+				_("Party type {0} cannot be booked against the {1} account {2}.").format(
+					frappe.bold(_(party_type)), _(account_type), frappe.bold(self.target_account)
+				),
+				PartyMismatchError,
+			)
+
+	def get_filter_value(self, fieldname: str) -> str | None:
+		"""Return the value the rule pins `fieldname` to, if it uses an equality filter."""
+		for row in json.loads(self.filters):
+			if row[1] == fieldname and row[2] == "=":
+				return row[3]
+
+		return None

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/test_bank_reconciliation_rule.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/test_bank_reconciliation_rule.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from banking.exceptions import CurrencyMismatchError
+from banking.exceptions import CurrencyMismatchError, PartyMismatchError
 from banking.klarna_kosma_integration.doctype.bank_reconciliation_rule.bank_reconciliation_rule import (
 	BankReconciliationRule,
 	NoFiltersError,
@@ -45,6 +45,9 @@ class TestBankReconciliationRule(FrappeTestCase):
 		parent_account = _group_account_with_parent(cls.test_company)
 		bank_account = create_currency_account("EUR", parent_account, "_Test_Account_EUR")
 		cls.target_account = create_currency_account("USD", parent_account, "_Test_Account_USD")
+		cls.payable_account = create_currency_account(
+			"EUR", parent_account, "_Test_Account_EUR_Payable_Brr", account_type="Payable"
+		)
 		cls.ba = create_bank_account(bank_account.name)
 
 	def test_validate_account_currencies(self):
@@ -68,6 +71,39 @@ class TestBankReconciliationRule(FrappeTestCase):
 		brr_doc.filters = "[]"
 		with self.assertRaises(NoFiltersError):
 			brr_doc.validate_filters()
+
+	def test_validate_target_account_party(self):
+		def rule(filters: list) -> BankReconciliationRule:
+			return BankReconciliationRule(
+				{
+					"doctype": "Bank Reconciliation Rule",
+					"bank_account": self.ba.name,
+					"target_account": self.payable_account.name,
+					"filters": json.dumps(filters),
+				}
+			)
+
+		without_party_filter = rule([["Bank Transaction", "description", "=", "X"]])
+		with self.assertRaises(PartyMismatchError):
+			without_party_filter.validate_target_account_party()
+
+		wrong_party_type = rule([["Bank Transaction", "party_type", "=", "Customer"]])
+		with self.assertRaises(PartyMismatchError):
+			wrong_party_type.validate_target_account_party()
+
+		rule([["Bank Transaction", "party_type", "=", "Supplier"]]).validate_target_account_party()
+
+	def test_validate_target_account_party_ignores_other_accounts(self):
+		brr_doc = BankReconciliationRule(
+			{
+				"doctype": "Bank Reconciliation Rule",
+				"bank_account": self.ba.name,
+				"target_account": self.target_account.name,
+				"filters": json.dumps([["Bank Transaction", "description", "=", "X"]]),
+			}
+		)
+
+		brr_doc.validate_target_account_party()
 
 	@patch(
 		"banking.klarna_kosma_integration.doctype.bank_reconciliation_rule.bank_reconciliation_rule.today",

--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -364,8 +364,9 @@ def create_je_automatic_rules(doc, cost_center, date, account, debit, credit):
 		party = {}
 		if party_account_type := get_party_account_type(target_account):
 			if reason := get_party_error(doc, party_account_type, target_account):
-				# Leave the transaction unreconciled instead of failing its submission,
-				# which would abort a whole bank statement import.
+				# Stop instead of raising, which would abort a whole statement import,
+				# and instead of falling through to the next rule, which would book the
+				# amount to an account the highest-priority match did not intend.
 				frappe.log_error(
 					title="Bank Reconciliation Rule not applied",
 					message=reason,

--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -7,6 +7,11 @@ from frappe.core.utils import find
 from frappe.utils import flt, getdate
 from frappe.utils.data import evaluate_filters, get_link_to_form
 
+from banking.klarna_kosma_integration.doctype.bank_reconciliation_rule.bank_reconciliation_rule import (
+	get_party_account_type,
+	party_type_matches_account_type,
+)
+
 
 class CustomBankTransaction(BankTransaction):
 	def before_validate(self):
@@ -300,6 +305,26 @@ def on_cancel(doc, method):
 		frappe.get_doc("Journal Entry", journal_entry).cancel()
 
 
+def get_party_error(doc, account_type: str, target_account: str) -> str | None:
+	"""Explain why the Bank Transaction cannot supply a party for `target_account`.
+
+	The transaction is the only source for the party of the automatic Journal Entry,
+	so a rule pointing at a Receivable or Payable account is not applicable to
+	transactions without a fitting party. Returns None if the party fits.
+	"""
+	if not (doc.party_type and doc.party):
+		return _("Bank Transaction {0} has no party, but target account {1} is a {2} account.").format(
+			doc.name, target_account, _(account_type)
+		)
+
+	if not party_type_matches_account_type(doc.party_type, account_type):
+		return _(
+			"Bank Transaction {0} has party type {1}, which cannot be booked against the {2} account {3}."
+		).format(doc.name, _(doc.party_type), _(account_type), target_account)
+
+	return None
+
+
 def create_je_automatic_rules(doc, cost_center, date, account, debit, credit):
 	allocated_amount = sum(flt(entry.allocated_amount) for entry in doc.payment_entries)
 	remaining_amount = abs(flt(doc.withdrawal) - flt(doc.deposit)) - allocated_amount
@@ -336,6 +361,21 @@ def create_je_automatic_rules(doc, cost_center, date, account, debit, credit):
 		if not evaluate_filters(doc, filters):
 			continue
 
+		party = {}
+		if party_account_type := get_party_account_type(target_account):
+			if reason := get_party_error(doc, party_account_type, target_account):
+				# Leave the transaction unreconciled instead of failing its submission,
+				# which would abort a whole bank statement import.
+				frappe.log_error(
+					title="Bank Reconciliation Rule not applied",
+					message=reason,
+					reference_doctype="Bank Reconciliation Rule",
+					reference_name=br_rule_name,
+				)
+				return
+
+			party = {"party_type": doc.party_type, "party": doc.party}
+
 		je_auto_name = create_automatic_journal_entry(
 			company=doc.company,
 			bank_account=doc.bank_account,
@@ -347,6 +387,7 @@ def create_je_automatic_rules(doc, cost_center, date, account, debit, credit):
 			debit=debit,
 			credit=credit,
 			rule=br_rule_name,
+			**party,
 		)
 		doc.append(
 			"payment_entries",
@@ -374,6 +415,8 @@ def create_automatic_journal_entry(
 	debit: float = 0,
 	credit: float = 0,
 	rule: str | None = None,
+	party_type: str | None = None,
+	party: str | None = None,
 ):
 	journal_entry = frappe.new_doc("Journal Entry")
 	journal_entry.voucher_type = "Bank Entry"
@@ -412,6 +455,8 @@ def create_automatic_journal_entry(
 			"debit_in_account_currency": credit,
 			"credit_in_account_currency": debit,
 			"cost_center": cost_center,
+			"party_type": party_type,
+			"party": party,
 		},
 	)
 

--- a/banking/overrides/test_bank_transaction_reconciliation_rule.py
+++ b/banking/overrides/test_bank_transaction_reconciliation_rule.py
@@ -6,7 +6,12 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from banking.testing_utils import TEST_COMPANY, create_bank_account, create_currency_account
+from banking.testing_utils import (
+	TEST_COMPANY,
+	create_bank_account,
+	create_currency_account,
+	create_supplier,
+)
 
 
 def create_bank_reconciliation_rule(bank_account, target_account, filters, disabled=0, submit=True):
@@ -40,7 +45,11 @@ class TestBankTransactionReconciliationRule(FrappeTestCase):
 		parent_account = frappe.db.get_value("Account", {"is_group": 1, "company": TEST_COMPANY})
 		cls.account_main = create_currency_account("EUR", parent_account, "_Test_Account_EUR")
 		cls.account_target = create_currency_account("EUR", parent_account, "_Test_Account_EUR_Target")
+		cls.account_payable = create_currency_account(
+			"EUR", parent_account, "_Test_Account_EUR_Payable", account_type="Payable"
+		)
 		cls.bank_account = create_bank_account(cls.account_main.name)
+		cls.supplier = create_supplier()
 
 	@patch("banking.overrides.bank_transaction.create_je_automatic_rules")
 	def test_before_submit_invokes_rule_engine(self, mock_create_auto_rules):
@@ -109,6 +118,56 @@ class TestBankTransactionReconciliationRule(FrappeTestCase):
 		self.assertEqual(bt.payment_entries[0].allocated_amount, 5.0)
 		self.assertEqual(bt.allocated_amount, 5.0)
 		self.assertEqual(bt.status, "Reconciled")
+
+	@patch("banking.overrides.bank_transaction.create_automatic_journal_entry")
+	def test_create_je_automatic_rules_sets_party_for_payable_account(self, mock_create_je):
+		from banking.overrides.bank_transaction import create_je_automatic_rules
+
+		frappe.db.delete("Bank Reconciliation Rule", {"bank_account": self.bank_account.name})
+		mock_create_je.return_value = "JE-TEST-0002"
+
+		create_bank_reconciliation_rule(
+			self.bank_account.name,
+			self.account_payable.name,
+			'[["Bank Transaction","party_type","=","Supplier",false]]',
+		)
+
+		bt = create_bank_transaction(
+			withdrawal=5.0,
+			bank_account=self.bank_account.name,
+			party_type="Supplier",
+			party=self.supplier.name,
+		)
+		cost_center = frappe.get_cached_value("Company", bt.company, "cost_center")
+
+		create_je_automatic_rules(bt, cost_center, "2025-01-01", self.account_main.name, 0, bt.withdrawal)
+
+		self.assertEqual(mock_create_je.call_args.kwargs["party_type"], "Supplier")
+		self.assertEqual(mock_create_je.call_args.kwargs["party"], self.supplier.name)
+
+	@patch("banking.overrides.bank_transaction.create_automatic_journal_entry")
+	def test_create_je_automatic_rules_skips_payable_account_without_party(self, mock_create_je):
+		from banking.overrides.bank_transaction import create_je_automatic_rules
+
+		frappe.db.delete("Bank Reconciliation Rule", {"bank_account": self.bank_account.name})
+
+		create_bank_reconciliation_rule(
+			self.bank_account.name,
+			self.account_payable.name,
+			'[["Bank Transaction","party_type","=","Supplier",false]]',
+		)
+
+		bt = create_bank_transaction(
+			withdrawal=5.0,
+			bank_account=self.bank_account.name,
+			party_type="Supplier",
+		)
+		cost_center = frappe.get_cached_value("Company", bt.company, "cost_center")
+
+		create_je_automatic_rules(bt, cost_center, "2025-01-01", self.account_main.name, 0, bt.withdrawal)
+
+		mock_create_je.assert_not_called()
+		self.assertFalse(bt.payment_entries)
 
 	@patch("banking.overrides.bank_transaction.create_automatic_journal_entry")
 	def test_create_je_automatic_rules_deposit(self, mock_create_je):

--- a/banking/testing_utils.py
+++ b/banking/testing_utils.py
@@ -20,16 +20,31 @@ def get_bank_parent_account(company: str = TEST_COMPANY) -> str:
 
 
 def create_currency_account(
-	currency: str, parent_account: str, account_name: str, company: str = TEST_COMPANY
+	currency: str,
+	parent_account: str,
+	account_name: str,
+	company: str = TEST_COMPANY,
+	account_type: str = "Bank",
 ):
 	account = create_account(
 		account_name=account_name,
-		account_type="Bank",
+		account_type=account_type,
 		parent_account=parent_account,
 		company=company,
 		account_currency=currency,
 	)
 	return frappe.get_doc("Account", account)
+
+
+def create_supplier(supplier_name: str = "_Test_Banking_Supplier"):
+	if frappe.db.exists("Supplier", supplier_name):
+		return frappe.get_doc("Supplier", supplier_name)
+
+	supplier = frappe.new_doc("Supplier")
+	supplier.supplier_name = supplier_name
+	supplier.supplier_group = frappe.db.get_value("Supplier Group", {"is_group": 0})
+	supplier.insert(ignore_permissions=True)
+	return supplier
 
 
 def create_bank_account(


### PR DESCRIPTION
**Bank Reconciliation Rules** built the **Journal Entry** without a party. ERPNext requires a party on Receivable and Payable rows, so a rule pointing at such an account aborted the submission of the **Bank Transaction**. During a statement or payment provider import, that stopped the whole run on the first match.

The **Journal Entry** now takes the party from the matched **Bank Transaction**. If the transaction cannot supply a fitting party, the rule is skipped and logged instead of raising. Rules with a Receivable or Payable target must now filter on party type, so the misconfiguration surfaces when the rule is saved.
