### PR TITLE
feat: add Transaction Type in Details tab

### DIFF
--- a/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
+++ b/banking/klarna_kosma_integration/doctype/bank_reconciliation_tool_beta/bank_reconciliation_tool_beta.py
@@ -148,6 +148,7 @@ def get_bank_transactions(
 		"bank_party_name",
 		"bank_party_account_number",
 		"bank_party_iban",
+		"transaction_type",
 		"reserved_voucher_type",
 		"reserved_voucher",
 	]

--- a/banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js
+++ b/banking/public/js/bank_reconciliation_beta/actions_panel/details_tab.js
@@ -157,6 +157,13 @@ banking.bank_reconciliation.DetailsTab = class DetailsTab {
 				hidden: this.transaction.bank_party_iban ? 0 : 1,
 			},
 			{
+				label: __("Transaction Type"),
+				fieldname: "transaction_type",
+				fieldtype: "Data",
+				read_only: 1,
+				hidden: this.transaction.transaction_type ? 0 : 1,
+			},
+			{
 				label: __("Update"),
 				fieldtype: "Section Break",
 				fieldname: "update_section",


### PR DESCRIPTION
Add a "Transaction Type" field in the "Details" tab of the bank reconciliation tool beta

LKP-84