### PR TITLE
feat(Bank Reconciliation Rule): reapply button

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.js
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.js
@@ -14,6 +14,7 @@ frappe.ui.form.on("Bank Reconciliation Rule", {
 
 			frm.trigger("set_target_account_query");
 			frm.remove_custom_button(__("Open Matches"));
+			frm.remove_custom_button(__("Reapply to Unreconciled"));
 			const filters_json =
 				frm.doc.filters && frm.doc.filters !== "[]" ? frm.doc.filters : "[]";
 			let has_filters = false;
@@ -27,6 +28,11 @@ frappe.ui.form.on("Bank Reconciliation Rule", {
 					stats.open_bank_transaction_list();
 				});
 			}
+			if (frm.doc.docstatus === 1 && !frm.doc.disabled && has_filters) {
+				frm.add_custom_button(__("Reapply to Unreconciled"), () => {
+					frm.trigger("reapply_to_unreconciled");
+				});
+			}
 
 			if (stats.needs_filter_rerender()) {
 				frm.trigger("render_bt_filters");
@@ -34,6 +40,50 @@ frappe.ui.form.on("Bank Reconciliation Rule", {
 				stats.fetch_and_show();
 			}
 		});
+	},
+	async reapply_to_unreconciled(frm) {
+		const { message: preview } = await frm.call({
+			method: "reapply_to_unreconciled",
+			doc: frm.doc,
+			args: { dry_run: 1 },
+			freeze: true,
+			freeze_message: __("Counting matching Bank Transactions..."),
+		});
+		const count = preview?.count || 0;
+		if (!count) {
+			frappe.msgprint({
+				title: __("Reapply Rule"),
+				message: __("No unreconciled Bank Transactions match this rule."),
+				indicator: "blue",
+			});
+			return;
+		}
+
+		frappe.confirm(
+			__(
+				"Apply this rule to {0} unreconciled Bank Transaction(s)? This will create Journal Entries and cannot be undone easily.",
+				[`<b>${count}</b>`]
+			),
+			async () => {
+				const { message: result } = await frm.call({
+					method: "reapply_to_unreconciled",
+					doc: frm.doc,
+					args: { dry_run: 0 },
+					freeze: true,
+					freeze_message: __("Reapplying rule..."),
+				});
+				const parts = [
+					__("Applied: {0}", [result.applied || 0]),
+					__("Skipped: {0}", [result.skipped || 0]),
+					__("Failed: {0}", [result.failed || 0]),
+				];
+				frappe.msgprint({
+					title: __("Reapply Rule"),
+					message: parts.join("<br>"),
+					indicator: result.failed ? "orange" : "green",
+				});
+			}
+		);
 	},
 	bank_account(frm) {
 		frm.trigger("set_target_account_query");

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py
@@ -257,10 +257,25 @@ class BankReconciliationRule(Document):
 		for name in transaction_names:
 			try:
 				bt = frappe.get_doc("Bank Transaction", name)
-				if bt.reserved_voucher:
-					skipped += 1
-					continue
+			except Exception:
+				failed += 1
+				if len(failed_names) < 10:
+					failed_names.append(name)
+				frappe.log_error(
+					title="Bank Reconciliation Rule reapply failed",
+					message=frappe.get_traceback(),
+					reference_doctype="Bank Transaction",
+					reference_name=name,
+				)
+				continue
 
+			if bt.reserved_voucher:
+				skipped += 1
+				continue
+
+			# JE submit and BT save must succeed together; otherwise the JE is orphaned.
+			frappe.db.savepoint("reapply_bt")
+			try:
 				result = apply_bank_reconciliation_rule(
 					bt,
 					self.name,
@@ -274,6 +289,7 @@ class BankReconciliationRule(Document):
 					# Filters no longer match (race) or party mismatch.
 					skipped += 1
 			except Exception:
+				frappe.db.rollback(save_point="reapply_bt")
 				failed += 1
 				if len(failed_names) < 10:
 					failed_names.append(name)
@@ -283,6 +299,8 @@ class BankReconciliationRule(Document):
 					reference_doctype="Bank Transaction",
 					reference_name=name,
 				)
+			else:
+				frappe.db.release_savepoint("reapply_bt")
 
 		return {
 			"applied": applied,

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py
@@ -9,7 +9,7 @@ from frappe import _
 from frappe.exceptions import ValidationError
 from frappe.model.db_query import DatabaseQuery
 from frappe.model.document import Document
-from frappe.utils import add_days, getdate, today
+from frappe.utils import add_days, cint, getdate, today
 from frappe.utils.data import get_filter
 
 from banking.exceptions import CurrencyMismatchError, PartyMismatchError
@@ -202,3 +202,91 @@ class BankReconciliationRule(Document):
 				return row[3]
 
 		return None
+
+	def _unreconciled_match_filters(self) -> list[list[Any]]:
+		user_filters = _normalize_filter_rows(json.loads(self.filters or "[]"))
+		user_filters.extend(
+			[
+				["Bank Transaction", "bank_account", "=", self.bank_account],
+				["Bank Transaction", "docstatus", "=", 1],
+				["Bank Transaction", "unallocated_amount", ">", 0],
+			]
+		)
+		return user_filters
+
+	def _assert_can_reapply(self):
+		if self.docstatus != 1:
+			frappe.throw(_("Please submit the Bank Reconciliation Rule before reapplying it."))
+		if self.disabled:
+			frappe.throw(_("Cannot reapply a disabled Bank Reconciliation Rule."))
+		if not self.filters:
+			frappe.throw(_("Please define at least one filter!"), NoFiltersError)
+		frappe.has_permission("Bank Transaction", ptype="write", throw=True)
+
+	@frappe.whitelist()
+	def reapply_to_unreconciled(self, dry_run: bool | str | int = False) -> dict[str, Any]:
+		"""Apply this rule to matching unreconciled Bank Transactions.
+
+		When `dry_run` is truthy, only return the count of matching transactions.
+		"""
+		self._assert_can_reapply()
+		dry_run = bool(cint(dry_run))
+
+		filters = self._unreconciled_match_filters()
+		transaction_names = DatabaseQuery("Bank Transaction").execute(
+			filters=filters,
+			order_by=None,
+			pluck="name",
+		)
+
+		if dry_run:
+			return {"count": len(transaction_names)}
+
+		try:
+			rule_filters = json.loads(self.filters)
+		except json.JSONDecodeError:
+			frappe.throw(_("Invalid filters"), NoFiltersError)
+
+		from banking.overrides.bank_transaction import apply_bank_reconciliation_rule
+
+		applied = 0
+		skipped = 0
+		failed = 0
+		failed_names: list[str] = []
+
+		for name in transaction_names:
+			try:
+				bt = frappe.get_doc("Bank Transaction", name)
+				if bt.reserved_voucher:
+					skipped += 1
+					continue
+
+				result = apply_bank_reconciliation_rule(
+					bt,
+					self.name,
+					self.target_account,
+					rule_filters,
+				)
+				if result == "applied":
+					bt.save(ignore_permissions=True)
+					applied += 1
+				else:
+					# Filters no longer match (race) or party mismatch.
+					skipped += 1
+			except Exception:
+				failed += 1
+				if len(failed_names) < 10:
+					failed_names.append(name)
+				frappe.log_error(
+					title="Bank Reconciliation Rule reapply failed",
+					message=frappe.get_traceback(),
+					reference_doctype="Bank Transaction",
+					reference_name=name,
+				)
+
+		return {
+			"applied": applied,
+			"skipped": skipped,
+			"failed": failed,
+			"failed_names": failed_names,
+		}

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/bank_reconciliation_rule.py
@@ -256,7 +256,7 @@ class BankReconciliationRule(Document):
 
 		for name in transaction_names:
 			try:
-				bt = frappe.get_doc("Bank Transaction", name)
+				bt = frappe.get_doc("Bank Transaction", name, for_update=True)
 			except Exception:
 				failed += 1
 				if len(failed_names) < 10:

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/test_bank_reconciliation_rule.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/test_bank_reconciliation_rule.py
@@ -253,6 +253,63 @@ class TestBankReconciliationRule(FrappeTestCase):
 		self.assertEqual(matching.unallocated_amount, 0)
 		self.assertTrue(matching.payment_entries)
 
+	def test_reapply_rolls_back_je_when_bt_save_fails(self):
+		desc = "REAPPLY-ROLLBACK-001"
+		rule, target = self._make_eur_target_and_rule(desc)
+		bt = self._insert_unreconciled_bt(desc)
+		bank_gl = frappe.db.get_value("Bank Account", self.ba.name, "account")
+		created_jes: list[str] = []
+
+		def _stub_je(**kwargs):
+			je = frappe.new_doc("Journal Entry")
+			je.voucher_type = "Bank Entry"
+			je.company = kwargs["company"]
+			je.posting_date = kwargs["date"]
+			je.append(
+				"accounts",
+				{
+					"account": bank_gl,
+					"debit_in_account_currency": kwargs.get("debit") or 0,
+					"credit_in_account_currency": kwargs.get("credit") or 0,
+				},
+			)
+			je.append(
+				"accounts",
+				{
+					"account": target.name,
+					"debit_in_account_currency": kwargs.get("credit") or 0,
+					"credit_in_account_currency": kwargs.get("debit") or 0,
+				},
+			)
+			je.insert(ignore_permissions=True)
+			created_jes.append(je.name)
+			return je.name
+
+		original_save = frappe.model.document.Document.save
+
+		def _save(self, *args, **kwargs):
+			if self.doctype == "Bank Transaction":
+				raise frappe.ValidationError("simulated save failure")
+			return original_save(self, *args, **kwargs)
+
+		with (
+			patch(
+				"banking.overrides.bank_transaction.create_automatic_journal_entry",
+				side_effect=_stub_je,
+			),
+			patch.object(frappe.model.document.Document, "save", _save),
+		):
+			result = rule.reapply_to_unreconciled()
+
+		self.assertEqual(result["applied"], 0)
+		self.assertEqual(result["failed"], 1)
+		self.assertTrue(created_jes)
+		self.assertFalse(frappe.db.exists("Journal Entry", created_jes[0]))
+
+		bt.reload()
+		self.assertEqual(bt.status, "Unreconciled")
+		self.assertFalse(bt.payment_entries)
+
 	def test_reapply_rejects_draft_and_disabled(self):
 		desc = "REAPPLY-GUARD-001"
 		draft_rule, _ = self._make_eur_target_and_rule(desc, submit=False)

--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/test_bank_reconciliation_rule.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_rule/test_bank_reconciliation_rule.py
@@ -165,3 +165,140 @@ class TestBankReconciliationRule(FrappeTestCase):
 			frappe.delete_doc("Bank Account", other_ba.name, force=1, ignore_permissions=True)
 			frappe.delete_doc("Account", other_bank_acc.name, force=1, ignore_permissions=True)
 			frappe.delete_doc("Account", eur_target.name, force=1, ignore_permissions=True)
+
+	def _make_eur_target_and_rule(self, description: str, *, submit=True, disabled=0):
+		parent_account = _group_account_with_parent(self.test_company)
+		eur_target = create_currency_account("EUR", parent_account, f"_Test_BRR_Reapply_{description[:12]}")
+		rule = frappe.new_doc("Bank Reconciliation Rule")
+		rule.bank_account = self.ba.name
+		rule.target_account = eur_target.name
+		rule.disabled = disabled
+		rule.filters = json.dumps([["Bank Transaction", "description", "=", description]])
+		rule.insert(ignore_permissions=True, ignore_mandatory=True)
+		if submit:
+			rule.flags.ignore_permissions = True
+			rule.submit()
+		return rule, eur_target
+
+	def _insert_unreconciled_bt(self, description: str, *, withdrawal=10.0, **extra):
+		bt = frappe.new_doc("Bank Transaction")
+		bt.company = self.test_company
+		bt.bank_account = self.ba.name
+		bt.withdrawal = withdrawal
+		bt.date = "2025-06-01"
+		bt.description = description
+		bt.update(extra)
+		bt.insert(ignore_permissions=True, ignore_mandatory=True, ignore_links=True)
+		frappe.db.set_value(
+			"Bank Transaction",
+			bt.name,
+			{
+				"docstatus": 1,
+				"status": "Unreconciled",
+				"unallocated_amount": withdrawal,
+				"allocated_amount": 0,
+			},
+			update_modified=False,
+		)
+		return frappe.get_doc("Bank Transaction", bt.name)
+
+	def test_reapply_to_unreconciled_dry_run_and_apply(self):
+		desc = "REAPPLY-MATCH-001"
+		rule, target = self._make_eur_target_and_rule(desc)
+		matching = self._insert_unreconciled_bt(desc)
+		self._insert_unreconciled_bt("REAPPLY-OTHER-001")
+
+		preview = rule.reapply_to_unreconciled(dry_run=1)
+		self.assertEqual(preview["count"], 1)
+
+		bank_gl = frappe.db.get_value("Bank Account", self.ba.name, "account")
+
+		def _stub_je(**kwargs):
+			je = frappe.new_doc("Journal Entry")
+			je.voucher_type = "Bank Entry"
+			je.company = kwargs["company"]
+			je.posting_date = kwargs["date"]
+			je.append(
+				"accounts",
+				{
+					"account": bank_gl,
+					"debit_in_account_currency": kwargs.get("debit") or 0,
+					"credit_in_account_currency": kwargs.get("credit") or 0,
+				},
+			)
+			je.append(
+				"accounts",
+				{
+					"account": target.name,
+					"debit_in_account_currency": kwargs.get("credit") or 0,
+					"credit_in_account_currency": kwargs.get("debit") or 0,
+				},
+			)
+			je.insert(ignore_permissions=True)
+			return je.name
+
+		with patch(
+			"banking.overrides.bank_transaction.create_automatic_journal_entry",
+			side_effect=_stub_je,
+		) as mock_je:
+			result = rule.reapply_to_unreconciled()
+
+		self.assertEqual(result["applied"], 1)
+		self.assertEqual(result["skipped"], 0)
+		self.assertEqual(result["failed"], 0)
+		mock_je.assert_called_once()
+
+		matching.reload()
+		self.assertEqual(matching.status, "Reconciled")
+		self.assertEqual(matching.unallocated_amount, 0)
+		self.assertTrue(matching.payment_entries)
+
+	def test_reapply_rejects_draft_and_disabled(self):
+		desc = "REAPPLY-GUARD-001"
+		draft_rule, _ = self._make_eur_target_and_rule(desc, submit=False)
+		with self.assertRaises(frappe.ValidationError):
+			draft_rule.reapply_to_unreconciled(dry_run=1)
+
+		disabled_rule, _ = self._make_eur_target_and_rule("REAPPLY-GUARD-002", disabled=1)
+		with self.assertRaises(frappe.ValidationError):
+			disabled_rule.reapply_to_unreconciled(dry_run=1)
+
+	def test_reapply_skips_reserved_and_party_mismatch(self):
+		desc = "REAPPLY-SKIP-001"
+		parent_account = _group_account_with_parent(self.test_company)
+		payable = create_currency_account(
+			"EUR", parent_account, "_Test_BRR_Reapply_Pay", account_type="Payable"
+		)
+		rule = frappe.new_doc("Bank Reconciliation Rule")
+		rule.bank_account = self.ba.name
+		rule.target_account = payable.name
+		rule.filters = json.dumps([["Bank Transaction", "description", "=", desc]])
+		# Bypass party validation on save by setting party_type filter for rule validity,
+		# then apply to a BT without party.
+		rule.filters = json.dumps(
+			[
+				["Bank Transaction", "description", "=", desc],
+				["Bank Transaction", "party_type", "=", "Supplier"],
+			]
+		)
+		rule.insert(ignore_permissions=True, ignore_mandatory=True)
+		rule.flags.ignore_permissions = True
+		rule.submit()
+
+		reserved = self._insert_unreconciled_bt(desc, party_type="Supplier")
+		frappe.db.set_value(
+			"Bank Transaction",
+			reserved.name,
+			{"reserved_voucher_type": "Journal Entry", "reserved_voucher": "JE-RESERVED"},
+			update_modified=False,
+		)
+
+		self._insert_unreconciled_bt(desc, withdrawal=7.0, party_type="Supplier")
+
+		with patch("banking.overrides.bank_transaction.create_automatic_journal_entry") as mock_je:
+			result = rule.reapply_to_unreconciled()
+
+		mock_je.assert_not_called()
+		self.assertEqual(result["applied"], 0)
+		self.assertEqual(result["skipped"], 2)
+		self.assertEqual(result["failed"], 0)

--- a/banking/overrides/bank_transaction.py
+++ b/banking/overrides/bank_transaction.py
@@ -325,13 +325,85 @@ def get_party_error(doc, account_type: str, target_account: str) -> str | None:
 	return None
 
 
+def apply_bank_reconciliation_rule(
+	doc,
+	rule_name: str,
+	target_account: str,
+	filters: list,
+	*,
+	cost_center: str | None = None,
+	date: str | None = None,
+	account: str | None = None,
+) -> str:
+	"""Apply one Bank Reconciliation Rule to a Bank Transaction.
+
+	Mutates `doc` (payment entries, amounts, status) on success. Caller must
+	`save()` when the transaction is already submitted.
+
+	Returns "applied", "no_match", or "party_mismatch".
+	"""
+	allocated_amount = sum(flt(entry.allocated_amount) for entry in doc.payment_entries)
+	remaining_amount = abs(flt(doc.withdrawal) - flt(doc.deposit)) - allocated_amount
+	if remaining_amount <= 0:
+		return "no_match"
+
+	if not evaluate_filters(doc, filters):
+		return "no_match"
+
+	debit, credit = (remaining_amount, 0.0) if flt(doc.deposit) else (0.0, remaining_amount)
+	date = date or doc.date or frappe.utils.nowdate()
+	cost_center = cost_center or frappe.get_cached_value("Company", doc.company, "cost_center")
+	account = account or frappe.get_cached_value("Bank Account", doc.bank_account, "account")
+
+	party = {}
+	if party_account_type := get_party_account_type(target_account):
+		if reason := get_party_error(doc, party_account_type, target_account):
+			# Stop instead of raising, which would abort a whole statement import,
+			# and instead of falling through to the next rule, which would book the
+			# amount to an account the highest-priority match did not intend.
+			frappe.log_error(
+				title="Bank Reconciliation Rule not applied",
+				message=reason,
+				reference_doctype="Bank Reconciliation Rule",
+				reference_name=rule_name,
+			)
+			return "party_mismatch"
+
+		party = {"party_type": doc.party_type, "party": doc.party}
+
+	je_auto_name = create_automatic_journal_entry(
+		company=doc.company,
+		bank_account=doc.bank_account,
+		bank_transaction=doc.name,
+		cost_center=cost_center,
+		date=date,
+		account=account,
+		target_account=target_account,
+		debit=debit,
+		credit=credit,
+		rule=rule_name,
+		**party,
+	)
+	doc.append(
+		"payment_entries",
+		{
+			"payment_document": "Journal Entry",
+			"payment_entry": je_auto_name,
+			"allocated_amount": debit + credit,
+		},
+	)
+	doc.allocated_amount = sum(flt(entry.allocated_amount) for entry in doc.payment_entries)
+	doc.unallocated_amount = abs(flt(doc.withdrawal) - flt(doc.deposit)) - doc.allocated_amount
+	if doc.unallocated_amount == 0:
+		doc.status = "Reconciled"
+	return "applied"
+
+
 def create_je_automatic_rules(doc, cost_center, date, account, debit, credit):
 	allocated_amount = sum(flt(entry.allocated_amount) for entry in doc.payment_entries)
 	remaining_amount = abs(flt(doc.withdrawal) - flt(doc.deposit)) - allocated_amount
 	if remaining_amount <= 0:
 		return
-
-	debit, credit = (remaining_amount, 0.0) if flt(doc.deposit) else (0.0, remaining_amount)
 
 	bank_reconciliation_rules = frappe.get_all(
 		"Bank Reconciliation Rule",
@@ -358,51 +430,19 @@ def create_je_automatic_rules(doc, cost_center, date, account, debit, credit):
 			)
 			continue
 
-		if not evaluate_filters(doc, filters):
-			continue
-
-		party = {}
-		if party_account_type := get_party_account_type(target_account):
-			if reason := get_party_error(doc, party_account_type, target_account):
-				# Stop instead of raising, which would abort a whole statement import,
-				# and instead of falling through to the next rule, which would book the
-				# amount to an account the highest-priority match did not intend.
-				frappe.log_error(
-					title="Bank Reconciliation Rule not applied",
-					message=reason,
-					reference_doctype="Bank Reconciliation Rule",
-					reference_name=br_rule_name,
-				)
-				return
-
-			party = {"party_type": doc.party_type, "party": doc.party}
-
-		je_auto_name = create_automatic_journal_entry(
-			company=doc.company,
-			bank_account=doc.bank_account,
-			bank_transaction=doc.name,
+		result = apply_bank_reconciliation_rule(
+			doc,
+			br_rule_name,
+			target_account,
+			filters,
 			cost_center=cost_center,
 			date=date,
 			account=account,
-			target_account=target_account,
-			debit=debit,
-			credit=credit,
-			rule=br_rule_name,
-			**party,
 		)
-		doc.append(
-			"payment_entries",
-			{
-				"payment_document": "Journal Entry",
-				"payment_entry": je_auto_name,
-				"allocated_amount": debit + credit,
-			},
-		)
-		doc.allocated_amount = sum(flt(entry.allocated_amount) for entry in doc.payment_entries)
-		doc.unallocated_amount = abs(flt(doc.withdrawal) - flt(doc.deposit)) - doc.allocated_amount
-		if doc.unallocated_amount == 0:
-			doc.status = "Reconciled"
-		break
+		if result == "party_mismatch":
+			return
+		if result == "applied":
+			break
 
 
 def create_automatic_journal_entry(


### PR DESCRIPTION
## Summary
- **Bank Reconciliation Rule**s only run when a **Bank Transaction** is submitted. Rules created later never touch existing unreconciled transactions.
- Add "Reapply to Unreconciled" button on submitted, active rules: preview matching count, confirm, then apply this rule (auto Journal Entry + allocation) to matching unreconciled **Bank Transaction**s. Reserved / party-mismatch cases are skipped; results are reported as applied / skipped / failed.

## Test plan
- [x] Create a rule after unreconciled **Bank Transaction**s already exist; confirm **Reapply to Unreconciled** appears
- [x] Dry-run count matches **Open Matches** for unreconciled rows; confirm applies and reconciles them
- [x] Draft / disabled rules have no button; reserved BTs and payable-without-party are skipped
- [x] New **Bank Transaction** submit still applies rules as before