### PR TITLE
fix(Bank Reconciliation Tool Beta): remember selected Document Type

### DIFF
--- a/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/create_tab.js
@@ -181,6 +181,22 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 		};
 	}
 
+	persist_create_preference(fieldname) {
+		this.panel_manager.create_preferences[fieldname] =
+			this.create_field_group.get_value(fieldname);
+	}
+
+	apply_document_type_requirements(document_type) {
+		const fields = this.create_field_group;
+		fields.get_field("party").df.reqd = document_type === "Payment Entry";
+		fields.get_field("party_type").df.reqd = document_type === "Payment Entry";
+		fields.get_field("journal_entry_type").df.reqd =
+			document_type === "Journal Entry";
+		fields.get_field("second_account").df.reqd =
+			document_type === "Journal Entry";
+		fields.refresh();
+	}
+
 	get_create_tab_fields() {
 		let party_type =
 			this.transaction.party_type ||
@@ -189,6 +205,10 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 			(this.accounting_dimension_defaults || {})[this.company] || {};
 		const { left_custom_dimension_fields, right_custom_dimension_fields } =
 			this.get_split_accounting_dimension_fields();
+		const document_type =
+			this.panel_manager.create_preferences.document_type || "Payment Entry";
+		const is_payment_entry = document_type === "Payment Entry";
+		const is_journal_entry = document_type === "Journal Entry";
 
 		return [
 			{
@@ -196,19 +216,12 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 				fieldname: "document_type",
 				fieldtype: "Select",
 				options: `Payment Entry\nJournal Entry`,
-				default: "Payment Entry",
+				default: document_type,
 				onchange: () => {
-					let value = this.create_field_group.get_value("document_type");
-					let fields = this.create_field_group;
-
-					fields.get_field("party").df.reqd = value === "Payment Entry";
-					fields.get_field("party_type").df.reqd = value === "Payment Entry";
-					fields.get_field("journal_entry_type").df.reqd =
-						value === "Journal Entry";
-					fields.get_field("second_account").df.reqd =
-						value === "Journal Entry";
-
-					this.create_field_group.refresh();
+					this.persist_create_preference("document_type");
+					this.apply_document_type_requirements(
+						this.create_field_group.get_value("document_type")
+					);
 				},
 			},
 			{
@@ -256,6 +269,7 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 				fieldtype: "Select",
 				options: `Bank Entry\nJournal Entry\nInter Company Journal Entry\nCash Entry\nCredit Card Entry\nDebit Note\nCredit Note\nContra Entry\nExcise Entry\nWrite Off Entry\nOpening Entry\nDepreciation Entry\nExchange Rate Revaluation\nDeferred Revenue\nDeferred Expense`,
 				default: "Bank Entry",
+				reqd: is_journal_entry,
 				depends_on: "eval: doc.document_type == 'Journal Entry'",
 			},
 			{
@@ -263,6 +277,7 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 				fieldtype: "Link",
 				label: "Account",
 				options: "Account",
+				reqd: is_journal_entry,
 				get_query: () => {
 					return {
 						filters: {
@@ -278,7 +293,7 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 				fieldtype: "Link",
 				label: "Party Type",
 				options: "DocType",
-				reqd: 1,
+				reqd: is_payment_entry,
 				default: party_type,
 				get_query: function () {
 					return {
@@ -298,7 +313,7 @@ erpnext.accounts.bank_reconciliation.CreateTab = class CreateTab {
 				label: "Party",
 				default: this.transaction.party,
 				options: party_type,
-				reqd: 1,
+				reqd: is_payment_entry,
 			},
 			{
 				fieldname: "accounting_dimensions_section",

--- a/banking/public/js/bank_reconciliation_beta/panel_manager.js
+++ b/banking/public/js/bank_reconciliation_beta/panel_manager.js
@@ -219,6 +219,10 @@ erpnext.accounts.bank_reconciliation.PanelManager = class PanelManager {
 		this.actions_filters.exact_match = 0;
 		this.actions_filters.exact_party_match = 0;
 		this.actions_filters.unpaid_invoices = 1;
+		// Sticky Create Voucher fields across transaction switches
+		this.create_preferences = {
+			document_type: "Payment Entry",
+		};
 	}
 
 	render_no_transactions() {


### PR DESCRIPTION
## Summary
- When switching bank transactions on the Create Voucher tab, Document Type reset to Payment Entry even if Journal Entry was selected, which broke batch workflows for similar entries.
- Persist Document Type in `create_preferences` on the panel manager (same idea as the active tab / Match filters), and restore it when rebuilding Create Voucher. Structured so Journal Entry Type, Account, etc. can follow the same pattern later.

## Test plan
- [x] Open Create Voucher, set Document Type to Journal Entry, switch to another bank transaction → Document Type stays Journal Entry
- [x] Switch back to Payment Entry, change transaction → Document Type stays Payment Entry
- [x] Reload / Get Bank Transactions → Document Type resets to Payment Entry